### PR TITLE
Remove copy of empty CAPS folder

### DIFF
--- a/test/nonregression/test_run_pipelines.py
+++ b/test/nonregression/test_run_pipelines.py
@@ -787,10 +787,7 @@ def test_run_SpatialSVM(cmdopt):
 
 def test_run_T1Linear(cmdopt):
     from os.path import dirname, join, abspath
-    import shutil
     from clinica.pipelines.t1_linear.t1_linear_pipeline import T1Linear
-    import nibabel as nib
-    import numpy as np
 
     working_dir = cmdopt
     root = dirname(abspath(join(abspath(__file__), pardir)))
@@ -799,7 +796,6 @@ def test_run_T1Linear(cmdopt):
     # Remove potential residual of previous UT
     clean_folder(join(working_dir, 'T1Linear'))
     clean_folder(join(root, 'out', 'caps'), recreate=False)
-    shutil.copytree(join(root, 'in', 'caps'), join(root, 'out', 'caps'))
 
     parameters = {
         'uncropped_image': False
@@ -815,7 +811,6 @@ def test_run_T1Linear(cmdopt):
     pipeline.run(plugin='MultiProc', plugin_args={'n_procs': 4}, bypass_check=True)
 
     # Check output vs ref
-
     out_folder = join(root, 'out')
     ref_folder = join(root, 'out')
 
@@ -829,8 +824,6 @@ def test_run_DLPrepareData(cmdopt):
     from os.path import dirname, join, abspath
     import shutil
     from clinica.pipelines.deeplearning_prepare_data.deeplearning_prepare_data_pipeline import DeepLearningPrepareData
-    import nibabel as nib
-    import numpy as np
 
     working_dir = cmdopt
     root = dirname(abspath(join(abspath(__file__), pardir)))


### PR DESCRIPTION
This PR removes copy of empty CAPS folder non-regression tests for `t1-linear` pipeline.