### PR TITLE
Clarifications and change how input data are grabbed for ML-Prepare-Data

### DIFF
--- a/clinica/pipelines/engine.py
+++ b/clinica/pipelines/engine.py
@@ -1,7 +1,9 @@
 # coding: utf8
 
 """
+This module contains the Pipeline abstract class needed for Clinica.
 
+Subclasses are located in clinica/pipeline/<pipeline_name>/<pipeline_name>_pipeline.py
 """
 
 import abc
@@ -509,7 +511,7 @@ class Pipeline(Workflow):
                    + 'Running anyway...' + Fore.RESET)
 
     def update_parallelize_info(self, plugin_args):
-        """ Peforms some checks of the number of threads given in parameters,
+        """ Performs some checks of the number of threads given in parameters,
         given the number of CPUs of the machine in which clinica is running.
         We force the use of plugin MultiProc
 
@@ -557,7 +559,7 @@ class Pipeline(Workflow):
                 cprint('How many threads do you want to use? If you do not '
                        + 'answer within ' + str(timeout)
                        + ' sec, default value of ' + str(n_cpu - 1)
-                       + ' will be taken.')
+                       + ' will be taken. Use --n_procs argument if you want to disable this message next time.')
                 stdin_answer, __, ___ = select.select([sys.stdin], [], [], timeout)
                 if stdin_answer:
                     answer = str(sys.stdin.readline().strip())
@@ -568,7 +570,7 @@ class Pipeline(Workflow):
                         break
                 cprint(Fore.RED + 'Your answer must be a positive integer.'
                        + Fore.RESET)
-            # If plugin_args is None, create the dictionnary
+            # If plugin_args is None, create the dictionary
             # If it already a dict, just update (or create -it is the same
             # code-) the correct key / value
             if plugin_args is None:

--- a/clinica/utils/atlas.py
+++ b/clinica/utils/atlas.py
@@ -1,5 +1,18 @@
 # coding: utf8
 
+"""
+This module contains utilities to handle atlases in Clinica.
+
+An atlas is currently defined by its name, a set of labels in a template space and
+the map of this template space (e.g. T1w, FA map derived from DWI).
+
+This current implementation has some drawbacks:
+- Atlas is misleading: it is only a set of labels in a template space
+- This implementation can not handle case where there are several maps (e.g. both T1w and T2w) in template space
+
+Either a refactoring of this module or the use of an external API
+(e.g. TemplateFlow - https://www.templateflow.org/) needs to be considered.
+"""
 
 import abc
 

--- a/clinica/utils/check_dependency.py
+++ b/clinica/utils/check_dependency.py
@@ -1,9 +1,11 @@
 # coding: utf8
 
 
-"""This module contains utilities to check dependencies of the different
-neuroimaging tools."""
+"""
+This module contains utilities to check dependencies before running Clinica.
 
+These functions can check binaries, software (e.g. FreeSurfer) or toolboxes (e.g. SPM).
+"""
 
 def is_binary_present(binary):
     """

--- a/clinica/utils/exceptions.py
+++ b/clinica/utils/exceptions.py
@@ -1,7 +1,7 @@
 # coding: utf8
 
 """
-Clinica exceptions
+This module handles Clinica exceptions.
 """
 
 

--- a/clinica/utils/freesurfer.py
+++ b/clinica/utils/freesurfer.py
@@ -1,7 +1,7 @@
 # coding: utf8
-
-
-"""This module contains FreeSurfer utilities."""
+"""
+This module contains FreeSurfer utilities.
+"""
 
 
 def extract_image_id_from_longitudinal_segmentation(freesurfer_id):

--- a/clinica/utils/group.py
+++ b/clinica/utils/group.py
@@ -1,6 +1,13 @@
 # coding: utf8
 
 
+"""
+This module contains utilities to handle groups in Clinica.
+
+See CAPS specifications for details about groups.
+"""
+
+
 def check_group_label(group_label):
     """Check that `group_label` is compliant with specifications."""
     if not group_label.isalnum():

--- a/clinica/utils/input_files.py
+++ b/clinica/utils/input_files.py
@@ -1,8 +1,9 @@
 # coding: utf8
 
 """
-Describe files to grab, to use with inputs.clinica_file_reader() and inputs.clinica_group_reader()
+This module contains dictionaries used in inputs.py::clinica_{file|group}_reader().
 
