### PR TITLE
Center nifti

### DIFF
--- a/clinica/cmdline.py
+++ b/clinica/cmdline.py
@@ -287,11 +287,12 @@ def execute():
     from clinica.iotools.utils.data_handling_cli import CmdParserSubjectsSessions
     from clinica.iotools.utils.data_handling_cli import CmdParserMergeTsv
     from clinica.iotools.utils.data_handling_cli import CmdParserMissingModalities
-
+    from clinica.iotools.utils.data_handling_cli import CmdParserCenterNifti
     io_tools = [
         CmdParserSubjectsSessions(),
         CmdParserMergeTsv(),
         CmdParserMissingModalities(),
+        CmdParserCenterNifti()
     ]
 
     HELP_IO_TOOLS = 'Tools to handle BIDS/CAPS datasets.'

--- a/clinica/iotools/utils/data_handling_cli.py
+++ b/clinica/iotools/utils/data_handling_cli.py
@@ -109,3 +109,53 @@ class CmdParserMissingModalities(ce.CmdParser):
 
         check_bids_folder(args.bids_directory)
         dt.compute_missing_mods(args.bids_directory, args.out_directory, args.output_prefix)
+
+
+class CmdParserCenterNifti(ce.CmdParser):
+
+    def define_name(self):
+        self._name = 'center-nifti'
+
+    def define_description(self):
+        self._description = 'Center nifti of a BIDS directory'
+
+    def define_options(self):
+        self._args.add_argument("bids_directory",
+                                help='Path to the BIDS dataset directory in which you want to center the NIfTI files/images.')
+        self._args.add_argument("output_bids_directory",
+                                help='Path to the output directory. This is where your BIDS folder with centered nifti will appear.')
+
+    def run_command(self, args):
+        from colorama import Fore
+        from os.path import isdir, abspath
+        from os import listdir
+        from os import makedirs
+        from clinica.iotools.utils.data_handling import center_all_nifti
+        from clinica.utils.stream import cprint
+        import sys
+
+        # check that output_folder does not exist, or is an empty folder
+        if isdir(args.output_bids_directory):
+            file_list = listdir(args.output_bids_directory)
+            if len(file_list) > 0:
+                error_str = Fore.YELLOW + '[Warning] Some files or directory have been found in ' + args.output_bids_directory + ': \n'
+                for f in file_list:
+                    error_str += '\t' + f + '\n'
+                error_str += 'Do you wish to continue ?(If yes, this may overwrite the files mentioned above).: ' + Fore.RESET
+                cprint(error_str)
+                while True:
+                    cprint('Your answer [yes/no]:')
+                    answer = input()
+                    if answer.lower() in ['yes', 'no']:
+                        break
+                    else:
+                        cprint(Fore.RED + 'You must answer yes or no' + Fore.RESET)
+                if answer.lower() == 'no':
+                    cprint(Fore.RED + 'Clinica will now exit...' + Fore.RESET)
+                    sys.exit(0)
+        else:
+            makedirs(args.output_bids_directory)
+
+        center_all_nifti(args.bids_directory, args.output_bids_directory)
+        cprint(Fore.GREEN + 'All NIfTI files/images of BIDS folder ' + abspath(args.bids_directory)
+               + ' have been centered in output folder ' + abspath(args.output_bids_directory) + Fore.RESET)

--- a/test/nonregression/test_run_iotools.py
+++ b/test/nonregression/test_run_iotools.py
@@ -205,3 +205,24 @@ def test_run_Aibl2Bids(cmdopt):
     compare_folders(join(root, 'out'), join(root, 'ref'),
                     shared_folder_name='bids')
     clean_folder(join(root, 'out', 'bids'), recreate=True)
+
+
+def test_run_CenterNifti(cmdopt):
+    from clinica.iotools.utils.data_handling import center_all_nifti
+    from os.path import dirname, join, abspath
+
+    root = dirname(abspath(join(abspath(__file__), pardir)))
+    root = join(root, 'data', 'CenterNifti')
+
+    clean_folder(join(root, 'out', 'bids_centered'), recreate=True)
+
+    bids_dir = join(root, 'in', 'bids')
+    output_dir = join(root, 'out', 'bids_centered')
+
+    center_all_nifti(bids_dir, output_dir)
+    hashes_out = create_list_hashes(output_dir, extensions_to_keep=('.nii.gz', '.nii'))
+    hashes_ref = create_list_hashes(join(root, 'ref', 'bids_centered'), extensions_to_keep=('.nii.gz', '.nii'))
+
+    if hashes_out != hashes_ref:
+        raise RuntimeError('Hashes of nii* files are different between out and ref')
+    clean_folder(join(root, 'out', 'bids_centered'), recreate=False)

--- a/test/test_coding_style.py
+++ b/test/test_coding_style.py
@@ -14,6 +14,7 @@ __email__ = "mauricio.diaz@inria.fr"
 __status__ = "Development"
 
 import pycodestyle
+from os.path import dirname, abspath, join
 
 
 def test_coding_style():
@@ -23,7 +24,7 @@ def test_coding_style():
         ignore=['E203', 'E121', 'E123', 'E126', 'E133',
                 'E226', 'E241', 'E242', 'E704', 'W503',
                 'E501', 'W504', 'W505', 'W605'])
-    result = style.check_files(['clinica/'])
+    clinica_folder = join(dirname(dirname(abspath(__file__))), 'clinica')
+    result = style.check_files([clinica_folder])
     result.print_statistics()
     assert result.total_errors == 0, "Found code style errors (and warnings)."
-    pass


### PR DESCRIPTION
This PR aims to provide an IO tool that allows the user to center all the Niftis of a BIDS directory.
Currently, this goes as follows : cmdline interface takes 2 inputs : `bids_directory` and `output_bids_directory`
- `bids_directory` is copied in `output_bids_directory`
- Each nifti file of `output_bids_directory` is replaced by its centered version

A bunch of checks are performed:
- check that `bids_directory` is an actual BIDS.
- if some files exist in `output_bids_directory`, we tell the user about it and ask him if he wants to continue anyway, knowing that some files may be erased.

If errors happen, they are all stored until each nifti files are treated. Then, all errors are displayed to the user.

With -v arg :
![Screen Shot 2019-10-01 at 16 00 51](https://user-images.githubusercontent.com/49677712/65979905-731c0200-e476-11e9-907b-d9d8a063e1de.png)

Otherwise : 
![Screen Shot 2019-10-01 at 18 10 04](https://user-images.githubusercontent.com/49677712/65980070-bd04e800-e476-11e9-89c1-dff4d45b47ac.png)
