### PR TITLE
Fix CI for DWI* pipelines

### DIFF
--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_pipeline.py
@@ -1,6 +1,7 @@
 # coding: utf8
 
 import clinica.pipelines.engine as cpe
+from nipype import config
 
 __author__ = ["Thomas Jacquemont", "Alexandre Routier"]
 __copyright__ = "Copyright 2016-2019 The Aramis Lab Team"
@@ -8,6 +9,12 @@ __credits__ = ["Nipype"]
 __license__ = "See LICENSE.txt file"
 __version__ = "0.1.0"
 __status__ = "Development"
+
+
+# Use hash instead of parameters for iterables folder names
+# Otherwise path will be too long and generate OSError
+cfg = dict(execution={'parameterize_dirs': False})
+config.update_config(cfg)
 
 
 class DwiPreprocessingUsingT1(cpe.Pipeline):

--- a/clinica/utils/mri_registration.py
+++ b/clinica/utils/mri_registration.py
@@ -30,7 +30,7 @@ def convert_flirt_transformation_to_mrtrix_transformation(
         out_mrtrix_matrix (str): Transformation matrix in MRtrix format.
     """
     import os
-    from .check_dependency import check_mrtrix
+    from clinica.utils.check_dependency import check_mrtrix
     check_mrtrix()
 
     assert(os.path.isfile(in_source_image))
@@ -81,7 +81,7 @@ def apply_ants_registration_syn_quick_transformation(
             transformations.
     """
     import os
-    from .check_dependency import check_ants
+    from clinica.utils.check_dependency import check_ants
     check_ants()
 
     assert(os.path.isfile(in_image))
@@ -120,7 +120,7 @@ def ants_registration_syn_quick(fix_image, moving_image, prefix_output=None):
         The deformed image with the deformation parameters.
     """
     import os
-    from .check_dependency import check_ants
+    from clinica.utils.check_dependency import check_ants
     check_ants()
 
     if prefix_output is None:
@@ -159,7 +159,7 @@ def ants_combine_transform(in_file, transforms_list, reference):
             in_bspline_transformation transformations.
     """
     import os
-    from .check_dependency import check_ants
+    from clinica.utils.check_dependency import check_ants
     check_ants()
 
     out_warp = os.path.abspath('out_warp.nii.gz')


### PR DESCRIPTION
The two commits fix issues met in CI namely:
- Too long path in `dwi-preprocessing-using-t1`
- Exceptions due to relative path in `mri_registrations.py`