### PR TITLE
Update T1 linear default behavior

### DIFF
--- a/clinica/pipelines/t1_linear/t1_linear_cli.py
+++ b/clinica/pipelines/t1_linear/t1_linear_cli.py
@@ -33,8 +33,8 @@ class T1LinearCLI(ce.CmdParser):
         optional = self._args.add_argument_group(PIPELINE_CATEGORIES['OPTIONAL'])
 
         optional.add_argument("-cp", "--uncropped_image",
-                              help='''Do not crop the image with template 
-                              (cropped image are suggested for using with DL 
+                              help='''Do not crop the image with template
+                              (cropped image are suggested for using with DL
                               models)''',
                               action='store_true',
                               default=False)

--- a/clinica/pipelines/t1_linear/t1_linear_cli.py
+++ b/clinica/pipelines/t1_linear/t1_linear_cli.py
@@ -32,7 +32,7 @@ class T1LinearCLI(ce.CmdParser):
         # Clinica optional arguments
         optional = self._args.add_argument_group(PIPELINE_CATEGORIES['OPTIONAL'])
 
-        optional.add_argument("-cp", "--uncropped_image",
+        optional.add_argument("-ui", "--uncropped_image",
                               help='''Do not crop the image with template
                               (cropped image are suggested for using with DL
                               models)''',

--- a/clinica/pipelines/t1_linear/t1_linear_cli.py
+++ b/clinica/pipelines/t1_linear/t1_linear_cli.py
@@ -32,8 +32,10 @@ class T1LinearCLI(ce.CmdParser):
         # Clinica optional arguments
         optional = self._args.add_argument_group(PIPELINE_CATEGORIES['OPTIONAL'])
 
-        optional.add_argument("-cp", "--crop_image",
-                              help='Crop the image using a template (suggested for using with DL models)',
+        optional.add_argument("-cp", "--uncropped_image",
+                              help='''Do not crop the image with template 
+                              (cropped image are suggested for using with DL 
+                              models)''',
                               action='store_true',
                               default=False)
 
@@ -47,7 +49,7 @@ class T1LinearCLI(ce.CmdParser):
         from clinica.utils.ux import print_end_pipeline, print_crash_files_and_exit
 
         parameters = {
-                'crop_image': args.crop_image
+                'uncropped_image': args.uncropped_image
         }
 
         # Most of the time, you will want to instantiate your pipeline with a

--- a/clinica/pipelines/t1_linear/t1_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/t1_linear_pipeline.py
@@ -162,7 +162,7 @@ class T1Linear(cpe.Pipeline):
             (self.output_node, write_node, [('affine_mat', '@affine_mat')]),
             ])
 
-        if (self.parameters.get('crop_image')):
+        if not (self.parameters.get('uncropped_image')):
             self.connect([
                 (self.output_node, write_node, [('outfile_crop', '@outfile_crop')]),
                 ])
@@ -232,7 +232,7 @@ class T1Linear(cpe.Pipeline):
             (n4biascorrection, self.output_node, [('output_image', 'outfile_corr')]),
             (ants_registration_node, self.output_node, [('warped_image', 'outfile_reg')]),
             ])
-        if (self.parameters.get('crop_image')):
+        if not (self.parameters.get('uncropped_image')):
             self.connect([
                 (ants_registration_node, cropnifti, [('warped_image', 'input_img')]),
                 (cropnifti, self.output_node, [('output_img', 'outfile_crop')]),

--- a/test/instantiation/test_instantiate_all_pipelines.py
+++ b/test/instantiation/test_instantiate_all_pipelines.py
@@ -386,6 +386,10 @@ def test_instantiate_T1Linear():
     root = dirname(abspath(join(abspath(__file__), pardir)))
     root = join(root, 'data', 'T1Linear')
 
+    parameters = {
+            'uncropped_image': False
+            }
+
     pipeline = T1Linear(
         bids_directory=join(root, 'in', 'bids'),
         caps_directory=join(root, 'in', 'caps'),

--- a/test/nonregression/test_run_pipelines.py
+++ b/test/nonregression/test_run_pipelines.py
@@ -802,7 +802,7 @@ def test_run_T1Linear(cmdopt):
     shutil.copytree(join(root, 'in', 'caps'), join(root, 'out', 'caps'))
 
     parameters = {
-        'crop_image': True
+        'uncropped_image': False
     }
     # Instantiate pipeline
     pipeline = T1Linear(


### PR DESCRIPTION
From now, the pipeline crops the input image using the template. 

If the option `--uncropped_image` is added to the command line, the image is not cropped.