### PR TITLE
Add categories for CLI when creating a pipeline with `clinica generate`

### DIFF
--- a/clinica/resources/templates/pipeline_template/cli.py.j2
+++ b/clinica/resources/templates/pipeline_template/cli.py.j2
@@ -26,24 +26,37 @@ class {{ pipeline.class_name }}CLI(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments
         """
+        from clinica.engine.cmdparser import PIPELINE_CATEGORIES
 
-        # self._args.add_argument("bids_directory",
-        #                         help='Path to the BIDS directory.')
-        # self._args.add_argument("caps_directory",
-        #                         help='Path to the CAPS directory.')
-        # self._args.add_argument("group_id",
-        #                         help='User-defined identifier for the provided group of subjects.')
-        # self._args.add_argument("-tsv", "--subjects_sessions_tsv",
-        #                         help='TSV file containing a list of subjects with their sessions.')
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
+        clinica_comp.add_argument("bids_directory",
+                                  help='Path to the BIDS directory.')
+        clinica_comp.add_argument("caps_directory",
+                                  help='Path to the CAPS directory.')
+        clinica_comp.add_argument("group_id",
+                                  help='User-defined identifier for the provided group of subjects.')
+
+        # Clinica standard arguments
+        clinica_opt = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_OPTIONAL'])
+        clinica_opt.add_argument("-tsv", "--subjects_sessions_tsv",
+                                 help='TSV file containing a list of subjects with their sessions.')
+        clinica_opt.add_argument("-wd", "--working_directory",
+                                 help='Temporary directory to store pipelines intermediate results')
+        clinica_opt.add_argument("-np", "--n_procs",
+                                 metavar=('N'), type=int,
+                                 help='Number of cores used to run in parallel')
+
         # Add your own pipeline command line arguments here to be used in the
         # method below. Example below:
-        self._args.add_argument("-hw", "--hello_word_arg",
-                                help='Word to say hello')
-        self._args.add_argument("-wd", "--working_directory",
-                                help='Temporary directory to store pipeline intermediate results')
-        self._args.add_argument("-np", "--n_procs", type=int,
-                                help='Number of cores used to run in parallel')
-        # END OF EXAMPLE
+        optional = self._args.add_argument_group(PIPELINE_CATEGORIES['OPTIONAL'])
+        optional.add_argument("-hw", "--hello_word_arg",
+                              help='Word to say hello')
+
+        # Add advanced arguments
+        advanced = self._args.add_argument_group(PIPELINE_CATEGORIES['ADVANCED'])
+        advanced.add_argument("-hw", "--hello_word_arg",
+                              help='Word to say hello')
 
     def run_command(self, args):
         """

--- a/clinica/resources/templates/pipeline_template/cli.py.j2
+++ b/clinica/resources/templates/pipeline_template/cli.py.j2
@@ -21,42 +21,46 @@ class {{ pipeline.class_name }}CLI(ce.CmdParser):
     def define_description(self):
         """Define a description of this pipeline.
         """
-        # self._description = 'Brief description: https://gitlab.icm-institute.org/aramislab/clinica/wikis/docs/Pipelines/{{ pipeline.class_name }}'
+        self._description = ('Brief description:\n'
+                             'http://clinica.run/doc/Pipelines/{{ pipeline.class_name }}/')
 
     def define_options(self):
         """Define the sub-command arguments
         """
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
 
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id...)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')
-        clinica_comp.add_argument("group_id",
-                                  help='User-defined identifier for the provided group of subjects.')
+
+        # group_id can be used by certain pipelines when some operations are performed at the group level
+        # (for example, generation of a template in pipeline t1-volume)
+        # clinica_comp.add_argument("group_id",
+        #                          help='User-defined identifier for the provided group of subjects.')
 
         # Clinica standard arguments
         clinica_opt = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_OPTIONAL'])
         clinica_opt.add_argument("-tsv", "--subjects_sessions_tsv",
                                  help='TSV file containing a list of subjects with their sessions.')
         clinica_opt.add_argument("-wd", "--working_directory",
-                                 help='Temporary directory to store pipelines intermediate results')
+                                 help='Temporary directory to store pipelines intermediate results.')
         clinica_opt.add_argument("-np", "--n_procs",
                                  metavar=('N'), type=int,
-                                 help='Number of cores used to run in parallel')
+                                 help='Number of cores used to run in parallel.')
 
         # Add your own pipeline command line arguments here to be used in the
         # method below. Example below:
         optional = self._args.add_argument_group(PIPELINE_CATEGORIES['OPTIONAL'])
         optional.add_argument("-hw", "--hello_word_arg",
-                              help='Word to say hello')
+                              help='Word to say hello.')
 
         # Add advanced arguments
         advanced = self._args.add_argument_group(PIPELINE_CATEGORIES['ADVANCED'])
-        advanced.add_argument("-hw", "--hello_word_arg",
-                              help='Word to say hello')
+        advanced.add_argument("-aa", "--advanced_arg",
+                              help='Your advanced argument.')
 
     def run_command(self, args):
         """
@@ -77,6 +81,7 @@ class {{ pipeline.class_name }}CLI(ce.CmdParser):
             # pipeline. See the file `{{ pipeline.module_name }}_pipeline.py` to
             # see an example of use.
             'hello_word'        : args.hello_word_arg or 'Hello'
+            'advanced_argument' : args.advanced_arg
         }
         if args.working_directory is None:
             args.working_directory = mkdtemp()


### PR DESCRIPTION
Update of the file `clinica/resources/templates/pipeline_template/cli.py.j2` to take into account pipeline categories created by @alexandreroutier a few months ago.

I hope this is what was expected in the airtable card `[CLI] Update CLI template with the command line categories`