### PR TITLE
Fix t1-volume pipelines and CI path for t1-freesurfer-longitudinal pipeline

### DIFF
--- a/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
+++ b/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
@@ -191,7 +191,7 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
         import nipype.pipeline.engine as npe
         import nipype.interfaces.utility as nutil
         from clinica.utils.io import unzip_nii
-        from clinica.pipelines.t1_volume_dartel2mni.t1_volume_dartel2mni_utils import prepare_flowfields, join_smoothed_files, select_gm_images
+        from ..t1_volume_dartel2mni import t1_volume_dartel2mni_utils as dartel2mni_utils
         from clinica.utils.spm import get_tpm
 
         # Get Tissue Probability Map from SPM
@@ -240,7 +240,7 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
 
             join_smoothing_node = npe.JoinNode(interface=nutil.Function(input_names=['smoothed_normalized_files'],
                                                                         output_names=['smoothed_normalized_files'],
-                                                                        function=join_smoothed_files),
+                                                                        function=dartel2mni_utils.join_smoothed_files),
                                                joinsource='smoothing_node',
                                                joinfield='smoothed_normalized_files',
                                                name='join_smoothing_node')
@@ -259,7 +259,7 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
             (self.input_node, unzip_flowfields_node, [('flowfield_files', 'in_file')]),
             (self.input_node, unzip_template_node, [('template_file', 'in_file')]),
             (unzip_tissues_node, dartel2mni_node, [('out_file', 'apply_to_files')]),
-            (unzip_flowfields_node, dartel2mni_node, [(('out_file', prepare_flowfields, self.parameters['tissues']),
+            (unzip_flowfields_node, dartel2mni_node, [(('out_file', dartel2mni_utils.prepare_flowfields, self.parameters['tissues']),
                                                        'flowfield_files')]),
             (unzip_template_node, dartel2mni_node, [('out_file', 'template_file')]),
             (dartel2mni_node, self.output_node, [('normalized_files', 'normalized_files')])

--- a/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_pipeline.py
+++ b/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_pipeline.py
@@ -466,12 +466,12 @@ class T1VolumeExistingTemplate(cpe.Pipeline):
         # Atlas Statistics
         # ================
         atlas_stats_node = npe.MapNode(nutil.Function(input_names=['in_image',
-                                                                   'in_atlas_list'],
+                                                                   'atlas_list'],
                                                       output_names=['atlas_statistics'],
                                                       function=parcellation_utils.atlas_statistics),
                                        name='atlas_stats_node',
                                        iterfield=['in_image'])
-        atlas_stats_node.inputs.in_atlas_list = self.parameters['atlas_list']
+        atlas_stats_node.inputs.atlas_list = self.parameters['atlas_list']
 
         # Connection
         # ==========
@@ -504,7 +504,6 @@ class T1VolumeExistingTemplate(cpe.Pipeline):
                                                            self.parameters['tissue_classes']), 'flowfield_files')]),
             (unzip_template_node, dartel2mni_node, [('out_file', 'template_file')]),
             (dartel2mni_node, self.output_node, [('normalized_files', 'normalized_files')]),
-            (dartel2mni_node, atlas_stats_node, [(('normalized_files', dartel2mni_utils.select_gm_images),
-                                                  'in_image')]),
+            (dartel2mni_node, atlas_stats_node, [(('normalized_files', dartel2mni_utils.select_gm_images), 'in_image')]),
             (atlas_stats_node, self.output_node, [('atlas_statistics', 'atlas_statistics')])
         ])

--- a/clinica/pipelines/t1_volume_new_template/t1_volume_new_template_pipeline.py
+++ b/clinica/pipelines/t1_volume_new_template/t1_volume_new_template_pipeline.py
@@ -115,7 +115,7 @@ class T1VolumeNewTemplate(cpe.Pipeline):
 
         import nipype.pipeline.engine as npe
         import nipype.interfaces.utility as nutil
-        import clinica.pipelines.t1_volume_tissue_segmentation.t1_volume_tissue_segmentation_utils as seg_utils
+        from ..t1_volume_tissue_segmentation import t1_volume_tissue_segmentation_utils as seg_utils
 
         # Reading BIDS
         # ============
