### PR TITLE
Remove duplicates during oasis-to-bids conversion

### DIFF
--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -100,6 +100,9 @@ def create_participants_df(study_name, clinical_spec_path, clinical_data_dir, bi
     if study_name == 'ADNI' or study_name == 'AIBL':
         # ADNImerge contains one row for each visits so there are duplicates
         participant_df = participant_df.drop_duplicates(subset=['alternative_id_1'], keep='first')
+    elif study_name == 'OASIS':
+        # OASIS provides several MRI for the same session
+        participant_df = participant_df[~participant_df.alternative_id_1.str.endswith("_MR2")]
     participant_df.reset_index(inplace=True, drop=True)
 
     # Adding participant_id column with BIDS ids

--- a/clinica/iotools/converters/oasis_to_bids/oasis_to_bids.py
+++ b/clinica/iotools/converters/oasis_to_bids/oasis_to_bids.py
@@ -108,5 +108,6 @@ class OasisToBids(Converter):
             os.mkdir(dest_dir)
 
         subjs_folders = glob(path.join(source_dir, 'OAS1_*'))
+        subjs_folders = [subj_folder for subj_folder in subjs_folders if subj_folder.endswith('_MR1')]
         poolrunner = Pool(cpu_count() - 1)
         poolrunner.map(convert_single_subject, subjs_folders)


### PR DESCRIPTION
- remove duplicates from participants.tsv
- ensure that the image converted corresponds to the alternative_id_1