### PR TITLE
Fix bug in center-nifti caused by nib.save

### DIFF
--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -584,7 +584,8 @@ def center_nifti_origin(input_image, output_image):
         new_img = nib.Nifti1Image(canonical_img.get_data(caching='unchanged'), affine=qform, header=hd)
 
         # Without deleting already-existing file, nib.save causes a severe bug on Linux system
-        os.remove(output_image)
+        if isfile(output_image):
+            os.remove(output_image)
 
         nib.save(new_img, output_image)
         if not isfile(output_image):

--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -563,6 +563,7 @@ def center_nifti_origin(input_image, output_image):
     from colorama import Fore
     from nibabel.spatialimages import ImageFileError
     from os.path import isfile
+    import os
 
     error_str = None
     try:
@@ -581,6 +582,9 @@ def center_nifti_origin(input_image, output_image):
             qform[i - 1, i - 1] = hd['pixdim'][i]
             qform[i - 1, 3] = -1.0 * hd['pixdim'][i] * hd['dim'][i] / 2.0
         new_img = nib.Nifti1Image(canonical_img.get_data(caching='unchanged'), affine=qform, header=hd)
+
+        # Without deleting already-existing file, nib.save causes a severe bug on Linux system
+        os.remove(output_image)
 
         nib.save(new_img, output_image)
         if not isfile(output_image):


### PR DESCRIPTION
Fix bug in center-nifti caused by nib.save.

If destination file already exists, nib.save crashes
![Screen Shot 2019-11-12 at 16 35 24](https://user-images.githubusercontent.com/49677712/68685453-75d83f80-056a-11ea-84de-e7130c3b2499.png)