@@ -137,7 +137,7 @@ class T1VolumeNewTemplate(cpe.Pipeline):
 
         import nipype.pipeline.engine as npe
         import nipype.interfaces.io as nio
-        import clinica.pipelines.t1_volume_tissue_segmentation.t1_volume_tissue_segmentation_utils as seg_utils
+        from ..t1_volume_tissue_segmentation import t1_volume_tissue_segmentation_utils as seg_utils
         from clinica.utils.io import zip_nii
         import os.path as op
         import re
@@ -424,12 +424,12 @@ class T1VolumeNewTemplate(cpe.Pipeline):
         # Atlas Statistics
         # ================
         atlas_stats_node = npe.MapNode(nutil.Function(input_names=['in_image',
-                                                                   'in_atlas_list'],
+                                                                   'atlas_list'],
                                                       output_names=['atlas_statistics'],
                                                       function=parcellation_utils.atlas_statistics),
                                        name='atlas_stats_node',
                                        iterfield=['in_image'])
-        atlas_stats_node.inputs.in_atlas_list = self.parameters['atlas_list']
+        atlas_stats_node.inputs.atlas_list = self.parameters['atlas_list']
 
         # Connection
         # ==========

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
@@ -97,15 +97,15 @@ class T1VolumeParcellation(cpe.Pipeline):
         """
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
-        import clinica.pipelines.t1_volume_parcellation.t1_volume_parcellation_utils as spu
         import nipype.interfaces.io as nio
+        from ..t1_volume_parcellation import t1_volume_parcellation_utils as parcellation_utils
 
-        atlas_stats_node = npe.MapNode(nutil.Function(input_names=['file_list',
+        atlas_stats_node = npe.MapNode(nutil.Function(input_names=['in_image',
                                                                    'atlas_list'],
                                                       output_names=['atlas_statistics'],
-                                                      function=spu.atlas_statistics),
+                                                      function=parcellation_utils.atlas_statistics),
                                        name='atlas_stats_node',
-                                       iterfield=['file_list'])
+                                       iterfield=['in_image'])
         outputnode = npe.Node(nutil.IdentityInterface(fields=['atlas_statistics']),
                               name='outputnode',
                               mandatory_inputs=True)
@@ -122,7 +122,7 @@ class T1VolumeParcellation(cpe.Pipeline):
         # Connection
         # ==========
         self.connect([
-            (self.input_node,      atlas_stats_node,    [('file_list',    'file_list')]),
+            (self.input_node,      atlas_stats_node,    [('file_list',    'in_image')]),
             (self.input_node,      atlas_stats_node,    [('atlas_list',    'atlas_list')]),
             (atlas_stats_node,     outputnode,          [('atlas_statistics',  'atlas_statistics')]),
             (outputnode,           datasink,            [('atlas_statistics', 'atlas_statistics')])

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_utils.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_utils.py
@@ -10,12 +10,12 @@ __email__ = "simona.bottani@icm-institute.org"
 __status__ = "Development"
 
 
-def atlas_statistics(file_list, atlas_list):
+def atlas_statistics(in_image, atlas_list):
     """
     For each atlas name provided it calculates for the input image the mean for each region in the atlas and saves it to a TSV file.
 
     Args:
-        file_list: A Nifti image
+        in_image: A Nifti image
         atlas_list: List of names of atlas to be applied
 
     Returns:
@@ -27,7 +27,7 @@ def atlas_statistics(file_list, atlas_list):
     from clinica.utils.statistics import statistics_on_atlas
     from clinica.utils.stream import cprint
 
-    orig_dir, base, ext = split_filename(file_list)
+    orig_dir, base, ext = split_filename(in_image)
     atlas_classes = AtlasAbstract.__subclasses__()
     atlas_statistics_list = []
     for atlas in atlas_list:
@@ -36,6 +36,6 @@ def atlas_statistics(file_list, atlas_list):
                 out_atlas_statistics = abspath(
                     join('./' + base + '_space-' + atlas + '_map-graymatter_statistics.tsv'))
                 cprint(out_atlas_statistics)
