### PR TITLE
t1-volume-existing-template update with iterables 

### DIFF
--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -863,10 +863,10 @@ def convert_flair(folder_input, folder_output, name, fixed_file=False):
             flair_path = glob(path.join(flair_lst[0], '*.nii.gz*'))[0]
             copy(flair_path, path.join(folder_output, name + (get_bids_suff('Flair')) + '.nii.gz'))
         elif len(flair_lst) == 0:
-                return -1
+            return -1
         elif len(flair_lst) > 1:
-                logging.warning('Multiple FLAIR found, computation aborted.')
-                raise('Aborted')
+            logging.warning('Multiple FLAIR found, computation aborted.')
+            raise('Aborted')
 
 
 def convert_fmri(folder_input, folder_output, name, fixed_fmri=False, task_name='rest'):

--- a/clinica/iotools/utils/pipeline_handling.py
+++ b/clinica/iotools/utils/pipeline_handling.py
@@ -116,7 +116,7 @@ def pet_volume_pipeline(caps_dir, df, **kwargs):
                     warnings.warn('The atlas wanted does not exist for ' + pipeline_name + ': ' + atlas_selected + ' in group ' + group_id, UserWarning)
 
         if len(atlas_paths) == 0:
-                raise InitException(pipeline_name)
+            raise InitException(pipeline_name)
 
         atlas_paths_preserved = list(atlas_paths)
         # Selection depending on the label 'pvc-rbv'
@@ -266,7 +266,7 @@ def t1_volume_pipeline(caps_dir, df, **kwargs):
                     warnings.warn('The atlas wanted does not exist for ' + pipeline_name + ': ' + atlas_selected + ' in group ' + group_id, UserWarning)
 
         if len(atlas_paths) == 0:
-                raise InitException(pipeline_name)
+            raise InitException(pipeline_name)
 
         atlas_paths.sort()
         for atlas_path in atlas_paths:

--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -735,26 +735,26 @@ def produce_tsv(pet, atlas_files):
         average_region = []
         region_names = []
         for r in range(len(annot_atlas_left[2])):
-                cprint(annot_atlas_left[2][r])
-                region_names.append(annot_atlas_left[2][r].astype(str) + '_lh')
-                region_names.append(annot_atlas_left[2][r].astype(str) + '_rh')
+            cprint(annot_atlas_left[2][r])
+            region_names.append(annot_atlas_left[2][r].astype(str) + '_lh')
+            region_names.append(annot_atlas_left[2][r].astype(str) + '_rh')
 
-                mask_left = annot_atlas_left[0] == r
-                mask_left = np.uint(mask_left)
+            mask_left = annot_atlas_left[0] == r
+            mask_left = np.uint(mask_left)
 
-                masked_data_left = mask_left * lh_pet_mgh
-                if np.sum(mask_left) == 0:
-                    average_region.append(np.nan)
-                else:
-                    average_region.append(np.sum(masked_data_left) / np.sum(mask_left))
+            masked_data_left = mask_left * lh_pet_mgh
+            if np.sum(mask_left) == 0:
+                average_region.append(np.nan)
+            else:
+                average_region.append(np.sum(masked_data_left) / np.sum(mask_left))
 
