### PR TITLE
pet-surface update for docker

### DIFF
--- a/clinica/pipelines/pet_surface/pet_surface_pipeline.py
+++ b/clinica/pipelines/pet_surface/pet_surface_pipeline.py
@@ -322,7 +322,7 @@ class PetSurface(cpe.Pipeline):
         if all(elem in os.environ.keys() for elem in ['SPMSTANDALONE_HOME', 'MCR_HOME']):
             if os.path.exists(os.path.expandvars('$SPMSTANDALONE_HOME')) and os.path.exists(os.path.expandvars('$MCR_HOME')):
                 print(Fore.GREEN + 'SPM standalone has been found and will be used in this pipeline' + Fore.RESET)
-                matlab_cmd = (os.path.join(os.environ['SPMSTANDALONE_HOME'], 'run_spm12.sh')
+                matlab_cmd = ('cd ' + os.path.expandvars('$SPMSTANDALONE_HOME') + ' && ' + './run_spm12.sh'
                               + ' ' + os.environ['MCR_HOME']
                               + ' script')
                 spm.SPMCommand.set_mlab_paths(matlab_cmd=matlab_cmd, use_mcr=True)

--- a/clinica/pipelines/pet_surface/pet_surface_pipeline.py
+++ b/clinica/pipelines/pet_surface/pet_surface_pipeline.py
@@ -276,7 +276,7 @@ class PetSurface(cpe.Pipeline):
                                                           'desikan_right',
                                                           'destrieux_left',
                                                           'destrieux_right',
-                                                          'use_SPM_standalone'],
+                                                          'use_spm_standalone'],
                                              output_names=[],
                                              function=utils.get_wf),
                                 name='full_pipeline_mapnode',
@@ -319,8 +319,8 @@ class PetSurface(cpe.Pipeline):
 
         full_pipe.inputs.matscript_folder_inverse_deformation = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 
-        # This section of code determine wether to use SPM standalone or not
-        full_pipe.inputs.use_SPM_standalone = False
+        # This section of code determines wether to use SPM standalone or not
+        full_pipe.inputs.use_spm_standalone = False
         if all(elem in os.environ.keys() for elem in ['SPMSTANDALONE_HOME', 'MCR_HOME']):
             if os.path.exists(os.path.expandvars('$SPMSTANDALONE_HOME')) and os.path.exists(os.path.expandvars('$MCR_HOME')):
                 print(Fore.GREEN + 'SPM standalone has been found and will be used in this pipeline' + Fore.RESET)
@@ -333,7 +333,7 @@ class PetSurface(cpe.Pipeline):
                                   + ' ' + os.environ['MCR_HOME']
                                   + ' script')
                 spm.SPMCommand.set_mlab_paths(matlab_cmd=matlab_cmd, use_mcr=True)
-                full_pipe.inputs.use_SPM_standalone = True
+                full_pipe.inputs.use_spm_standalone = True
             else:
                 raise FileNotFoundError('$SPMSTANDALONE_HOME and $MCR_HOME are defined, but linked to non existent folder ')
 

--- a/clinica/pipelines/pet_surface/pet_surface_pipeline.py
+++ b/clinica/pipelines/pet_surface/pet_surface_pipeline.py
@@ -319,8 +319,8 @@ class PetSurface(cpe.Pipeline):
         full_pipe.inputs.matscript_folder_inverse_deformation = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 
         full_pipe.inputs.use_SPM_standalone = False
-        if 'SPMSTANDALONE_HOME' and 'MCR_HOME' in os.environ.keys():
-            if os.path.exists(os.path.expandvars('SPMSTANDALONE_HOME')) and os.path.exists(os.path.expandvars('MCR_HOME')):
+        if all(elem in os.environ.keys() for elem in ['SPMSTANDALONE_HOME', 'MCR_HOME']):
+            if os.path.exists(os.path.expandvars('$SPMSTANDALONE_HOME')) and os.path.exists(os.path.expandvars('$MCR_HOME')):
                 print(Fore.GREEN + 'SPM standalone has been found and will be used in this pipeline' + Fore.RESET)
                 matlab_cmd = (os.path.join(os.environ['SPMSTANDALONE_HOME'], 'run_spm12.sh')
                               + ' ' + os.environ['MCR_HOME']

--- a/clinica/pipelines/pet_surface/pet_surface_pipeline.py
+++ b/clinica/pipelines/pet_surface/pet_surface_pipeline.py
@@ -328,7 +328,7 @@ class PetSurface(cpe.Pipeline):
                                   + ' ' + os.environ['MCR_HOME']
                                   + ' script')
                 elif platform.system() == 'Linux':