-                statistics_on_atlas(file_list, atlas_class(), out_atlas_statistics)
+                statistics_on_atlas(in_image, atlas_class(), out_atlas_statistics)
                 atlas_statistics_list.append(out_atlas_statistics)
     return atlas_statistics_list

--- a/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
+++ b/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
@@ -191,11 +191,12 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
         if self.parameters['tpm'] is not None:
             tissue_map = self.parameters['tpm']
 
-        new_segment.inputs.tissues = seg_utils.get_tissue_tuples(tissue_map,
-                                                             self.parameters['tissue_classes'],
-                                                             self.parameters['dartel_tissues'],
-                                                             self.parameters['save_warped_unmodulated'],
-                                                             self.parameters['save_warped_modulated'])
+        new_segment.inputs.tissues = seg_utils.get_tissue_tuples(
+            tissue_map,
+            self.parameters['tissue_classes'],
+            self.parameters['dartel_tissues'],
+            self.parameters['save_warped_unmodulated'],
+            self.parameters['save_warped_modulated'])
 
         # Print end message
         # =================

--- a/test/instantiation/test_instantiate_all_pipelines.py
+++ b/test/instantiation/test_instantiate_all_pipelines.py
@@ -333,7 +333,7 @@ def test_instantiate_T1FreeSurferTemplate():
     from tempfile import mkdtemp
 
     root = dirname(abspath(join(abspath(__file__), pardir)))
-    root = join(root, 'data', 'T1FreeSurferTemplate')
+    root = join(root, 'data', 'T1FreeSurferLongitudinal')
     # build pipeline
     pipeline = T1FreeSurferTemplate(caps_directory=join(root, 'in', 'caps'),
                                     tsv_file=join(root, 'in', 'subjects.tsv'))
@@ -345,14 +345,14 @@ def test_instantiate_T1FreeSurferTemplate():
 
 
 def test_instantiate_T1FreeSurferLongitudinalCorrection():