-                mask_right = annot_atlas_right[0] == r
-                mask_right = np.uint(mask_right)
-                masked_data_right = mask_right * rh_pet_mgh
-                if np.sum(mask_right) == 0:
-                    average_region.append(np.nan)
-                else:
-                    average_region.append(np.sum(masked_data_right) / np.sum(mask_right))
+            mask_right = annot_atlas_right[0] == r
+            mask_right = np.uint(mask_right)
+            masked_data_right = mask_right * rh_pet_mgh
+            if np.sum(mask_right) == 0:
+                average_region.append(np.nan)
+            else:
+                average_region.append(np.sum(masked_data_right) / np.sum(mask_right))
 
         final_tsv = pds.DataFrame({'index': range(len(region_names)),
                                    'label_name': region_names,

--- a/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_pipeline.py
+++ b/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_pipeline.py
@@ -12,6 +12,13 @@ __email__ = "jorge.samper-gonzalez@inria.fr"
 __status__ = "Development"
 
 
+# Use hash instead of parameters for iterables folder names
+# Otherwise path will be too long and generate OSError
+from nipype import config
+cfg = dict(execution={'parameterize_dirs': False})
+config.update_config(cfg)
+
+
 class T1VolumeExistingTemplate(cpe.Pipeline):
     """T1VolumeExistingTemplate
 
@@ -145,6 +152,10 @@ class T1VolumeExistingTemplate(cpe.Pipeline):
 
         pattern_final_dartel = join(self.caps_directory, 'groups', 'group-' + g_id, 't1', 'group-' + g_id + '_template.nii*')
         final_template = glob.glob(pattern_final_dartel)
+        if len(final_template) != 1:
+            raise FileNotFoundError('Could find template !')
+        else:
+            final_template = final_template[0]
 
         read_node = npe.Node(name="read_node",
                              interface=nutil.IdentityInterface(fields=['t1w',

--- a/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_pipeline.py
+++ b/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_pipeline.py
@@ -222,7 +222,6 @@ class T1VolumeExistingTemplate(cpe.Pipeline):
                                               interface=nio.DataSink(infields=datasink_infields))
         write_segmentation_node.inputs.base_directory = self.caps_directory
         write_segmentation_node.inputs.parameterization = False
-
         write_segmentation_node.inputs.regexp_substitutions = [
             (r'(.*)c1(sub-.*)(\.nii(\.gz)?)$', r'\1\2_segm-graymatter\3'),
             (r'(.*)c2(sub-.*)(\.nii(\.gz)?)$', r'\1\2_segm-whitematter\3'),

--- a/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_pipeline.py
+++ b/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_pipeline.py
@@ -168,13 +168,13 @@ class T1VolumeExistingTemplate(cpe.Pipeline):
     def build_output_node(self):
         """Build and connect an output node to the pipelines.
         """
+        import re
         import nipype.pipeline.engine as npe
         import nipype.interfaces.io as nio
         import nipype.interfaces.utility as nutil
-        import clinica.pipelines.t1_volume_tissue_segmentation.t1_volume_tissue_segmentation_utils as seg_utils
-        import clinica.pipelines.t1_volume_existing_template.t1_volume_existing_template_utils as existing_dartel_utils
         from clinica.utils.io import zip_nii
-        import re
+        from ..t1_volume_tissue_segmentation import t1_volume_tissue_segmentation_utils as seg_utils
+        from ..t1_volume_existing_template import t1_volume_existing_template_utils as existing_template_utils
 
         # Writing Segmentation output into CAPS
         # =====================================
@@ -233,7 +233,7 @@ class T1VolumeExistingTemplate(cpe.Pipeline):
 
         extract_container_node_write_segmentation = npe.Node(nutil.Function(input_names=['filename'],
                                                                             output_names=['container_path'],
-                                                                            function=existing_dartel_utils.container_name_for_write_segmentation),
+                                                                            function=existing_template_utils.container_name_for_write_segmentation),
                                                              name='extract_container_node_write_segmentation')
 
         self.connect([
@@ -266,7 +266,7 @@ class T1VolumeExistingTemplate(cpe.Pipeline):
         ]
         extract_container_node_write_flowfields = npe.Node(nutil.Function(input_names=['filename', 'group_id'],
                                                                           output_names=['container_path'],
-                                                                          function=existing_dartel_utils.container_name_for_write_normalized),
+                                                                          function=existing_template_utils.container_name_for_write_normalized),
                                                            name='extract_container_node_write_flowfields')
         extract_container_node_write_flowfields.inputs.group_id = self._group_id
         self.connect([
@@ -301,7 +301,7 @@ class T1VolumeExistingTemplate(cpe.Pipeline):
 
         extract_container_node_write_normalized = npe.Node(nutil.Function(input_names=['filename', 'group_id'],
                                                                           output_names=['container_path'],
-                                                                          function=existing_dartel_utils.container_name_for_write_normalized),
+                                                                          function=existing_template_utils.container_name_for_write_normalized),
                                                            name='extract_container_node_write_normalized')
         extract_container_node_write_normalized.inputs.group_id = self._group_id
 
@@ -322,7 +322,7 @@ class T1VolumeExistingTemplate(cpe.Pipeline):
 
         extract_container_node_atlas = npe.Node(nutil.Function(input_names=['filename', 'group_id'],
                                                                output_names=['container_path'],
-                                                               function=existing_dartel_utils.container_name_for_atlas),
+                                                               function=existing_template_utils.container_name_for_atlas),
                                                 name='extract_container_node_atlas')
         extract_container_node_atlas.inputs.group_id = self._group_id
         self.connect([

--- a/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_pipeline.py
+++ b/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_pipeline.py
@@ -119,23 +119,15 @@ class T1VolumeExistingTemplate(cpe.Pipeline):
                 'atlas_statistics']
 
     def build_input_node(self):
-        """Build and connect an input node to the pipelines.
-        """
-
-        import nipype.interfaces.io as nio
+        """Build and connect an input node to the pipelines."""
         import nipype.pipeline.engine as npe
         import nipype.interfaces.utility as nutil
         import clinica.pipelines.t1_volume_tissue_segmentation.t1_volume_tissue_segmentation_utils as seg_utils
         from os.path import join
         import glob
 
-        # Reading BIDS node
-        # =================
-
-
         # Reading T1w
         # ============
-
         t1w_images = seg_utils.select_bids_images(self.subjects,
                                                   self.sessions,
                                                   'T1w',
@@ -149,7 +141,6 @@ class T1VolumeExistingTemplate(cpe.Pipeline):
 
         # Dartel Template
         # ================
-
         pattern_final_dartel = join(self.caps_directory, 'groups', 'group-' + g_id, 't1', 'group-' + g_id + '_template.nii*')
         final_template = glob.glob(pattern_final_dartel)
         if len(final_template) != 1:
@@ -177,7 +168,6 @@ class T1VolumeExistingTemplate(cpe.Pipeline):
     def build_output_node(self):
         """Build and connect an output node to the pipelines.
         """
-
         import nipype.pipeline.engine as npe
         import nipype.interfaces.io as nio
         import nipype.interfaces.utility as nutil

--- a/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_pipeline.py
+++ b/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_pipeline.py
@@ -283,7 +283,7 @@ class T1VolumeExistingTemplate(cpe.Pipeline):
         self.connect([
             (self.output_node, write_flowfields_node, [(('dartel_flow_fields', zip_nii, True), 'flow_fields')]),
             (self.input_node, extract_container_node_write_flowfields, [('input_images', 'filename')]),
-            (extract_container_node_write_flowfields, write_segmentation_node, [('container_path', 'container')])
+            (extract_container_node_write_flowfields, write_flowfields_node, [('container_path', 'container')])
         ])
 
         # Writing normalized images (and smoothed) into CAPS

--- a/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_utils.py
+++ b/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_utils.py
@@ -149,26 +149,29 @@ def create_iteration_parameters(dartel_templates, iteration_parameters):
 
 def container_name_for_atlas(filename, group_id):
     import re
+    import os
 
     m = re.search(r'(sub-[a-zA-Z0-9]+)_(ses-[a-zA-Z0-9]+)_', filename)
     subject = m.group(1)
     session = m.group(2)
-    return 'subjects/' + subject + '/' + session + '/t1/spm/dartel/group-' + group_id + '/atlas_statistics'
+    return os.path.join('subjects', subject, session, 't1', 'spm', 'dartel', 'group-' + group_id, 'atlas_statistics')
 
 
 def container_name_for_write_normalized(filename, group_id):
     import re
+    import os
 
     m = re.search(r'(sub-[a-zA-Z0-9]+)_(ses-[a-zA-Z0-9]+)_', filename)
     subject = m.group(1)
     session = m.group(2)
-    return 'subjects/' + subject + '/' + session + '/t1/spm/dartel/group-' + group_id
+    return os.path.join('subjects', subject, session, 't1', 'spm', 'dartel', 'group-' + group_id)
 
 
 def container_name_for_write_segmentation(filename):
     import re
+    import os
 
     m = re.search(r'(sub-[a-zA-Z0-9]+)_(ses-[a-zA-Z0-9]+)_', filename)
     subject = m.group(1)
     session = m.group(2)
-    return 'subjects/' + subject + '/' + session + '/t1/spm/segmentation'
+    return os.path.join('subjects', subject, session, 't1', 'spm', 'segmentation')

--- a/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_utils.py
+++ b/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_utils.py
@@ -145,3 +145,17 @@ def create_iteration_parameters(dartel_templates, iteration_parameters):
                                              dartel_templates[i])
                                             )
         return new_iteration_parameters
+
+
+def container_name_for_atlas(filename, group_id):
+    import re
+
+    m = re.search(r'(sub-[a-zA-Z0-9]+)_(ses-[a-zA-Z0-9]+)_', filename)
+    subject = m.group(1)
+    session = m.group(2)
+    return 'subjects/' + subject + '/' + session + '/t1/spm/dartel/group-' + group_id + '/atlas_statistics'
+
+
+def container_name_for_write_normalized(filename, group_id):
+    from os.path import dirname
+    return dirname(get_container_name_from_t1w_for_atlas(filename, group_id))

--- a/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_utils.py
+++ b/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_utils.py
@@ -157,8 +157,12 @@ def container_name_for_atlas(filename, group_id):
 
 
 def container_name_for_write_normalized(filename, group_id):
-    from os.path import dirname
-    return dirname(container_name_for_atlas(filename, group_id))
+    import re
+
+    m = re.search(r'(sub-[a-zA-Z0-9]+)_(ses-[a-zA-Z0-9]+)_', filename)
+    subject = m.group(1)
+    session = m.group(2)
+    return 'subjects/' + subject + '/' + session + '/t1/spm/dartel/group-' + group_id
 
 
 def container_name_for_write_segmentation(filename):

--- a/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_utils.py
+++ b/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_utils.py
@@ -158,4 +158,13 @@ def container_name_for_atlas(filename, group_id):
 
 def container_name_for_write_normalized(filename, group_id):
     from os.path import dirname
-    return dirname(get_container_name_from_t1w_for_atlas(filename, group_id))
+    return dirname(container_name_for_atlas(filename, group_id))
+
+
+def container_name_for_write_segmentation(filename):
+    import re
+
+    m = re.search(r'(sub-[a-zA-Z0-9]+)_(ses-[a-zA-Z0-9]+)_', filename)
+    subject = m.group(1)
+    session = m.group(2)
+    return 'subjects/' + subject + '/' + session + '/t1/spm/segmentation'


### PR DESCRIPTION
This pull request make some modification to allow the pipeline `T1VolumeExistingTemplate` to fail for some subjects without affecting the others. 

The files are grabbed with the use of `glob`, allowing to have a list of input files, eventually leading to the utilization of `iterables`.

The main problem to deal with were the containers of the datasink. A trick had to be found. Container variable of datasink is now linked to input T1w file through a function that give away the container name based on the filename.

Work to do left (but not necessary for this merge request) :  
- replace MapNode by node when necessary.
- @alexandreroutier needs to test wether the intended behavior is working (crash on one of the file : do the other keep running ?

Attached : 
- new diagram
- working directory with an axemple of unnecessary MapNode (creating mapflows even though there will always be only one instance here thanks to previous iterable)
![t1volexTemplate](https://user-images.githubusercontent.com/49677712/64037713-9e00f680-cb56-11e9-9b66-416410a46841.png)
![Screen Shot 2019-08-30 at 18 44 43](https://user-images.githubusercontent.com/49677712/64037729-ab1de580-cb56-11e9-8f2d-e0f0e9c514c6.png)
