### PR TITLE
Remove the double equal from conda environment file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: clinica_env
 channels:
   - defaults
 dependencies:
-  - python==3.6
+  - python=3.6
   - pip
   - pip:
       - nibabel==2.3.3


### PR DESCRIPTION
This PR addresses issue #15 , in order to be compatible with Conda >= 4.7. 
It was tested with conda versions greater than 4.0.