-    """Instantiation test for t1freesurfer_longitudinal_correction pipeline
+    """Instantiation test for t1_freesurfer_longitudinal_correction pipeline
     """
     from clinica.pipelines.t1_freesurfer_longitudinal.t1_freesurfer_longitudinal_correction_pipeline import T1FreeSurferLongitudinalCorrection
     from os.path import dirname, join, abspath
     from tempfile import mkdtemp
 
     root = dirname(abspath(join(abspath(__file__), pardir)))
-    root = join(root, 'data', 'T1FreeSurferLongitudinalCorrection')
+    root = join(root, 'data', 'T1FreeSurferLongitudinal')
     # build pipeline
     pipeline = T1FreeSurferLongitudinalCorrection(caps_directory=join(root, 'in', 'caps'),
                                                   tsv_file=join(root, 'in', 'subjects.tsv'))

--- a/test/nonregression/test_run_pipelines.py
+++ b/test/nonregression/test_run_pipelines.py
@@ -745,78 +745,6 @@ def test_run_SpatialSVM(cmdopt):
     clean_folder(join(root, 'out', 'caps'), recreate=True)
 
 
-def test_run_T1FreeSurferTemplate(cmdopt):
-    """
-    Functional test for T1FreeSurfer_template pipeline
-    """
-    from clinica.pipelines.t1_freesurfer_longitudinal.t1_freesurfer_template_pipeline import T1FreeSurferTemplate
-
-    from os.path import dirname, join, abspath, isfile
-    import shutil
-    import numpy as np
-    import numpy.linalg
-    import pandas as pd
-    import nibabel as nib
-
-    working_dir = abspath(cmdopt)
-    root = dirname(abspath(join(abspath(__file__), pardir)))
-    root = join(root, 'data', 'T1FreeSurferTemplate')
-
-    # define I/O
-    in_tsv = join(root, 'in', 'subjects.tsv')
-    out_caps_dir = join(root, 'out', 'caps')
-    clean_folder(out_caps_dir, recreate=False)
-    clean_folder(join(working_dir, 'T1FreeSurferTemplate'))
-
-    # Copy necessary data from in to out
-    shutil.copytree(join(root, 'in', 'caps'), join(root, 'out', 'caps'))
-
-    # run pipeline
-    pipeline = T1FreeSurferTemplate(caps_directory=out_caps_dir,
-                                    tsv_file=in_tsv)
-    pipeline.parameters['recon_all_args'] = '-qcache'
-    pipeline.parameters['working_directory'] = working_dir
-    pipeline.base_dir = working_dir
-    pipeline.parameters['overwrite_caps'] = 'True'
-    pipeline.parameters['n_procs'] = 4
-    pipeline.run(bypass_check=True)
-
-    # compare output with reference
-    ref_caps_dir = join(root, 'ref', 'caps')
-    subject_array = np.array(pd.read_csv(in_tsv, sep='\t')['participant_id'])
-    session_array = np.array(pd.read_csv(in_tsv, sep='\t')['session_id'])
-    unique_subject_array, inverse_positions = np.unique(
-        subject_array, return_inverse=True)
-    unique_subject_list = unique_subject_array.tolist()
-    unique_subject_number = len(unique_subject_list)
-    # for each unique subject we find the corresponding list of sessions
-    persubject_session_list2 = [
-        session_array[
-            inverse_positions == subject_index
-            ].tolist() for subject_index in range(unique_subject_number)]
-    for subject in unique_subject_list:
-        # retrieve longitudinal identifier corresponding to the list of
-        # sessions used to build the template
-        subject_session_list = persubject_session_list2[subject_index]
-        long_subdirname = ''.join(subject_session_list)
-        long_subdirname = 'long-{0}'.format(long_subdirname)
-        # define path to segmentation ('aseg.mgz')
-        out_aseg_path = join(out_caps_dir, 'subjects', subject, long_subdirname, 'freesurfer_unbiased_template', subject, 'mri', 'aseg.mgz')
-        ref_aseg_path = join(ref_caps_dir, 'subjects', subject, long_subdirname, 'freesurfer_unbiased_template', subject, 'mri', 'aseg.mgz')
-        # check if file exists
-        if not isfile(out_aseg_path) or not isfile(ref_aseg_path):
-            raise OSError('aseg not created')
-
-        # compare ref and output segmentations
-        out_aseg = nib.load(out_aseg_path)
-        ref_aseg = nib.load(ref_aseg_path)
-        tolerance = 10**-4
-        assert np.allclose(out_aseg.affine, ref_aseg.affine, rtol=tolerance, equal_nan=True)
-        assert np.allclose(out_aseg.get_data(), ref_aseg.get_data(), rtol=tolerance, equal_nan=True)
-
-    clean_folder(out_caps_dir, recreate=False)
-
-
 def test_run_T1FreeSurferLongitudinal(cmdopt):
     """
     Functional test for T1FreeSurfer_longitudinal workflow.
@@ -858,6 +786,7 @@ def test_run_T1FreeSurferLongitudinal(cmdopt):
     template_pipeline.parameters['overwrite_caps'] = 'True'
     template_pipeline.parameters['n_procs'] = 4
     template_pipeline.build()
+
     longcorr_pipeline = T1FreeSurferLongitudinalCorrection(caps_directory=out_caps_dir,
                                                            tsv_file=in_tsv)
     longcorr_pipeline.parameters['recon_all_args'] = '-qcache'
@@ -866,6 +795,7 @@ def test_run_T1FreeSurferLongitudinal(cmdopt):
     longcorr_pipeline.parameters['overwrite_caps'] = 'True'
     longcorr_pipeline.parameters['n_procs'] = 4
     longcorr_pipeline.build()
+    
     longitudinal_workflow = npe.Workflow(name='T1FreeSurferLongitudinalCorrection')
     longitudinal_workflow.base_dir = working_dir
     longitudinal_workflow.connect(


### PR DESCRIPTION
This PR aims to fix some `t1-volume`  pipelines after the removal of `atlas_statistics`  function in `t1_volume_dartel2mni` folder (this function was duplicated in `t1_volume_parcellation` folder). 

Signature of the function changed which made nodes calling it crashed.

It also fix CI functions regarding t1-freesurfer-longitudinal pipeline.

TODO: Upload CI data for T1FreeSurferLongitudinal on each CI machine.