+These dictionaries describe files to grab.
 """
 
 """ T1w """

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -1,5 +1,9 @@
 # coding: utf8
 
+"""
+This module contains utilities to grab or download files for Clinica.
+"""
+
 import hashlib
 from collections import namedtuple
 

--- a/clinica/utils/participant.py
+++ b/clinica/utils/participant.py
@@ -1,4 +1,11 @@
 # coding: utf8
+
+"""
+This module contains utilities for longitudinal pipelines.
+
+See CAPS specifications for details about long ID.
+"""
+
 from clinica.utils.filemanip import read_participant_tsv
 
 

--- a/clinica/utils/spm.py
+++ b/clinica/utils/spm.py
@@ -1,5 +1,9 @@
 # coding: utf8
 
+"""
+This module contains SPM utilities.
+"""
+
 INDEX_TISSUE_MAP = {
     1: 'graymatter',
     2: 'whitematter',

--- a/clinica/utils/statistics.py
+++ b/clinica/utils/statistics.py
@@ -1,5 +1,10 @@
 # coding: utf8
 
+"""
+This module contains utilities for statistics.
+
+Currently, it contains one function to generate TSV file containing mean map based on a parcellation.
+"""
 
 def statistics_on_atlas(in_normalized_map, in_atlas, out_file=None):
     """
@@ -43,9 +48,9 @@ def statistics_on_atlas(in_normalized_map, in_atlas, out_file=None):
     img = nib.load(in_normalized_map)
     img_data = img.get_data()
 
-    atlas_correspondance = pandas.io.parsers.read_csv(in_atlas.get_tsv_roi(), sep='\t')
-    label_name = list(atlas_correspondance.roi_name)
-    label_value = list(atlas_correspondance.roi_value)  # TODO create roi_value column in lut_*.txt and remove irrelevant RGB information
+    atlas_correspondence = pandas.io.parsers.read_csv(in_atlas.get_tsv_roi(), sep='\t')
+    label_name = list(atlas_correspondence.roi_name)
+    label_value = list(atlas_correspondence.roi_value)  # TODO create roi_value column in lut_*.txt and remove irrelevant RGB information
 
     mean_signal_value = []
     for label in label_value:

--- a/clinica/utils/stream.py
+++ b/clinica/utils/stream.py
@@ -1,8 +1,9 @@
 # coding: utf8
 
 """
-Redirect stream and log
+This module handles stream and log redirection.
 """
+
 import sys
 
 clinica_verbose = False

--- a/clinica/utils/ux.py
+++ b/clinica/utils/ux.py
@@ -1,5 +1,10 @@
 # coding: utf8
 
+"""
+This module gathers formatted messages that are displayed when running Clinica.
+
+These functions are mainly called by the pipelines.
+"""
 
 LINES_TO_DISPLAY = 25
 

--- a/test/instantiation/test_instantiate_all_pipelines.py
+++ b/test/instantiation/test_instantiate_all_pipelines.py
@@ -323,7 +323,8 @@ def test_instantiate_SpatialSVM():
     root = join(root, 'data', 'SpatialSVM')
 
     parameters = {
-        'group_id': 'ADNIbl'
+        'group_label': 'ADNIbl',
+        'orig_input_data': 't1-volume'
     }
     pipeline = SpatialSVM(
         caps_directory=join(root, 'in', 'caps'),

--- a/test/nonregression/test_run_pipelines.py
+++ b/test/nonregression/test_run_pipelines.py
@@ -754,7 +754,8 @@ def test_run_SpatialSVM(cmdopt):
     shutil.copytree(join(root, 'in', 'caps'), join(root, 'out', 'caps'))
 
     parameters = {
-        'group_id': 'ADNIbl'
+        'group_label': 'ADNIbl',
+        'orig_input_data': 't1-volume'
     }
     # Instantiate pipeline and run()
     pipeline = SpatialSVM(


### PR DESCRIPTION
Hi,

This PR contains the following small modifications:
- Clarify how to deactivate `How many threads.. message`
- Add modules description in utils/ folder.
- Change how input data are chosen in ML-Prepare-Data. Flags for `Pipeline options if you use inputs from pet-volume pipeline:` will be updated in another PR

Alex