### PR TITLE
[utils] fixing how cprint handles tuples

### DIFF
--- a/clinica/utils/stream.py
+++ b/clinica/utils/stream.py
@@ -34,11 +34,14 @@ class FilterOut(object):
 def active_cprint():
     sys.stdout = FilterOut(sys.stdout)
 
-
 def cprint(msg):
     global clinica_verbose
     if clinica_verbose is True:
         print(msg)
     else:
-        print("@clinica@%s\n" % msg)
+        if type(msg) == tuple: 
+            msg = ", ".join(m for m in msg)
+            print("@clinica@ %s" % msg)
+        else: 
+            print("@clinica@ %s" % msg)
     sys.stdout.flush()


### PR DESCRIPTION
This PR fixes how cprint handles tuples as previously the following code would cause the ADNI to BIDS conversion to crash if there were multiple `key_preferred_visit`. https://github.com/aramis-lab/clinica/blob/fbdb62724c02033abb2b26c970d10569d6f2f823/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_t1.py#L523-L526