### PR TITLE
Fix OASIS-2-BIDS when computer has 1 core (Issue #22)

### DIFF
--- a/clinica/iotools/converters/oasis_to_bids/oasis_to_bids.py
+++ b/clinica/iotools/converters/oasis_to_bids/oasis_to_bids.py
@@ -109,5 +109,5 @@ class OasisToBids(Converter):
 
         subjs_folders = glob(path.join(source_dir, 'OAS1_*'))
         subjs_folders = [subj_folder for subj_folder in subjs_folders if subj_folder.endswith('_MR1')]
-        poolrunner = Pool(cpu_count() - 1)
+        poolrunner = Pool(max(os.cpu_count()-1, 1))
         poolrunner.map(convert_single_subject, subjs_folders)


### PR DESCRIPTION
When a machine has only one core, `Pool(cpu_count() - 1)` is replaced by `Pool(max(os.cpu_count()-1, 1))` to avoid `Pool(0)`.