### PR TITLE
Display failed image(s) when running t1-linear pipeline

### DIFF
--- a/clinica/pipelines/t1_linear/t1_linear_cli.py
+++ b/clinica/pipelines/t1_linear/t1_linear_cli.py
@@ -15,7 +15,7 @@ class T1LinearCLI(ce.CmdParser):
         """Define a description of this pipeline.
         """
         self._description = ('Affine registration of T1w images to the MNI standard space:\n'
-                             'http://clinica.run/doc/Pipelines/T1Linear/')
+                             'http://clinica.run/doc/Pipelines/T1_Linear/')
 
     def define_options(self):
         """Define the sub-command arguments

--- a/clinica/pipelines/t1_linear/t1_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/t1_linear_pipeline.py
@@ -279,4 +279,3 @@ class T1Linear(cpe.Pipeline):
             self.connect([
                 (ants_registration_node, print_end_message, [('warped_image', 'final_file')]),
             ])
-

--- a/clinica/pipelines/t1_linear/t1_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/t1_linear_pipeline.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-import clinica.pipelines.engine as cpe
-
 # Use hash instead of parameters for iterables folder names
 # Otherwise path will be too long and generate OSError
 from nipype import config
+
+import clinica.pipelines.engine as cpe
+
 cfg = dict(execution={'parameterize_dirs': False})
 config.update_config(cfg)
 
@@ -62,12 +63,12 @@ class T1Linear(cpe.Pipeline):
         """Build and connect an input node to the pipeline.
         """
         from os import pardir
-        from os.path import dirname, join, abspath, split, exists
-        import sys
+        from os.path import dirname, join, abspath, exists
+        from colorama import Fore
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
-        from clinica.utils.inputs import check_bids_folder
         from clinica.utils.exceptions import ClinicaBIDSError, ClinicaException
+        from clinica.utils.filemanip import extract_subjects_sessions_from_filename
         from clinica.utils.inputs import clinica_file_reader
         from clinica.utils.input_files import T1W_NII
         from clinica.utils.inputs import fetch_file, RemoteFileStructure
@@ -75,7 +76,6 @@ class T1Linear(cpe.Pipeline):
         from clinica.utils.stream import cprint
 
         root = dirname(abspath(join(abspath(__file__), pardir, pardir)))
-        path_to_mask = join(root, 'resources', 'masks')
         path_to_mask = join(root, 'resources', 'masks')
         url_aramis = 'https://aramislab.paris.inria.fr/files/data/img_t1_linear/'
         FILE1 = RemoteFileStructure(
@@ -103,6 +103,20 @@ class T1Linear(cpe.Pipeline):
                 fetch_file(FILE1, path_to_mask)
             except IOError as err:
                 cprint('Unable to download required template (ref_crop) for processing:', err)
+
+        # Display image(s) already present in CAPS folder
+        # ===============================================
+        processed_ids = self.get_processed_images(self.caps_directory, self.subjects, self.sessions)
+        if len(processed_ids) > 0:
+            cprint("%sClinica found %s image(s) already processed in CAPS directory:%s" %
+                   (Fore.YELLOW, len(processed_ids), Fore.RESET))
+            for image_id in processed_ids:
+                cprint("%s\t%s%s" % (Fore.YELLOW, image_id.replace('_', ' | '), Fore.RESET))
+            cprint("%s\nImage(s) will be ignored by Clinica.\n%s" % (Fore.YELLOW, Fore.RESET))
+            input_ids = [p_id + '_' + s_id for p_id, s_id in
+                         zip(self.subjects, self.sessions)]
+            to_process_ids = list(set(input_ids) - set(processed_ids))
+            self.subjects, self.sessions = extract_subjects_sessions_from_filename(to_process_ids)
 
         # Inputs from anat/ folder
         # ========================

--- a/clinica/pipelines/t1_linear/t1_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/t1_linear_pipeline.py
@@ -20,6 +20,21 @@ class T1Linear(cpe.Pipeline):
         A clinica pipeline object containing the T1 Linear pipeline.
     """
 
+    @staticmethod
+    def get_processed_images(caps_directory, subjects, sessions):
+        import os
+        from clinica.utils.inputs import clinica_file_reader
+        from clinica.utils.input_files import T1W_LINEAR_CROPPED
+        from clinica.utils.filemanip import extract_image_ids
+        image_ids = []
+        if os.path.isdir(caps_directory):
+            cropped_files = clinica_file_reader(
+                subjects, sessions,
+                caps_directory, T1W_LINEAR_CROPPED, False
+            )
+            image_ids = extract_image_ids(cropped_files)
+        return image_ids
+
     def check_custom_dependencies(self):
         """Check dependencies that can not be listed in the `info.json` file.
         """

--- a/clinica/pipelines/t1_linear/t1_linear_utils.py
+++ b/clinica/pipelines/t1_linear/t1_linear_utils.py
@@ -1,11 +1,5 @@
 # coding: utf8
 
-"""T1 Linear - Clinica Utilities.
-This file has been generated automatically by the `clinica generate template`
-command line tool. See here for more details:
-http://clinica.run/doc/InteractingWithClinica/
-"""
-
 
 def get_substitutions_datasink(bids_file):
 
@@ -56,3 +50,12 @@ def crop_nifti(input_img, ref_crop):
     crop_template = ref_crop
 
     return output_img, crop_template
+
+
+def print_end_pipeline(t1w, final_file):
+    """
+    Display end message for <subject_id> when <final_file> is connected.
+    """
+    from clinica.utils.ux import print_end_image
+    from clinica.utils.filemanip import get_subject_id
+    print_end_image(get_subject_id(t1w))

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(join(this_directory, 'README.md'), encoding='utf-8') as f:
 install_reqs = parse_requirements('requirements.txt', session='hack')
 try:
     requirements = [str(ir.req) for ir in install_reqs]
-except:
+except Exception:
     requirements = [str(ir.requirement) for ir in install_reqs]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,10 @@ with open(join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 install_reqs = parse_requirements('requirements.txt', session='hack')
-reqs = [str(ir.req) for ir in install_reqs]
+try:
+    requirements = [str(ir.req) for ir in install_reqs]
+except:
+    requirements = [str(ir.requirement) for ir in install_reqs]
 
 setup(
     name='clinica',
@@ -40,5 +43,5 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python',
     ],
-    install_requires=reqs
+    install_requires=requirements
 )


### PR DESCRIPTION
This PR contains:

- Add get_processed_images method. This ables to
    * Ignore & Display image(s) already present in CAPS folder
    * Display failed image(s) when running t1-linear pipeline
- Print end message when an image has finished
- Fix Issue #102 