-                    matlab_cmd = ('./run_spm12.sh'
+                    matlab_cmd = (os.path.join(os.path.expandvars('$SPMSTANDALONE_HOME'), 'run_spm12.sh')
                                   + ' ' + os.environ['MCR_HOME']
                                   + ' script')
                 spm.SPMCommand.set_mlab_paths(matlab_cmd=matlab_cmd, use_mcr=True)

--- a/clinica/pipelines/pet_surface/pet_surface_pipeline.py
+++ b/clinica/pipelines/pet_surface/pet_surface_pipeline.py
@@ -257,6 +257,7 @@ class PetSurface(cpe.Pipeline):
         import clinica.pipelines.pet_surface.pet_surface_utils as utils
         from colorama import Fore
         from nipype.interfaces import spm
+        import platform
 
         full_pipe = npe.MapNode(niu.Function(input_names=['subject_id',
                                                           'session_id',
@@ -322,9 +323,14 @@ class PetSurface(cpe.Pipeline):
         if all(elem in os.environ.keys() for elem in ['SPMSTANDALONE_HOME', 'MCR_HOME']):
             if os.path.exists(os.path.expandvars('$SPMSTANDALONE_HOME')) and os.path.exists(os.path.expandvars('$MCR_HOME')):
                 print(Fore.GREEN + 'SPM standalone has been found and will be used in this pipeline' + Fore.RESET)
-                matlab_cmd = ('cd ' + os.path.expandvars('$SPMSTANDALONE_HOME') + ' && ' + './run_spm12.sh'
-                              + ' ' + os.environ['MCR_HOME']
-                              + ' script')
+                if platform.system() == 'Darwin':
+                    matlab_cmd = ('cd ' + os.path.expandvars('$SPMSTANDALONE_HOME') + ' && ' + './run_spm12.sh'
+                                  + ' ' + os.environ['MCR_HOME']
+                                  + ' script')
+                elif platform.system() == 'Linux':
+                    matlab_cmd = ('./run_spm12.sh'
+                                  + ' ' + os.environ['MCR_HOME']
+                                  + ' script')
                 spm.SPMCommand.set_mlab_paths(matlab_cmd=matlab_cmd, use_mcr=True)
                 full_pipe.inputs.use_SPM_standalone = True
             else:

--- a/clinica/pipelines/pet_surface/pet_surface_pipeline.py
+++ b/clinica/pipelines/pet_surface/pet_surface_pipeline.py
@@ -319,6 +319,7 @@ class PetSurface(cpe.Pipeline):
 
         full_pipe.inputs.matscript_folder_inverse_deformation = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 
+        # This section of code determine wether to use SPM standalone or not
         full_pipe.inputs.use_SPM_standalone = False
         if all(elem in os.environ.keys() for elem in ['SPMSTANDALONE_HOME', 'MCR_HOME']):
             if os.path.exists(os.path.expandvars('$SPMSTANDALONE_HOME')) and os.path.exists(os.path.expandvars('$MCR_HOME')):

--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -233,9 +233,11 @@ def runApplyInverseDeformationField_SPM_standalone(target,
     if platform.system() == 'Darwin':
         # Mac OS
         cmdline = 'cd $SPMSTANDALONE_HOME && ./run_spm12.sh $MCR_HOME batch ' + script_location
-    else:
+    elif platform.system() == 'Linux':
         # Linux OS
         cmdline = '$SPMSTANDALONE_HOME/run_spm12.sh $MCR_HOME batch ' + script_location
+    else:
+        raise SystemError('Only support Mac OS and Linux')
     os.system(cmdline)
 
     output_file = join(abspath('./'), prefix + basename(img))

--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -210,6 +210,7 @@ def runApplyInverseDeformationField_SPM_standalone(target,
     check when building the pipeline ensures that all the env vars exists ($SPMSTANDALONE_HOME and $MCR_HOME)
     """
     from os.path import abspath, join, basename, exists
+    import platform
     import os
 
     prefix = 'subject_space_'
@@ -229,7 +230,12 @@ def runApplyInverseDeformationField_SPM_standalone(target,
 
     # Generate command line to run
     # SPM standalone must be run directly from its root folder
-    cmdline = 'cd $SPMSTANDALONE_HOME && ./run_spm12.sh $MCR_HOME batch ' + script_location
+    if platform.system() == 'Darwin':
+        # Mac OS
+        cmdline = 'cd $SPMSTANDALONE_HOME && ./run_spm12.sh $MCR_HOME batch ' + script_location
+    else:
+        # Linux OS
+        cmdline = '$SPMSTANDALONE_HOME/run_spm12.sh $MCR_HOME batch ' + script_location
     os.system(cmdline)
 
     output_file = join(abspath('./'), prefix + basename(img))

--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -834,7 +834,7 @@ def get_wf(subject_id,
            destrieux_right,
            desikan_left,
            desikan_right,
-           use_SPM_standalone):
+           use_spm_standalone):
     """get_wf create a full workflow for only one subject, and then executes it
 
             Args:
@@ -942,7 +942,7 @@ def get_wf(subject_id,
                                       warping_regularization=[0, 0.001, 0.5, 0.05, 0.2]),
                           name='normalize_to_MNI')
 
-    if use_SPM_standalone is True:
+    if use_spm_standalone is True:
         fun_apply_inverse_deformation = utils.runApplyInverseDeformationField_SPM_standalone
     else:
         fun_apply_inverse_deformation = utils.runApplyInverseDeformationField

--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -865,6 +865,7 @@ def get_wf(subject_id,
     from nipype.interfaces.petpvc import PETPVC
     from nipype.interfaces.spm import Coregister, Normalize12
     import clinica.pipelines.pet_surface.pet_surface_utils as utils
+    import platform
 
     cprint('***** Beginning processing of ' + subject_id + ' on ' + session_id + ' *****')
 
@@ -923,8 +924,9 @@ def get_wf(subject_id,
 
     if 'SPMSTANDALONE_HOME' in os.environ:
         # Path is different between SPM standalone MAC and Linux. First is MAC location
-        tpmnii = os.path.join(str(os.getenv("SPMSTANDALONE_HOME")), 'spm12_mcr/spm12/tpm/TPM.nii')
-        if not os.path.exists(tpmnii):
+        if platform.system() == 'Darwin':
+            tpmnii = os.path.join(str(os.getenv("SPMSTANDALONE_HOME")), 'spm12_mcr/spm12/tpm/TPM.nii')
+        elif platform.system() == 'Linux':
             # Try Linux location
             tpmnii = os.path.join(str(os.getenv("SPMSTANDALONE_HOME")), 'spm12_mcr/spm12/spm12/tpm/TPM.nii')
     else:

--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -914,7 +914,7 @@ def get_wf(subject_id,
                            name='vol2vol_mask')
 
     if 'SPMSTANDALONE_HOME' in os.environ:
-        tpmnii = os.path.join(str(os.getenv("SPM_HOME")), 'spm12_mcr/spm12/spm12/tpm/TPM.nii')
+        tpmnii = os.path.join(str(os.getenv("SPMSTANDALONE_HOME")), 'spm12_mcr/spm12/tpm/TPM.nii')
     else:
         tpmnii = os.path.join(os.path.expandvars('$SPM_HOME'), 'tpm', 'TPM.nii')
     if not os.path.exists(tpmnii):

--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -914,7 +914,11 @@ def get_wf(subject_id,
                            name='vol2vol_mask')
 
     if 'SPMSTANDALONE_HOME' in os.environ:
+        # Path is different between SPM standalone MAC and Linux. First is MAC location
         tpmnii = os.path.join(str(os.getenv("SPMSTANDALONE_HOME")), 'spm12_mcr/spm12/tpm/TPM.nii')
+        if not os.path.exists(tpmnii):
+            # Try Linux location
+            tpmnii = os.path.join(str(os.getenv("SPMSTANDALONE_HOME")), 'spm12_mcr/spm12/spm12/tpm/TPM.nii')
     else:
         tpmnii = os.path.join(os.path.expandvars('$SPM_HOME'), 'tpm', 'TPM.nii')
     if not os.path.exists(tpmnii):

--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -200,10 +200,52 @@ def make_label_conversion(gtmsegfile, csv):
     return list_of_regions
 
 
+def runApplyInverseDeformationField_SPM_standalone(target,
+                                                   deformation_field,
+                                                   img,
+                                                   matscript_folder):
+    """
+    This function does the exact same job as runApplyInverseDeformationField but with SPM standalone. We directly create
+    a batch file that SPM standalone can run. This function does not check wether SPM standalone must be used. Previous
+    check when building the pipeline ensures that all the env vars exists ($SPMSTANDALONE_HOME and $MCR_HOME)
+    """
+    from os.path import abspath, join, basename, exists
+    import os
+
+    prefix = 'subject_space_'
+
+    # Write SPM batch command directly in a script that is readable by SPM standalone
+    script_location = abspath('./m_script.m')
+    script_file = open(script_location, 'w+')
+    script_file.write('jobs{1}.spm.util.defs.comp{1}.inv.comp{1}.def = {\'' + deformation_field + '\'};\n')
+    script_file.write('jobs{1}.spm.util.defs.comp{1}.inv.space = {\'' + target + '\'};\n')
+    script_file.write('jobs{1}.spm.util.defs.out{1}.pull.fnames = {\'' + img + '\'};\n')
+    script_file.write('jobs{1}.spm.util.defs.out{1}.pull.savedir.saveusr = {\'' + abspath(os.getcwd()) + '\'};\n')
+    script_file.write('jobs{1}.spm.util.defs.out{1}.pull.interp = 4;\n')
+    script_file.write('jobs{1}.spm.util.defs.out{1}.pull.mask = 1;\n')
+    script_file.write('jobs{1}.spm.util.defs.out{1}.pull.fwhm = [0 0 0];\n')
+    script_file.write('jobs{1}.spm.util.defs.out{1}.pull.prefix = \'' + prefix + '\';\n')
+    script_file.close()
+
+    # Generate command line to run
+    # SPM standalone must be run directly from its root folder
+    cmdline = 'cd $SPMSTANDALONE_HOME && ./run_spm12.sh $MCR_HOME batch ' + script_location
+    os.system(cmdline)
+
+    output_file = join(abspath('./'), prefix + basename(img))
+    if not exists(output_file):
+        raise IOError('Something went wrong while trying to run runApplyInverseDeformationField_SPM_standalone'
+                      + '. Output file not generated. Command launched :\n\t '
+                      + cmdline + '\n. We strongly recommand that you use the supported version of Matlab MCR '
+                      + ' recommanded by the creators of SPM.')
+    return output_file
+
+
 def runApplyInverseDeformationField(target,
                                     deformation_field,
                                     img,
                                     matscript_folder):
+
     import sys
     import os
     from nipype.interfaces.matlab import MatlabCommand, get_matlab_command
@@ -783,7 +825,8 @@ def get_wf(subject_id,
            destrieux_left,
            destrieux_right,
            desikan_left,
-           desikan_right):
+           desikan_right,
+           use_SPM_standalone):
     """get_wf create a full workflow for only one subject, and then executes it
 
             Args:
@@ -804,7 +847,6 @@ def get_wf(subject_id,
                 Void
     """
     import os
-    import inspect
     from clinica.utils.stream import cprint
     import nipype.pipeline.engine as pe
     import nipype.interfaces.utility as niu
@@ -886,12 +928,16 @@ def get_wf(subject_id,
                                       warping_regularization=[0, 0.001, 0.5, 0.05, 0.2]),
                           name='normalize_to_MNI')
 
+    if use_SPM_standalone is True:
+        fun_apply_inverse_deformation = utils.runApplyInverseDeformationField_SPM_standalone
+    else:
+        fun_apply_inverse_deformation = utils.runApplyInverseDeformationField
     apply_inverse_deformation = pe.Node(niu.Function(input_names=['target',
                                                                   'deformation_field',
                                                                   'img',
                                                                   'matscript_folder'],
                                                      output_names=['freesurfer_space_eroded_mask'],
-                                                     function=utils.runApplyInverseDeformationField),
+                                                     function=fun_apply_inverse_deformation),
                                         name='applyInverseDeformation')
     apply_inverse_deformation.inputs.matscript_folder = matscript_folder_inverse_deformation
 


### PR DESCRIPTION
pet-surface can now be used with SPM standalone on mac and Linux (tested on latest version of SPM standalone for mac and linux, and MCR v713 for mac and MCR v2018b for linux)

SPM standalone is used when `SPMSTANDALONE_HOME` and `MCR_HOME` are found in the `os.environ.keys()`

The key idea is to create a batch file that SPM can read. The command to run a batch file with spm standalone is :
`$SPMSTANDALONE_HOME/run_spm12.sh /path/to/MCR batch /path/to/batch/file.m`

BUT :  
In Mac Os : the script `run_spm12.sh` must be run from its very own folder, leading to a command like : 
`cd $SPMSTANDALONE_HOME && ./run_spm12.sh /path/to/MCR batch /path/to/batch/file.m`  

The batch file is created on the fly when the function `runApplyInverseDeformationField_SPM_standalone` is run.

The file ApplyInverseDeformationField.m  could not be used (like before), as it does not have the syntax to be recognised as a spm batch file. 

If SPM standalone is not used, the pipeline is executed as before.

To use SPM_STANDALONE in the rest of the pipeline (like for the Coregister, or Normalize12), we use the standard method : 
```python
matlab_cmd = ('cd ' + os.path.expandvars('$SPMSTANDALONE_HOME') + ' && ' + './run_spm12.sh'
                                  + ' ' + os.environ['MCR_HOME']
                                  + ' script')
spm.SPMCommand.set_mlab_paths(matlab_cmd=matlab_cmd, use_mcr=True)
```
 and we change `matlab_cmd` in the same way as previously explained if we are on a Linux machine