### PR TITLE
Use group label wording instead of group ID

### DIFF
--- a/clinica/pipelines/deeplearning_prepare_data/deeplearning_prepare_data_cli.py
+++ b/clinica/pipelines/deeplearning_prepare_data/deeplearning_prepare_data_cli.py
@@ -19,7 +19,7 @@ class DeepLearningPrepareDataCLI(ce.CmdParser):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
 
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id...)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label...)
         # Most of the time, you will want to read your pipeline inputs into
         # a BIDS and/or CAPS directory. If your pipeline does not require BIDS input,
         # simply remove the two lines involving the BIDS directory.

--- a/clinica/pipelines/dwi_connectome/dwi_connectome_cli.py
+++ b/clinica/pipelines/dwi_connectome/dwi_connectome_cli.py
@@ -17,7 +17,7 @@ class DwiConnectomeCli(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')

--- a/clinica/pipelines/dwi_dti/dwi_dti_cli.py
+++ b/clinica/pipelines/dwi_dti/dwi_dti_cli.py
@@ -17,7 +17,7 @@ class DwiDtiCli(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')

--- a/clinica/pipelines/dwi_preprocessing_using_phasediff_fieldmap/dwi_preprocessing_using_phasediff_fieldmap_cli.py
+++ b/clinica/pipelines/dwi_preprocessing_using_phasediff_fieldmap/dwi_preprocessing_using_phasediff_fieldmap_cli.py
@@ -17,7 +17,7 @@ class DwiPreprocessingUsingPhaseDiffFieldmapCli(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_cli.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_cli.py
@@ -17,7 +17,7 @@ class DwiPreprocessingUsingT1Cli(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')

--- a/clinica/pipelines/machine_learning/algorithm.py
+++ b/clinica/pipelines/machine_learning/algorithm.py
@@ -21,15 +21,6 @@ from sklearn.multiclass import OneVsOneClassifier, OneVsRestClassifier
 from clinica.pipelines.machine_learning import base
 import clinica.pipelines.machine_learning.ml_utils as utils
 
-__author__ = "Jorge Samper-Gonzalez"
-__copyright__ = "Copyright 2016-2019 The Aramis Lab Team"
-__credits__ = ["Jorge Samper-Gonzalez", "Pascal Lu", "Simona Bottani"]
-__license__ = "See LICENSE.txt file"
-__version__ = "0.1.0"
-__maintainer__ = "Jorge Samper-Gonzalez"
-__email__ = "jorge.samper-gonzalez@inria.fr"
-__status__ = "Development"
-
 
 class DualSVMAlgorithm(base.MLAlgorithm):
 

--- a/clinica/pipelines/machine_learning/base.py
+++ b/clinica/pipelines/machine_learning/base.py
@@ -3,15 +3,6 @@
 
 from abc import ABC, abstractmethod
 
-__author__ = "Jorge Samper-Gonzalez"
-__copyright__ = "Copyright 2016-2019 The Aramis Lab Team"
-__credits__ = ["Jorge Samper-Gonzalez"]
-__license__ = "See LICENSE.txt file"
-__version__ = "0.1.0"
-__maintainer__ = "Jorge Samper-Gonzalez"
-__email__ = "jorge.samper-gonzalez@inria.fr"
-__status__ = "Development"
-
 
 class MLWorkflow(ABC):
 

--- a/clinica/pipelines/machine_learning/input.py
+++ b/clinica/pipelines/machine_learning/input.py
@@ -16,18 +16,6 @@ import clinica.pipelines.machine_learning.tsv_based_io as tbio
 import clinica.pipelines.machine_learning.ml_utils as utils
 
 
-
-
-__author__ = "Jorge Samper-Gonzalez"
-__copyright__ = "Copyright 2016-2019 The Aramis Lab Team"
-__credits__ = ["Jorge Samper-Gonzalez", "Simona Bottani"]
-__license__ = "See LICENSE.txt file"
-__version__ = "0.1.0"
-__maintainer__ = "Jorge Samper-Gonzalez"
-__email__ = "jorge.samper-gonzalez@inria.fr"
-__status__ = "Development"
-
-
 class CAPSInput(base.MLInput):
 
     def __init__(self, input_params):
@@ -139,7 +127,7 @@ class CAPSInput(base.MLInput):
         parameters_dict = {'caps_directory': None,
                            'subjects_visits_tsv': None,
                            'diagnoses_tsv': None,
-                           'group_id': None,
+                           'group_label': None,
                            'image_type': None,
                            'precomputed_kernel': None}
 
@@ -171,7 +159,7 @@ class CAPSVoxelBasedInput(CAPSInput):
             fwhm = '' if self._input_params['fwhm'] == 0 else '_fwhm-%dmm' % int(self._input_params['fwhm'])
 
             self._images = [path.join(self._input_params['caps_directory'], 'subjects', self._subjects[i],
-                                      self._sessions[i], 't1/spm/dartel/group-' + self._input_params['group_id'],
+                                      self._sessions[i], 't1/spm/dartel/group-' + self._input_params['group_label'],
                                       '%s_%s_T1w_segm-graymatter_space-Ixi549Space_modulated-%s%s_probability.nii.gz'
                                       % (self._subjects[i], self._sessions[i], self._input_params['modulated'], fwhm))
                             for i in range(len(self._subjects))]
@@ -181,7 +169,7 @@ class CAPSVoxelBasedInput(CAPSInput):
             suvr = 'pons' if self._input_params['image_type'] == 'fdg' else 'cerebellumPons'
 
             self._images = [path.join(self._input_params['caps_directory'], 'subjects', self._subjects[i],
-                                      self._sessions[i], 'pet/preprocessing/group-' + self._input_params['group_id'],
+                                      self._sessions[i], 'pet/preprocessing/group-' + self._input_params['group_label'],
                                       '%s_%s_task-rest_acq-%s_pet_space-Ixi549Space%s_suvr-%s_mask-brain%s_pet.nii.gz'
                                       % (self._subjects[i], self._sessions[i], self._input_params['image_type'], pvc,
                                          suvr, fwhm))
@@ -253,7 +241,7 @@ class CAPSRegionBasedInput(CAPSInput):
 
         if self._input_params['image_type'] == 'T1':
             self._images = [path.join(self._input_params['caps_directory'], 'subjects', self._subjects[i],
-                                      self._sessions[i], 't1/spm/dartel/group-' + self._input_params['group_id'],
+                                      self._sessions[i], 't1/spm/dartel/group-' + self._input_params['group_label'],
                                       'atlas_statistics/', '%s_%s_T1w_space-%s_map-graymatter_statistics.tsv'
                                       % (self._subjects[i], self._sessions[i], self._input_params['atlas']))
                             for i in range(len(self._subjects))]
@@ -262,7 +250,7 @@ class CAPSRegionBasedInput(CAPSInput):
             suvr = 'pons' if self._input_params['image_type'] == 'fdg' else 'cerebellumPons'
 
             self._images = [path.join(self._input_params['caps_directory'], 'subjects', self._subjects[i],
-                                      self._sessions[i], 'pet/preprocessing/group-' + self._input_params['group_id'],
+                                      self._sessions[i], 'pet/preprocessing/group-' + self._input_params['group_label'],
                                       'atlas_statistics', '%s_%s_task-rest_acq-%s_pet_space-%s%s_suvr-%s_statistics.tsv'
                                       % (self._subjects[i], self._sessions[i], self._input_params['image_type'],
                                          self._input_params['atlas'], pvc, suvr))
@@ -432,7 +420,7 @@ class CAPSTSVBasedInput(CAPSInput):
         #    return self._x
 
         cprint('Loading TSV subjects')
-        string = str('group-' + self._input_params['group_id'] + '_T1w_space-' + self._input_params['atlas'] +
+        string = str('group-' + self._input_params['group_label'] + '_T1w_space-' + self._input_params['atlas'] +
                      '_map-graymatter')
 
         self._x = tbio.load_data(string, self._input_params['caps_directory'], self._subjects, self._sessions,
@@ -495,7 +483,7 @@ class CAPSVoxelBasedInputREGSVM(CAPSVoxelBasedInput):
             fwhm = '' if self._input_params['fwhm'] == 0 else '_fwhm-%dmm' % int(self._input_params['fwhm'])
             suvr = 'pons' if self._input_params['image_type'] == 'fdg' else 'cerebellumPons'
             self._images = [path.join(self._input_params['caps_directory'], 'subjects', self._subjects[i],
-                                      self._sessions[i], 'pet/preprocessing/group-' + self._input_params['group_id'],
+                                      self._sessions[i], 'pet/preprocessing/group-' + self._input_params['group_label'],
                                       '%s_%s_task-rest_acq-%s_pet_space-Ixi549Space%s_suvr-%s_mask-brain%s_pet.nii.gz'
                                       % (self._subjects[i], self._sessions[i], self._input_params['image_type'],
                                          pvc, suvr, fwhm))

--- a/clinica/pipelines/machine_learning/ml_workflows.py
+++ b/clinica/pipelines/machine_learning/ml_workflows.py
@@ -1,25 +1,14 @@
 # coding: utf8
 
 
-import os
-from os import path
 import numpy as np
 
 from clinica.pipelines.machine_learning import base, input, algorithm, validation
 
-__author__ = "Jorge Samper-Gonzalez"
-__copyright__ = "Copyright 2016-2019 The Aramis Lab Team"
-__credits__ = ["Jorge Samper-Gonzalez"]
-__license__ = "See LICENSE.txt file"
-__version__ = "0.1.0"
-__maintainer__ = "Jorge Samper-Gonzalez"
-__email__ = "jorge.samper-gonzalez@inria.fr"
-__status__ = "Development"
-
 
 class VoxelBasedKFoldDualSVM(base.MLWorkflow):
 
-    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_id, image_type, output_dir, fwhm=0,
+    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_label, image_type, output_dir, fwhm=0,
                  modulated="on", pvc=None, precomputed_kernel=None, mask_zeros=True, n_threads=15, n_folds=10,
                  grid_search_folds=10, balanced=True, c_range=np.logspace(-6, 2, 17), splits_indices=None):
 
@@ -32,7 +21,7 @@ class VoxelBasedKFoldDualSVM(base.MLWorkflow):
 
 class VoxelBasedRepKFoldDualSVM(base.MLWorkflow):
 
-    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_id, image_type, output_dir, fwhm=0,
+    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_label, image_type, output_dir, fwhm=0,
                  modulated="on", pvc=None, precomputed_kernel=None, mask_zeros=True, n_threads=15, n_iterations=100,
                  n_folds=10, grid_search_folds=10, balanced=True, c_range=np.logspace(-6, 2, 17), splits_indices=None):
 
@@ -45,7 +34,7 @@ class VoxelBasedRepKFoldDualSVM(base.MLWorkflow):
 
 class VoxelBasedRepHoldOutDualSVM(base.MLWorkflow):
 
-    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_id, image_type, output_dir, fwhm=0,
+    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_label, image_type, output_dir, fwhm=0,
                  modulated="on", pvc=None, precomputed_kernel=None, mask_zeros=True, n_threads=15, n_iterations=100,
                  test_size=0.3, grid_search_folds=10, balanced=True, c_range=np.logspace(-6, 2, 17),
                  splits_indices=None):
@@ -59,7 +48,7 @@ class VoxelBasedRepHoldOutDualSVM(base.MLWorkflow):
 
 class VertexBasedRepHoldOutDualSVM(base.MLWorkflow):
 
-    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_id, output_dir, image_type='fdg', fwhm=20,
+    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_label, output_dir, image_type='fdg', fwhm=20,
                  precomputed_kernel=None, n_threads=15, n_iterations=100, test_size=0.3, grid_search_folds=10,
                  balanced=True, c_range=np.logspace(-10, 2, 1000), splits_indices=None):
 
@@ -72,7 +61,7 @@ class VertexBasedRepHoldOutDualSVM(base.MLWorkflow):
 
 class RegionBasedRepHoldOutDualSVM(base.MLWorkflow):
 
-    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_id, image_type,  atlas,
+    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_label, image_type,  atlas,
                  output_dir, pvc=None, n_threads=15, n_iterations=100, test_size=0.3,
                  grid_search_folds=10, balanced=True, c_range=np.logspace(-6, 2, 17), splits_indices=None):
 
@@ -85,7 +74,7 @@ class RegionBasedRepHoldOutDualSVM(base.MLWorkflow):
 
 class RegionBasedRepHoldOutLogisticRegression(base.MLWorkflow):
 
-    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_id, image_type, atlas,
+    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_label, image_type, atlas,
                  output_dir, pvc=None, n_threads=15, n_iterations=100, test_size=0.3,
                  grid_search_folds=10, balanced=True, c_range=np.logspace(-6, 2, 17), splits_indices=None):
 
@@ -98,7 +87,7 @@ class RegionBasedRepHoldOutLogisticRegression(base.MLWorkflow):
 
 class RegionBasedRepHoldOutRandomForest(base.MLWorkflow):
 
-    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_id, image_type, atlas,
+    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_label, image_type, atlas,
                  output_dir, pvc=None, n_threads=15, n_iterations=100, test_size=0.3,
                  grid_search_folds=10, balanced=True, n_estimators_range=(100, 200, 400),
                  max_depth_range=[None], min_samples_split_range=[2],
@@ -113,7 +102,7 @@ class RegionBasedRepHoldOutRandomForest(base.MLWorkflow):
 
 class RegionBasedLearningCurveRepHoldOutDualSVM(base.MLWorkflow):
 
-    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_id, image_type,  atlas,
+    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_label, image_type,  atlas,
                  output_dir, pvc=None, precomputed_kernel=None, n_threads=15, n_iterations=100, test_size=0.3,
                  n_learning_points=10, grid_search_folds=10, balanced=True, c_range=np.logspace(-6, 2, 17)):
 
@@ -126,7 +115,7 @@ class RegionBasedLearningCurveRepHoldOutDualSVM(base.MLWorkflow):
 
 class VoxelBasedLearningCurveRepHoldOutDualSVM(base.MLWorkflow):
 
-    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_id, image_type, output_dir, fwhm=0,
+    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_label, image_type, output_dir, fwhm=0,
                  modulated="on", pvc=None, precomputed_kernel=None, mask_zeros=True, n_threads=15, n_iterations=100,
                  test_size=0.3, n_learning_points=10, grid_search_folds=10, balanced=True,
                  c_range=np.logspace(-6, 2, 17)):
@@ -140,7 +129,7 @@ class VoxelBasedLearningCurveRepHoldOutDualSVM(base.MLWorkflow):
 
 class RegionBasedRepKFoldDualSVM(base.MLWorkflow):
 
-    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_id, image_type,  atlas,
+    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_label, image_type,  atlas,
                  output_dir, pvc=None, n_threads=15, n_iterations=100, test_size=0.3, n_folds=10,
                  grid_search_folds=10, balanced=True, c_range=np.logspace(-6, 2, 17), splits_indices=None):
 
@@ -153,7 +142,7 @@ class RegionBasedRepKFoldDualSVM(base.MLWorkflow):
 
 class CAPSTsvRepHoldOutDualSVM(base.MLWorkflow):
 
-    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_id, image_type,  atlas, dataset,
+    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_label, image_type,  atlas, dataset,
                  output_dir, pvc=None, n_threads=15, n_iterations=100, test_size=0.3,
                  grid_search_folds=10, balanced=True, c_range=np.logspace(-6, 2, 17), splits_indices=None):
 
@@ -165,7 +154,7 @@ class CAPSTsvRepHoldOutDualSVM(base.MLWorkflow):
 
 
 class CAPSTsvRepHoldOutRandomForest(base.MLWorkflow):
-    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_id, image_type, atlas, dataset,
+    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_label, image_type, atlas, dataset,
                  output_dir, pvc=None, n_threads=15, n_iterations=100, test_size=0.3,
                  grid_search_folds=10, balanced=True, n_estimators_range=(100, 200, 400),
                  max_depth_range=[None], min_samples_split_range=[2],
@@ -182,7 +171,7 @@ class CAPSTsvRepHoldOutRandomForest(base.MLWorkflow):
 
 class VoxelBasedREGRepKFoldDualSVM(base.MLWorkflow):
 
-    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_id, image_type, output_dir, fwhm=0,
+    def __init__(self, caps_directory, subjects_visits_tsv, diagnoses_tsv, group_label, image_type, output_dir, fwhm=0,
                  modulated="on", pvc=None, precomputed_kernel=None, mask_zeros=True, n_threads=15, n_iterations=100,
                  n_folds=10,
                  test_size=0.1, grid_search_folds=10, balanced=True, c_range=np.logspace(-6, 2, 17),

--- a/clinica/pipelines/machine_learning/region_based_io.py
+++ b/clinica/pipelines/machine_learning/region_based_io.py
@@ -6,23 +6,14 @@ import pandas as pd
 import nibabel as nib
 from os.path import join
 
-__author__ = "Jorge Samper-Gonzalez"
-__copyright__ = "Copyright 2016-2019 The Aramis Lab Team"
-__credits__ = ["Jorge Samper-Gonzalez", "Simona Bottani"]
-__license__ = "See LICENSE.txt file"
-__version__ = "0.1.0"
-__maintainer__ = "Jorge Samper-Gonzalez"
-__email__ = "jorge.samper-gonzalez@inria.fr"
-__status__ = "Development"
 
-
-def get_caps_t1_list(input_directory, subjects_visits_tsv, group_id, atlas_id):
+def get_caps_t1_list(input_directory, subjects_visits_tsv, group_label, atlas_id):
     """
     path to arrive to the list of the file with the statistics on atlas_id
     Args:
         input_directory:
         subjects_visits_tsv:
-        group_id:
+        group_label:
         atlas_id:
 
     Returns:
@@ -38,19 +29,19 @@ def get_caps_t1_list(input_directory, subjects_visits_tsv, group_id, atlas_id):
     subjects = list(subjects_visits.participant_id)
     sessions = list(subjects_visits.session_id)
     image_list = [join(input_directory + '/subjects/' + subjects[i] + '/'
-                       + sessions[i] + '/t1/spm/dartel/group-' + group_id + '/atlas_statistics/' + subjects[i] + '_'
+                       + sessions[i] + '/t1/spm/dartel/group-' + group_label + '/atlas_statistics/' + subjects[i] + '_'
                        + sessions[i]+'_T1w_space-'+atlas_id+'_map-graymatter_statistics.tsv')
                   for i in range(len(subjects))]
     return image_list
 
 
-def get_caps_pet_list(input_directory, subjects_visits_tsv, group_id, atlas_id):
+def get_caps_pet_list(input_directory, subjects_visits_tsv, group_label, atlas_id):
     """
 
     Args:
         input_directory:
         subjects_visits_tsv:
-        group_id:
+        group_label:
         atlas_id:
 
     Returns:

--- a/clinica/pipelines/machine_learning/tsv_based_io.py
+++ b/clinica/pipelines/machine_learning/tsv_based_io.py
@@ -1,18 +1,9 @@
 # coding: utf8
 
-import numpy as np
-import pandas as pd
-import nibabel as nib
 import os
 
-__author__ = "Simona Bottani"
-__copyright__ = "Copyright 2016-2019 The Aramis Lab Team"
-__credits__ = ["Simona Bottani"]
-__license__ = "See LICENSE.txt file"
-__version__ = "0.1.0"
-__maintainer__ = "Arnaud Marcoux"
-__email__ = "simona.bottani@icm-institute.com"
-__status__ = "Development"
+import numpy as np
+import pandas as pd
 
 
 def load_data(images, caps_directory, subjects, sessions, dataset):

--- a/clinica/pipelines/machine_learning/validation.py
+++ b/clinica/pipelines/machine_learning/validation.py
@@ -9,15 +9,6 @@ from multiprocessing.pool import ThreadPool
 
 from clinica.pipelines.machine_learning import base
 
-__author__ = "Jorge Samper-Gonzalez"
-__copyright__ = "Copyright 2016-2019 The Aramis Lab Team"
-__credits__ = ["Jorge Samper-Gonzalez"]
-__license__ = "See LICENSE.txt file"
-__version__ = "0.1.0"
-__maintainer__ = "Jorge Samper-Gonzalez"
-__email__ = "jorge.samper-gonzalez@inria.fr"
-__status__ = "Development"
-
 
 class KFoldCV(base.MLValidation):
 

--- a/clinica/pipelines/machine_learning/vertex_based_io.py
+++ b/clinica/pipelines/machine_learning/vertex_based_io.py
@@ -1,26 +1,12 @@
 # coding: utf8
 
-import numpy as np
-import pandas as pd
-import nibabel as nib
-import os
-
-__author__ = "Arnaud Marcoux"
-__copyright__ = "Copyright 2016-2019 The Aramis Lab Team"
-__credits__ = ["Arnaud Marcoux"]
-__license__ = "See LICENSE.txt file"
-__version__ = "0.1.0"
-__maintainer__ = "Arnaud Marcoux"
-__email__ = "arnaud.marcoux@inria.fr"
-__status__ = "Development"
-
 
 def load_data(mgh_list):
     """
 
     Args: mgh_list : list of mgh files. Each element contains as many paths as
     needed (each element must be associated to a single subject). Surfaces must
-    have the same number of vertices accross subjects.
+    have the same number of vertices across subjects.
 
     Returns: data : matrix of raw data
 

--- a/clinica/pipelines/machine_learning/voxel_based_io.py
+++ b/clinica/pipelines/machine_learning/voxel_based_io.py
@@ -5,17 +5,8 @@ import pandas as pd
 import nibabel as nib
 from os.path import join
 
-__author__ = "Jorge Samper-Gonzalez"
-__copyright__ = "Copyright 2016-2019 The Aramis Lab Team"
-__credits__ = ["Jorge Samper-Gonzalez"]
-__license__ = "See LICENSE.txt file"
-__version__ = "0.1.0"
-__maintainer__ = "Jorge Samper-Gonzalez"
-__email__ = "jorge.samper-gonzalez@inria.fr"
-__status__ = "Development"
 
-
-def get_caps_t1_list(input_directory, subjects_visits_tsv, group_id, fwhm, modulated):
+def get_caps_t1_list(input_directory, subjects_visits_tsv, group_label, fwhm, modulated):
 
     subjects_visits = pd.io.parsers.read_csv(subjects_visits_tsv, sep='\t')
     if list(subjects_visits.columns.values) != ['participant_id', 'session_id']:
@@ -24,18 +15,18 @@ def get_caps_t1_list(input_directory, subjects_visits_tsv, group_id, fwhm, modul
     sessions = list(subjects_visits.session_id)
     if fwhm == 0:
         image_list = [join(input_directory, 'subjects/' + subjects[i] + '/'
-                           + sessions[i] + '/t1/spm/dartel/group-' + group_id + '/'
+                           + sessions[i] + '/t1/spm/dartel/group-' + group_label + '/'
                            + subjects[i] + '_' + sessions[i] + '_T1w_segm-graymatter'+'_space-Ixi549Space_modulated-'+modulated+'_probability.nii.gz') for i in range(len(subjects))]
     else:
         image_list = [join(input_directory, 'subjects/' + subjects[i] + '/'
-                           + sessions[i] + '/t1/spm/dartel/group-' + group_id + '/'
+                           + sessions[i] + '/t1/spm/dartel/group-' + group_label + '/'
                            + subjects[i] + '_' + sessions[i] + '_T1w_segm-graymatter' + '_space-Ixi549Space_modulated-' + modulated + '_fwhm-'+fwhm+'mm_probability.nii.gz')
                       for i in range(len(subjects))]
 
     return image_list
 
 
-def get_caps_pet_list(input_directory, subjects_visits_tsv, group_id, pet_type):
+def get_caps_pet_list(input_directory, subjects_visits_tsv, group_label, pet_type):
 
     subjects_visits = pd.io.parsers.read_csv(subjects_visits_tsv, sep='\t')
     if list(subjects_visits.columns.values) != ['participant_id', 'session_id']:
@@ -44,7 +35,7 @@ def get_caps_pet_list(input_directory, subjects_visits_tsv, group_id, pet_type):
     sessions = list(subjects_visits.session_id)
 
     image_list = [join(input_directory, 'subjects/' + subjects[i] + '/'
-                       + sessions[i] + '/pet/preprocessing/group-' + group_id + '/' + subjects[i]
+                       + sessions[i] + '/pet/preprocessing/group-' + group_label + '/' + subjects[i]
                        + '_' + sessions[i] + '_task-rest_acq-' + pet_type + '_pet_space-Ixi549Space_pet.nii.gz') for i in range(len(subjects))]
 
     return image_list

--- a/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_cli.py
+++ b/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_cli.py
@@ -18,7 +18,7 @@ class SpatialSVMCLI(ce.CmdParser):
         """Define the sub-command arguments."""
         from colorama import Fore
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')

--- a/clinica/pipelines/pet_surface/pet_surface_cli.py
+++ b/clinica/pipelines/pet_surface/pet_surface_cli.py
@@ -17,7 +17,7 @@ class PetSurfaceCLI(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')

--- a/clinica/pipelines/pet_surface/pet_surface_longitudinal_cli.py
+++ b/clinica/pipelines/pet_surface/pet_surface_longitudinal_cli.py
@@ -17,7 +17,7 @@ class PetSurfaceLongitudinalCLI(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')

--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -808,15 +808,15 @@ def get_wf(subject_id,
             Args:
                 (string) subject_id          : The subject id
                 (string) session_id          : The session id
-                (string) psf                 : Path the json file containing information on the point spread function
+                (string) psf                 : Path the JSON file containing information on the point spread function
                 (string) caps_dir            : Path to the CAPS directory
                 (string) pet                 : Path to the PET image in the bids directory
                 (string) orig_nu             : Path to the orig_nu file (must be in the CAPS directory, in mri)
                 (string) white_surface_left  : Path to the left white surface in native space of subject
-                (string) white_surface_right : Path to the right white suface in native space of subject
+                (string) white_surface_right : Path to the right white surface in native space of subject
                 (string) csv_segmentation    : Path to the csv for the segmentation (problems encountered while using __file__)
                 (string) subcortical_eroded_mask               : Path to the mask of the eroded version used for the suvr
-                (string) matscript_folder_inverse_deformation  : Path to the current foler (containing the matlab script
+                (string) matscript_folder_inverse_deformation  : Path to the current folder containing the matlab script
                                                                  used to call the spm function for the inverse deformation
 
             Returns:

--- a/clinica/pipelines/pet_volume/pet_volume_cli.py
+++ b/clinica/pipelines/pet_volume/pet_volume_cli.py
@@ -17,13 +17,13 @@ class PETVolumeCLI(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')
-        clinica_comp.add_argument("group_id",
+        clinica_comp.add_argument("group_label",
                                   help='User-defined identifier for the provided group of subjects.')
         # Optional arguments (e.g. FWHM)
         optional = self._args.add_argument_group(PIPELINE_CATEGORIES['OPTIONAL'])
@@ -58,7 +58,7 @@ class PETVolumeCLI(ce.CmdParser):
         from clinica.utils.ux import print_end_pipeline, print_crash_files_and_exit
 
         parameters = {
-            'group_id': args.group_id,
+            'group_label': args.group_label,
             'psf_tsv': self.absolute_path(args.psf_tsv),
             'pet_tracer': args.pet_tracer,
             'mask_tissues': args.mask_tissues,

--- a/clinica/pipelines/pet_volume/pet_volume_pipeline.py
+++ b/clinica/pipelines/pet_volume/pet_volume_pipeline.py
@@ -20,8 +20,8 @@ class PETVolume(cpe.Pipeline):
         from clinica.utils.group import check_group_label
         default_atlases = ['AAL2', 'LPBA40', 'Neuromorphometrics', 'AICHA', 'Hammers']
 
-        if 'group_id' not in self.parameters.keys():
-            raise KeyError('Missing compulsory group_id key in pipeline parameter.')
+        if 'group_label' not in self.parameters.keys():
+            raise KeyError('Missing compulsory group_label key in pipeline parameter.')
         if 'psf_tsv' not in self.parameters.keys():
             self.parameters['psf_tsv'] = None
         if 'pet_tracer' not in self.parameters.keys():
@@ -37,7 +37,7 @@ class PETVolume(cpe.Pipeline):
         if 'atlases' not in self.parameters.keys():
             self.parameters['atlases'] = default_atlases
 
-        check_group_label(self.parameters['group_id'])
+        check_group_label(self.parameters['group_label'])
 
     def check_custom_dependencies(self):
         """Check dependencies that can not be listed in the `info.json` file.
@@ -104,11 +104,11 @@ class PETVolume(cpe.Pipeline):
         from clinica.utils.stream import cprint
 
         # Check that group already exists
-        if not exists(join(self.caps_directory, 'groups', 'group-' + self.parameters['group_id'])):
+        if not exists(join(self.caps_directory, 'groups', 'group-' + self.parameters['group_label'])):
             print_groups_in_caps_directory(self.caps_directory)
             raise ClinicaException(
                 '%sGroup %s does not exist. Did you run t1-volume or t1-volume-create-dartel pipeline?%s' %
-                (Fore.RED, self.parameters['group_id'], Fore.RESET)
+                (Fore.RED, self.parameters['group_label'], Fore.RESET)
             )
 
         # Tissues DataGrabber
@@ -176,14 +176,14 @@ class PETVolume(cpe.Pipeline):
             flowfields_caps = clinica_file_reader(self.subjects,
                                                   self.sessions,
                                                   self.caps_directory,
-                                                  t1_volume_deformation_to_template(self.parameters['group_id']))
+                                                  t1_volume_deformation_to_template(self.parameters['group_label']))
         except ClinicaException as e:
             all_errors.append(e)
 
         # Dartel Template
         try:
             final_template = clinica_group_reader(self.caps_directory,
-                                                  t1_volume_final_group_template(self.parameters['group_id']))
+                                                  t1_volume_final_group_template(self.parameters['group_label']))
         except ClinicaException as e:
             all_errors.append(e)
 
@@ -319,7 +319,7 @@ class PETVolume(cpe.Pipeline):
         ]
 
         self.connect([(self.input_node, container_path, [('pet_image', 'pet_filename')]),
-                      (container_path, write_images_node, [(('container', fix_join, 'group-' + self.parameters['group_id']),
+                      (container_path, write_images_node, [(('container', fix_join, 'group-' + self.parameters['group_label']),
                                                             'container')]),
                       (self.output_node, write_images_node, [(('pet_t1_native', zip_nii, True), 'pet_t1_native'),
                                                              (('pet_mni', zip_nii, True), 'pet_mni'),
@@ -335,7 +335,7 @@ class PETVolume(cpe.Pipeline):
                                                               'pet_pvc_suvr_masked'),
                                                              (('pet_pvc_suvr_masked_smoothed', zip_nii, True),
                                                               'pet_pvc_suvr_masked_smoothed')]),
-                      (container_path, write_atlas_node, [(('container', fix_join, 'group-' + self.parameters['group_id']),
+                      (container_path, write_atlas_node, [(('container', fix_join, 'group-' + self.parameters['group_label']),
                                                            'container')]),
                       (self.output_node, write_atlas_node, [('atlas_statistics', 'atlas_statistics'),
                                                             ('pvc_atlas_statistics', 'pvc_atlas_statistics')])

--- a/clinica/pipelines/statistics_volume/statistics_volume_cli.py
+++ b/clinica/pipelines/statistics_volume/statistics_volume_cli.py
@@ -40,8 +40,8 @@ class StatisticsVolumeCLI(ce.CmdParser):
 
         # Optional arguments (e.g. FWHM)
         optional = self._args.add_argument_group(PIPELINE_CATEGORIES['OPTIONAL'])
-        optional.add_argument("-gic", "--group_id_caps", type=str, default=None,
-                              help='Name of the group that Clinica needs to use to grab input file.')
+        optional.add_argument("-gld", "--group_label_dartel", type=str, default=None,
+                              help='Name of the DARTEL template that Clinica needs to use to grab input file.')
         optional.add_argument("-fwhm", "--full_width_at_half_maximum", type=int, default=8,
                               help='Full Width at Half Maximum (FWHM) of the smoothing used in your input file '
                                    '(default: --full_width_at_half_maximum %(default)s).')
@@ -88,10 +88,10 @@ class StatisticsVolumeCLI(ce.CmdParser):
         parameters = {
             'contrast': args.contrast,
             'orig_input_data': args.orig_input_data,
-            'group_label': args.group_id,
+            'group_label': args.group_label,
             'custom_files': args.custom_files,
             'cluster_threshold': args.cluster_threshold,
-            'group_id_caps': args.group_id_caps,
+            'group_label_dartel': args.group_label_dartel,
             'full_width_at_half_maximum': args.full_width_at_half_maximum
         }
 

--- a/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
+++ b/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
@@ -15,6 +15,8 @@ class StatisticsVolume(cpe.Pipeline):
 
         if 'orig_input_data' not in self.parameters.keys():
             raise KeyError('Missing compulsory orig_input_data key in pipeline parameter.')
+        if 'group_label_dartel' not in self.parameters.keys():
+            self.parameters['group_label_dartel'] = None
 
         if self.parameters['cluster_threshold'] < 0 or self.parameters['cluster_threshold'] > 1:
             raise ClinicaException("Cluster threshold should be between 0 and 1 "
@@ -61,8 +63,8 @@ class StatisticsVolume(cpe.Pipeline):
         from clinica.utils.ux import print_images_to_process, print_begin_image
 
         gic = '*'
-        if self.parameters['group_id_caps'] is not None:
-            gic = self.parameters['group_id_caps']
+        if self.parameters['group_label_dartel'] is not None:
+            gic = self.parameters['group_label_dartel']
 
         all_errors = []
         if self.parameters['orig_input_data'] == 'pet-volume':

--- a/clinica/pipelines/t1_freesurfer/t1_freesurfer_cli.py
+++ b/clinica/pipelines/t1_freesurfer/t1_freesurfer_cli.py
@@ -17,7 +17,7 @@ class T1FreeSurferCLI(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')

--- a/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_cli.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_cli.py
@@ -16,7 +16,7 @@ class T1FreeSurferLongitudinalCLI(ce.CmdParser):
 
     def define_options(self):
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')

--- a/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_correction_cli.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_correction_cli.py
@@ -16,7 +16,7 @@ class T1FreeSurferLongitudinalCorrectionCLI(ce.CmdParser):
 
     def define_options(self):
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')

--- a/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_template_cli.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_template_cli.py
@@ -16,7 +16,7 @@ class T1FreeSurferTemplateCLI(ce.CmdParser):
 
     def define_options(self):
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')

--- a/clinica/pipelines/t1_linear/t1_linear_cli.py
+++ b/clinica/pipelines/t1_linear/t1_linear_cli.py
@@ -22,7 +22,7 @@ class T1LinearCLI(ce.CmdParser):
         """
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
 
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id...)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label...)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')

--- a/clinica/pipelines/t1_volume/t1_volume_cli.py
+++ b/clinica/pipelines/t1_volume/t1_volume_cli.py
@@ -17,13 +17,13 @@ class T1VolumeCLI(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')
-        clinica_comp.add_argument("group_id",
+        clinica_comp.add_argument("group_label",
                                   help='User-defined identifier for the provided group of subjects.')
         # Optional arguments (e.g. FWHM)
         optional = self._args.add_argument_group(PIPELINE_CATEGORIES['OPTIONAL'])

--- a/clinica/pipelines/t1_volume_create_dartel/t1_volume_create_dartel_cli.py
+++ b/clinica/pipelines/t1_volume_create_dartel/t1_volume_create_dartel_cli.py
@@ -17,13 +17,13 @@ class T1VolumeCreateDartelCLI(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')
-        clinica_comp.add_argument("group_id",
+        clinica_comp.add_argument("group_label",
                                   help='User-defined identifier for the provided group of subjects.')
         # Clinica standard arguments (e.g. --n_procs)
         self.add_clinica_standard_arguments()
@@ -41,7 +41,7 @@ class T1VolumeCreateDartelCLI(ce.CmdParser):
         from clinica.utils.ux import print_end_pipeline, print_crash_files_and_exit
 
         parameters = {
-            'group_id': args.group_id,
+            'group_label': args.group_label,
             'dartel_tissues': args.dartel_tissues
         }
         pipeline = T1VolumeCreateDartel(

--- a/clinica/pipelines/t1_volume_create_dartel/t1_volume_create_dartel_pipeline.py
+++ b/clinica/pipelines/t1_volume_create_dartel/t1_volume_create_dartel_pipeline.py
@@ -13,12 +13,12 @@ class T1VolumeCreateDartel(cpe.Pipeline):
         """Check pipeline parameters."""
         from clinica.utils.group import check_group_label
 
-        if 'group_id' not in self.parameters.keys():
-            raise KeyError('Missing compulsory group_id key in pipeline parameter.')
+        if 'group_label' not in self.parameters.keys():
+            raise KeyError('Missing compulsory group_label key in pipeline parameter.')
         if 'dartel_tissues' not in self.parameters.keys():
             self.parameters['dartel_tissues'] = [1, 2, 3]
 
-        check_group_label(self.parameters['group_id'])
+        check_group_label(self.parameters['group_label'])
 
     def check_custom_dependencies(self):
         """Check dependencies that can not be listed in the `info.json` file."""
@@ -57,13 +57,13 @@ class T1VolumeCreateDartel(cpe.Pipeline):
 
         representative_output = os.path.join(self.caps_directory,
                                              'groups',
-                                             'group-' + self.parameters['group_id'],
+                                             'group-' + self.parameters['group_label'],
                                              't1',
-                                             'group-' + self.parameters['group_id'] + '_template.nii.gz'
+                                             'group-' + self.parameters['group_label'] + '_template.nii.gz'
                                              )
         if os.path.exists(representative_output):
             cprint("%sDARTEL template for %s already exists. Currently, Clinica does not propose to overwrite outputs "
-                   "for this pipeline.%s" % (Fore.YELLOW, self.parameters['group_id'], Fore.RESET))
+                   "for this pipeline.%s" % (Fore.YELLOW, self.parameters['group_label'], Fore.RESET))
             print_groups_in_caps_directory(self.caps_directory)
             sys.exit(0)
 
@@ -101,7 +101,7 @@ class T1VolumeCreateDartel(cpe.Pipeline):
         if len(self.subjects):
             print_images_to_process(self.subjects, self.sessions)
             cprint('Computational time for DARTEL creation will depend on the number of images.')
-            print_begin_image('group-' + self.parameters['group_id'])
+            print_begin_image('group-' + self.parameters['group_label'])
 
         self.connect([
             (read_parameters_node, self.input_node, [('dartel_inputs', 'dartel_input_images')])
@@ -123,7 +123,7 @@ class T1VolumeCreateDartel(cpe.Pipeline):
         write_flowfields_node.inputs.base_directory = self.caps_directory
         write_flowfields_node.inputs.parameterization = False
         write_flowfields_node.inputs.container = ['subjects/' + self.subjects[i] + '/' + self.sessions[i] +
-                                                  '/t1/spm/dartel/group-' + self.parameters['group_id']
+                                                  '/t1/spm/dartel/group-' + self.parameters['group_label']
                                                   for i in range(len(self.subjects))]
         write_flowfields_node.inputs.regexp_substitutions = [
             (r'(.*)_Template(\.nii(\.gz)?)$', r'\1\2'),
@@ -136,7 +136,7 @@ class T1VolumeCreateDartel(cpe.Pipeline):
             (r'(.*)r(sub-.*)(\.nii(\.gz)?)$', r'\1\2\3'),
             (r'(.*)_dartelinput(\.nii(\.gz)?)$', r'\1\2'),
             (r'(.*)flow_fields/u_(sub-.*)_segm-.*(\.nii(\.gz)?)$',
-             r'\1\2_target-' + re.escape(self.parameters['group_id']) + r'_transformation-forward_deformation\3'),
+             r'\1\2_target-' + re.escape(self.parameters['group_label']) + r'_transformation-forward_deformation\3'),
             (r'trait_added', r'')
         ]
 
@@ -145,12 +145,12 @@ class T1VolumeCreateDartel(cpe.Pipeline):
         write_template_node = npe.Node(nio.DataSink(), name='write_template_node')
         write_template_node.inputs.parameterization = False
         write_template_node.inputs.base_directory = self.caps_directory
-        write_template_node.inputs.container = op.join('groups/group-' + self.parameters['group_id'], 't1')
+        write_template_node.inputs.container = op.join('groups/group-' + self.parameters['group_label'], 't1')
         write_template_node.inputs.regexp_substitutions = [
             (r'(.*)final_template_file/.*(\.nii(\.gz)?)$',
-             r'\1group-' + re.escape(self.parameters['group_id']) + r'_template\2'),
+             r'\1group-' + re.escape(self.parameters['group_label']) + r'_template\2'),
             (r'(.*)template_files/.*([0-9])(\.nii(\.gz)?)$',
-             r'\1group-' + re.escape(self.parameters['group_id']) + r'_iteration-\2_template\3')
+             r'\1group-' + re.escape(self.parameters['group_label']) + r'_iteration-\2_template\3')
         ]
 
         self.connect([

--- a/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_cli.py
+++ b/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_cli.py
@@ -17,13 +17,13 @@ class T1VolumeDartel2MNICLI(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')
-        clinica_comp.add_argument("group_id",
+        clinica_comp.add_argument("group_label",
                                   help='User-defined identifier for the provided group of subjects.')
         # Optional arguments (e.g. FWHM)
         optional = self._args.add_argument_group(PIPELINE_CATEGORIES['OPTIONAL'])
@@ -57,7 +57,7 @@ class T1VolumeDartel2MNICLI(ce.CmdParser):
         from clinica.utils.ux import print_end_pipeline, print_crash_files_and_exit
 
         parameters = {
-            'group_id': args.group_id,
+            'group_label': args.group_label,
             'tissues': args.tissues,
             'voxel_size': args.voxel_size,
             'modulate': args.modulate,

--- a/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
+++ b/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
@@ -13,8 +13,8 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
         """Check pipeline parameters."""
         from clinica.utils.group import check_group_label
 
-        if 'group_id' not in self.parameters.keys():
-            raise KeyError('Missing compulsory group_id key in pipeline parameter.')
+        if 'group_label' not in self.parameters.keys():
+            raise KeyError('Missing compulsory group_label key in pipeline parameter.')
 
         if 'tissues' not in self.parameters:
             self.parameters['tissues'] = [1, 2, 3]
@@ -25,7 +25,7 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
         if 'smooth' not in self.parameters:
             self.parameters['smooth'] = [8]
 
-        check_group_label(self.parameters['group_id'])
+        check_group_label(self.parameters['group_label'])
 
     def check_custom_dependencies(self):
         """Check dependencies that can not be listed in the `info.json` file."""
@@ -64,11 +64,11 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
         from clinica.utils.ux import print_groups_in_caps_directory, print_images_to_process
 
         # Check that group already exists
-        if not os.path.exists(os.path.join(self.caps_directory, 'groups', 'group-' + self.parameters['group_id'])):
+        if not os.path.exists(os.path.join(self.caps_directory, 'groups', 'group-' + self.parameters['group_label'])):
             print_groups_in_caps_directory(self.caps_directory)
             raise ClinicaException(
                 '%sGroup %s does not exist. Did you run t1-volume or t1-volume-create-dartel pipeline?%s' %
-                (Fore.RED, self.parameters['group_id'], Fore.RESET)
+                (Fore.RED, self.parameters['group_label'], Fore.RESET)
             )
 
         all_errors = []
@@ -106,7 +106,7 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
-                t1_volume_deformation_to_template(self.parameters['group_id']))
+                t1_volume_deformation_to_template(self.parameters['group_label']))
         except ClinicaException as e:
             all_errors.append(e)
 
@@ -115,7 +115,7 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
         try:
             read_input_node.inputs.template_file = clinica_group_reader(
                 self.caps_directory,
-                t1_volume_final_group_template(self.parameters['group_id'])
+                t1_volume_final_group_template(self.parameters['group_label'])
             )
         except ClinicaException as e:
             all_errors.append(e)
@@ -151,7 +151,7 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
         write_normalized_node.inputs.base_directory = self.caps_directory
         write_normalized_node.inputs.parameterization = False
         write_normalized_node.inputs.container = ['subjects/' + self.subjects[i] + '/' + self.sessions[i] +
-                                                  '/t1/spm/dartel/group-' + self.parameters['group_id']
+                                                  '/t1/spm/dartel/group-' + self.parameters['group_label']
                                                   for i in range(len(self.subjects))]
         write_normalized_node.inputs.regexp_substitutions = [
             (r'(.*)c1(sub-.*)(\.nii(\.gz)?)$', r'\1\2_segm-graymatter_probability\3'),

--- a/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_cli.py
+++ b/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_cli.py
@@ -17,13 +17,13 @@ class T1VolumeExistingTemplateCLI(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')
-        clinica_comp.add_argument("group_id",
+        clinica_comp.add_argument("group_label",
                                   help='User-defined identifier for the provided group of subjects.')
         # Optional arguments (e.g. FWHM)
         optional = self._args.add_argument_group(PIPELINE_CATEGORIES['OPTIONAL'])

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_cli.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_cli.py
@@ -17,11 +17,11 @@ class T1VolumeParcellationCLI(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')
-        clinica_comp.add_argument("group_id",
+        clinica_comp.add_argument("group_label",
                                   help='User-defined identifier for the provided group of subjects.')
         # Clinica standard arguments (e.g. --n_procs)
         self.add_clinica_standard_arguments()
@@ -33,7 +33,8 @@ class T1VolumeParcellationCLI(ce.CmdParser):
         from clinica.utils.ux import print_end_pipeline, print_crash_files_and_exit
 
         parameters = {
-            'group_id': args.group_id,
+            'group_label': args.group_label,
+            'atlases': args.atlases,
         }
         pipeline = T1VolumeParcellation(
             caps_directory=self.absolute_path(args.caps_directory),

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
@@ -19,12 +19,12 @@ class T1VolumeParcellation(cpe.Pipeline):
 
         default_atlases = ['AAL2', 'LPBA40', 'Neuromorphometrics', 'AICHA', 'Hammers']
 
-        if 'group_id' not in self.parameters.keys():
-            raise KeyError('Missing compulsory group_id key in pipeline parameter.')
+        if 'group_label' not in self.parameters.keys():
+            raise KeyError('Missing compulsory group_label key in pipeline parameter.')
         if 'atlases' not in self.parameters.keys():
             self.parameters['atlases'] = default_atlases
 
-        check_group_label(self.parameters['group_id'])
+        check_group_label(self.parameters['group_label'])
 
     def get_input_fields(self):
         """Specify the list of possible inputs of this pipeline.
@@ -57,18 +57,18 @@ class T1VolumeParcellation(cpe.Pipeline):
         from clinica.utils.ux import print_groups_in_caps_directory, print_images_to_process
 
         # Check that group already exists
-        if not os.path.exists(os.path.join(self.caps_directory, 'groups', 'group-' + self.parameters['group_id'])):
+        if not os.path.exists(os.path.join(self.caps_directory, 'groups', 'group-' + self.parameters['group_label'])):
             print_groups_in_caps_directory(self.caps_directory)
             raise ClinicaException(
                 '%sGroup %s does not exist. Did you run t1-volume or t1-volume-create-dartel pipeline?%s' %
-                (Fore.RED, self.parameters['group_id'], Fore.RESET)
+                (Fore.RED, self.parameters['group_label'], Fore.RESET)
             )
 
         try:
             gm_mni = clinica_file_reader(self.subjects,
                                          self.sessions,
                                          self.caps_directory,
-                                         t1_volume_template_tpm_in_mni(self.parameters['group_id'], 1, True))
+                                         t1_volume_template_tpm_in_mni(self.parameters['group_label'], 1, True))
         except ClinicaException as e:
             final_error_str = 'Clinica faced error(s) while trying to read files in your CAPS directory.\n'
             final_error_str += str(e)
@@ -118,7 +118,7 @@ class T1VolumeParcellation(cpe.Pipeline):
         datasink.inputs.parameterization = True
         datasink.inputs.regexp_substitutions = [
             (r'(.*)(atlas_statistics)/.*/(sub-(.*)_ses-(.*)_T1.*)$',
-             r'\1/subjects/sub-\4/ses-\5/t1/spm/dartel/group-' + self.parameters['group_id'] + r'/\2/\3')]
+             r'\1/subjects/sub-\4/ses-\5/t1/spm/dartel/group-' + self.parameters['group_label'] + r'/\2/\3')]
 
         # Connection
         # ==========

--- a/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_cli.py
+++ b/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_cli.py
@@ -17,13 +17,13 @@ class T1VolumeRegisterDartelCLI(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')
-        clinica_comp.add_argument("group_id",
+        clinica_comp.add_argument("group_label",
                                   help='User-defined identifier for the provided group of subjects.')
         # Optional arguments (e.g. FWHM)
         optional = self._args.add_argument_group(PIPELINE_CATEGORIES['OPTIONAL'])
@@ -47,7 +47,7 @@ class T1VolumeRegisterDartelCLI(ce.CmdParser):
         from clinica.utils.ux import print_end_pipeline, print_crash_files_and_exit
 
         parameters = {
-            'group_id': args.group_id,
+            'group_label': args.group_label,
             'tissues': args.tissues,
         }
         pipeline = T1VolumeRegisterDartel(

--- a/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_pipeline.py
+++ b/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_pipeline.py
@@ -17,12 +17,12 @@ class T1VolumeRegisterDartel(cpe.Pipeline):
         """Check pipeline parameters."""
         from clinica.utils.group import check_group_label
 
-        if 'group_id' not in self.parameters.keys():
-            raise KeyError('Missing compulsory group_id key in pipeline parameter.')
+        if 'group_label' not in self.parameters.keys():
+            raise KeyError('Missing compulsory group_label key in pipeline parameter.')
         if 'tissues' not in self.parameters.keys():
             self.parameters['tissues'] = [1, 2, 3]
 
-        check_group_label(self.parameters['group_id'])
+        check_group_label(self.parameters['group_label'])
 
     def get_input_fields(self):
         """Specify the list of possible inputs of this pipelines.
@@ -78,7 +78,7 @@ class T1VolumeRegisterDartel(cpe.Pipeline):
             try:
                 current_iter = clinica_group_reader(
                     self.caps_directory,
-                    t1_volume_i_th_iteration_group_template(self.parameters['group_id'], i)
+                    t1_volume_i_th_iteration_group_template(self.parameters['group_label'], i)
                 )
 
                 dartel_iter_templates.append(current_iter)
@@ -117,7 +117,7 @@ class T1VolumeRegisterDartel(cpe.Pipeline):
         write_flowfields_node.inputs.base_directory = self.caps_directory
         write_flowfields_node.inputs.parameterization = False
         write_flowfields_node.inputs.container = ['subjects/' + self.subjects[i] + '/' + self.sessions[i] +
-                                                  '/t1/spm/dartel/group-' + self.parameters['group_id']
+                                                  '/t1/spm/dartel/group-' + self.parameters['group_label']
                                                   for i in range(len(self.subjects))]
         write_flowfields_node.inputs.regexp_substitutions = [
             (r'(.*)_Template(\.nii(\.gz)?)$', r'\1\2'),
@@ -130,7 +130,7 @@ class T1VolumeRegisterDartel(cpe.Pipeline):
             (r'(.*)r(sub-.*)(\.nii(\.gz)?)$', r'\1\2\3'),
             (r'(.*)_dartelinput(\.nii(\.gz)?)$', r'\1\2'),
             (r'(.*)flow_fields/u_(sub-.*)_segm-.*(\.nii(\.gz)?)$',
-             r'\1\2_target-' + re.escape(self.parameters['group_id']) + r'_transformation-forward_deformation\3'),
+             r'\1\2_target-' + re.escape(self.parameters['group_label']) + r'_transformation-forward_deformation\3'),
             (r'trait_added', r'')
         ]
 

--- a/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_cli.py
+++ b/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_cli.py
@@ -17,7 +17,7 @@ class T1VolumeTissueSegmentationCLI(ce.CmdParser):
     def define_options(self):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label)
         clinica_comp = self._args.add_argument_group(PIPELINE_CATEGORIES['CLINICA_COMPULSORY'])
         clinica_comp.add_argument("bids_directory",
                                   help='Path to the BIDS directory.')

--- a/clinica/resources/templates/pipeline_template/cli.py.j2
+++ b/clinica/resources/templates/pipeline_template/cli.py.j2
@@ -25,7 +25,7 @@ class {{ pipeline.class_name }}CLI(ce.CmdParser):
         """Define the sub-command arguments."""
         from clinica.engine.cmdparser import PIPELINE_CATEGORIES
 
-        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_id...)
+        # Clinica compulsory arguments (e.g. BIDS, CAPS, group_label...)
         # Most of the time, you will want to read your pipeline inputs into
         # a BIDS and/or CAPS directory. If your pipeline does not require BIDS input,
         # simply remove the two lines involving the BIDS directory.
@@ -35,9 +35,9 @@ class {{ pipeline.class_name }}CLI(ce.CmdParser):
         clinica_comp.add_argument("caps_directory",
                                   help='Path to the CAPS directory.')
 
-        # group_id can be used by certain pipelines when some operations are performed at the group level
-        # (for example, generation of a template in pipeline t1-volume)
-        # clinica_comp.add_argument("group_id",
+        # group_label can be used by certain pipelines when some operations are performed at the group level
+        # (for example, generation of a template in t1-volume pipeline)
+        # clinica_comp.add_argument("group_label",
         #                           help='User-defined identifier for the provided group of subjects.')
 
         # Add your own pipeline command line arguments here to be used in the

--- a/docs/InteractingWithClinica.md
+++ b/docs/InteractingWithClinica.md
@@ -93,8 +93,8 @@ Running a pipeline involves most of the time these two parameters:
 - `bids_directory`, which is the input folder containing the dataset in a [BIDS](../BIDS) hierarchy;
 - `caps_directory`, which is the output folder containing the expected results in a [CAPS](../CAPS/Introduction) hierarchy. It can be also the input folder containing the dataset in a [CAPS](../CAPS/Introduction) hierarchy.
 
-### `group_id`
-You will see the `group_id` flag when working on any group-wise analysis (e.g. template creation from a list of subjects, statistical analysis). This is simply a label name that will define the  group of subjects used for this analysis. It will be written in your output CAPS folder, for possible future reuses. For example, an `AD` group ID label could be used when creating a template for a group of Alzheimer’s disease patients. Any time you would like to use this `AD` template you will need to provide the group ID used to identify the pipeline output obtained from this group. You might also use `CNvsAD`, for instance, as group ID for a statistical group comparison between patients with Alzheimer's disease (`AD`) and cognitively normal (`CN`) subjects.
+### `group_label`
+You will see the `group_label` flag when working on any group-wise analysis (e.g. template creation from a list of subjects, statistical analysis). This is simply a label name that will define the  group of subjects used for this analysis. It will be written in your output CAPS folder, for possible future reuses. For example, an `AD` group ID label could be used when creating a template for a group of Alzheimer’s disease patients. Any time you would like to use this `AD` template you will need to provide the group ID used to identify the pipeline output obtained from this group. You might also use `CNvsAD`, for instance, as group ID for a statistical group comparison between patients with Alzheimer's disease (`AD`) and cognitively normal (`CN`) subjects.
 
 ### `-tsv` / `--subjects_sessions_tsv`
 

--- a/docs/Pipelines/PET_Volume.md
+++ b/docs/Pipelines/PET_Volume.md
@@ -27,13 +27,13 @@ You need to have performed the [`t1-volume`](../T1_Volume) pipeline on your T1-w
 The pipeline can be run with the following command line:
 
 ```Text
-clinica run pet-volume <bids_directory> <caps_directory> <group_id>
+clinica run pet-volume <bids_directory> <caps_directory> <group_label>
 ```
 where:
 
 - `bids_directory` is the input folder containing the dataset in a [BIDS](../../BIDS) hierarchy.
 - `caps_directory` acts both as an input folder (where the results of the `t1-volume-*` pipeline are stored) and as the output folder containing the results in a [CAPS](../../CAPS/Introduction) hierarchy.
-- `group_id` is the ID of the group that is associated to the DARTEL template that you had created when running the `t1-volume-*` pipeline.
+- `group_label` is the ID of the group that is associated to the DARTEL template that you had created when running the `t1-volume-*` pipeline.
 
 Pipeline options:
 

--- a/docs/Pipelines/T1_Volume.md
+++ b/docs/Pipelines/T1_Volume.md
@@ -20,14 +20,14 @@ If you only installed the core of Clinica, this pipeline needs the installation 
 
  The pipeline `t1-volume` can be run with the following command line:
 ```Text
-clinica run t1-volume <bids_directory> <caps_directory> <group_id>
+clinica run t1-volume <bids_directory> <caps_directory> <group_label>
 ```
 
 where:
 
 - `bids_directory` is the input folder containing the dataset in a [BIDS](../../BIDS) hierarchy.
 - `caps_directory` is the output folder containing the results in a [CAPS](../../CAPS/Introduction) hierarchy.
-- `group_id` is the user-defined identifier for the provided group of subjects.
+- `group_label` is the user-defined identifier for the provided group of subjects.
 
 Pipeline options:
 
@@ -65,19 +65,19 @@ The main output files are:
 
 ### Inter-subject registration using Dartel
 The final estimation of the gray matter template is stored under the following folder of the [CAPS hierarchy](../../CAPS/Specifications/#dartel):
-`groups/group-<group_id>/t1/group-<group_id>_template.nii.gz`
+`groups/group-<group_label>/t1/group-<group_label>_template.nii.gz`
 
 <center>![](../../img/T1_Volume/ex_Dartel_template_GM.png)</center>
 *<center><small>Example of a group template calculated using DARTEL. Only the gray matter class is shown.</small></center>*
 
 The flow fields containing the deformation from an image to the group template are stored in the folder
-`subjects/sub-<participant_label>/ses-<session_label>/t1/spm/dartel/group-<group_id>/`
+`subjects/sub-<participant_label>/ses-<session_label>/t1/spm/dartel/group-<group_label>/`
 under the filename
 `<source_file>_target-<group-id>_transformation-forward_deformation.nii.gz`.
 
 ### Dartel template to MNI
 Results are stored in the following folder of the [CAPS hierarchy](../../CAPS/Specifications/#dartel-to-mni):
-`subjects/sub-<participant_label>/ses-<session_label>/t1/spm/dartel/group-<group_id>`.
+`subjects/sub-<participant_label>/ses-<session_label>/t1/spm/dartel/group-<group_label>`.
 
 The main output files are:
 
@@ -91,7 +91,7 @@ The different tissue maps that have been registered to the MNI space and modulat
 
 ### Atlas statistics
 Results are stored in the following folder of the [CAPS hierarchy](../../CAPS/Specifications/#atlas-statistics):
-`subjects/sub-<participant_label>/ses-<session_label>/t1/spm/dartel/group-<group_id>/atlas_statistics/`.
+`subjects/sub-<participant_label>/ses-<session_label>/t1/spm/dartel/group-<group_label>/atlas_statistics/`.
 
 The main output file is:
 
@@ -137,27 +137,27 @@ The four main processing steps of the `t1-volume` pipeline can be performed indi
 
     Command line:
     ```Text
-    clinica run t1-volume-create-dartel <bids_directory> <caps_directory> <group_id>
+    clinica run t1-volume-create-dartel <bids_directory> <caps_directory> <group_label>
     ```
 
 - **B2: Inter-subject registration using Dartel (using an existing Dartel template)**
 
     Command line:
     ```Text
-    clinica run t1-volume-register-dartel <bids_directory> <caps_directory> <group_id>
+    clinica run t1-volume-register-dartel <bids_directory> <caps_directory> <group_label>
     ```
 
 - **C: Dartel template to MNI**
 
     Command line:
     ```Text
-    clinica run t1-volume-dartel2mni <bids_directory> <caps_directory> <group_id>
+    clinica run t1-volume-dartel2mni <bids_directory> <caps_directory> <group_label>
     ```
 - **D: Atlas statistics**
 
     Command line:
     ```Text
-    clinica run t1-volume-parcellation <caps_directory> <group_id>
+    clinica run t1-volume-parcellation <caps_directory> <group_label>
     ```
 
 These four processing steps can also be performed in one go with one of these two functions:

--- a/test/instantiation/test_instantiate_all_pipelines.py
+++ b/test/instantiation/test_instantiate_all_pipelines.py
@@ -52,7 +52,7 @@ def test_instantiate_T1VolumeCreateDartel():
     root = join(root, 'data', 'T1VolumeCreateDartel')
 
     parameters = {
-        'group_id': 'UnitTest'
+        'group_label': 'UnitTest'
     }
     pipeline = T1VolumeCreateDartel(
         bids_directory=join(root, 'in', 'bids'),
@@ -71,7 +71,7 @@ def test_instantiate_T1VolumeDartel2MNI():
     root = join(root, 'data', 'T1VolumeDartel2MNI')
 
     parameters = {
-        'group_id': 'UnitTest'
+        'group_label': 'UnitTest'
     }
     pipeline = T1VolumeDartel2MNI(
         bids_directory=join(root, 'in', 'bids'),
@@ -90,7 +90,7 @@ def test_instantiate_T1VolumeRegisterDartel():
     root = join(root, 'data', 'T1VolumeExistingDartel')
 
     parameters = {
-        'group_id': 'UnitTest'
+        'group_label': 'UnitTest'
     }
     pipeline = T1VolumeRegisterDartel(
         bids_directory=join(root, 'in', 'bids'),
@@ -109,7 +109,7 @@ def test_instantiate_T1VolumeParcellation():
     root = join(root, 'data', 'T1VolumeParcellation')
 
     parameters = {
-        'group_id': 'UnitTest'
+        'group_label': 'UnitTest'
     }
     pipeline = T1VolumeParcellation(
         caps_directory=join(root, 'in', 'caps'),
@@ -191,7 +191,7 @@ def test_instantiate_PETVolume():
     root = join(root, 'data', 'PETVolume')
 
     parameters = {
-        'group_id': 'UnitTest'
+        'group_label': 'UnitTest'
     }
     pipeline = PETVolume(
         bids_directory=join(root, 'in', 'bids'),
@@ -273,7 +273,7 @@ def test_instantiate_InputsML():
     caps_dir = join(root, 'in', 'caps')
     tsv = join(root, 'in', 'subjects.tsv')
     diagnoses_tsv = join(root, 'in', 'diagnosis.tsv')
-    group_id = 'allADNIdartel'
+    group_label = 'allADNIdartel'
     image_type = ['T1', 'fdg']
     atlases = ['AAL2', 'Neuromorphometrics', 'AICHA', 'LPBA40', 'Hammers']
     possible_psf = [0, 5, 10, 15, 20, 25]
@@ -281,7 +281,7 @@ def test_instantiate_InputsML():
     voxel_input = [CAPSVoxelBasedInput({'caps_directory': caps_dir,
                                         'subjects_visits_tsv': tsv,
                                         'diagnoses_tsv': diagnoses_tsv,
-                                        'group_id': group_id,
+                                        'group_label': group_label,
                                         'image_type': im,
                                         'fwhm': 8})
                    for im in image_type]
@@ -289,7 +289,7 @@ def test_instantiate_InputsML():
     region_input = [CAPSRegionBasedInput({'caps_directory': caps_dir,
                                           'subjects_visits_tsv': tsv,
                                           'diagnoses_tsv': diagnoses_tsv,
-                                          'group_id': group_id,
+                                          'group_label': group_label,
                                           'image_type': im,
                                           'atlas': at})
                     for im in image_type
@@ -298,7 +298,7 @@ def test_instantiate_InputsML():
     vertex_input = [CAPSVertexBasedInput({'caps_directory': caps_dir,
                                           'subjects_visits_tsv': tsv,
                                           'diagnoses_tsv': diagnoses_tsv,
-                                          'group_id': group_id,
+                                          'group_label': group_label,
                                           'image_type': 'fdg',
                                           'fwhm': fwhm})
                     for fwhm in possible_psf]
@@ -413,7 +413,7 @@ def test_instantiate_StatisticsVolume():
         'measure_label': 'fdg',
         'group_label': 'UnitTest',
         'cluster_threshold': 0.001,
-        'group_id_caps': None,
+        'group_label_caps': None,
         'full_width_at_half_maximum': 8
     }
 

--- a/test/nonregression/test_run_pipelines.py
+++ b/test/nonregression/test_run_pipelines.py
@@ -121,7 +121,7 @@ def test_run_T1VolumeCreateDartel(cmdopt):
     shutil.copytree(join(root, 'in', 'caps'), join(root, 'out', 'caps'))
 
     parameters = {
-        'group_id': 'UnitTest'
+        'group_label': 'UnitTest'
     }
     # Instantiate pipeline
     pipeline = T1VolumeCreateDartel(
@@ -173,7 +173,7 @@ def test_run_T1VolumeDartel2MNI(cmdopt):
     shutil.copytree(join(root, 'in', 'caps'), join(root, 'out', 'caps'))
 
     parameters = {
-        'group_id': 'UnitTest'
+        'group_label': 'UnitTest'
     }
     # Instantiate pipeline and run()
     pipeline = T1VolumeDartel2MNI(
@@ -218,7 +218,7 @@ def test_run_T1VolumeRegisterDartel(cmdopt):
 
     # Instantiate and run pipeline
     parameters = {
-        'group_id': 'UnitTest'
+        'group_label': 'UnitTest'
     }
     pipeline = T1VolumeRegisterDartel(
         bids_directory=join(root, 'in', 'bids'),
@@ -266,7 +266,7 @@ def test_run_T1VolumeParcellation(cmdopt):
 
     # Instantiate pipeline
     parameters = {
-        'group_id': 'UnitTest'
+        'group_label': 'UnitTest'
     }
     pipeline = T1VolumeParcellation(
         caps_directory=join(root, 'in', 'caps'),
@@ -473,7 +473,7 @@ def test_run_PETVolume(cmdopt):
     shutil.copytree(join(root, 'in', 'caps'), join(root, 'out', 'caps'))
 
     parameters = {
-        'group_id': 'UnitTest'
+        'group_label': 'UnitTest'
     }
     pipeline = PETVolume(
         bids_directory=join(root, 'in', 'bids'),
@@ -667,32 +667,32 @@ def test_run_WorkflowsML(cmdopt):
     caps_dir = join(root_input, 'in', 'caps')
     tsv = join(root_input, 'in', 'subjects.tsv')
     diagnoses_tsv = join(root_input, 'in', 'diagnosis.tsv')
-    group_id = 'allADNIdartel'
+    group_label = 'allADNIdartel'
 
     output_dir1 = join(root, 'out', 'VertexBasedRepHoldOutDualSVM')
     clean_folder(output_dir1, recreate=True)
-    wf1 = VertexBasedRepHoldOutDualSVM(caps_dir, tsv, diagnoses_tsv, group_id, output_dir1, image_type='fdg', fwhm=20,
+    wf1 = VertexBasedRepHoldOutDualSVM(caps_dir, tsv, diagnoses_tsv, group_label, output_dir1, image_type='fdg', fwhm=20,
                                        n_threads=8, n_iterations=10, grid_search_folds=3, test_size=0.3)
     wf1.run()
     shutil.rmtree(output_dir1)
 
     output_dir2 = join(root, 'out', 'RegionBasedRepHoldOutLogisticRegression')
     clean_folder(output_dir2, recreate=True)
-    wf2 = RegionBasedRepHoldOutLogisticRegression(caps_dir, tsv, diagnoses_tsv, group_id, 'fdg', 'AICHA', output_dir2,
+    wf2 = RegionBasedRepHoldOutLogisticRegression(caps_dir, tsv, diagnoses_tsv, group_label, 'fdg', 'AICHA', output_dir2,
                                                   n_threads=8, n_iterations=10, grid_search_folds=3, test_size=0.3)
     wf2.run()
     shutil.rmtree(output_dir2)
 
     output_dir3 = join(root, 'out', 'RegionBasedRepHoldOutRandomForest')
     clean_folder(output_dir3, recreate=True)
-    wf3 = RegionBasedRepHoldOutRandomForest(caps_dir, tsv, diagnoses_tsv, group_id, 'T1', 'AAL2', output_dir3,
+    wf3 = RegionBasedRepHoldOutRandomForest(caps_dir, tsv, diagnoses_tsv, group_label, 'T1', 'AAL2', output_dir3,
                                             n_threads=8, n_iterations=10, grid_search_folds=3, test_size=0.3)
     wf3.run()
     shutil.rmtree(output_dir3)
 
     output_dir4 = join(root, 'out', 'VoxelBasedKFoldDualSVM')
     clean_folder(output_dir4, recreate=True)
-    wf4 = VoxelBasedKFoldDualSVM(caps_dir, tsv, diagnoses_tsv, group_id, 'fdg', output_dir4, fwhm=8, n_threads=8,
+    wf4 = VoxelBasedKFoldDualSVM(caps_dir, tsv, diagnoses_tsv, group_label, 'fdg', output_dir4, fwhm=8, n_threads=8,
                                  n_folds=5, grid_search_folds=3)
     wf4.run()
     shutil.rmtree(output_dir4)
@@ -878,7 +878,7 @@ def test_run_StatisticsVolume(cmdopt):
         'measure_label': 'fdg',
         'group_label': 'UnitTest',
         'cluster_threshold': 0.001,
-        'group_id_caps': None,
+        'group_label_caps': None,
         'full_width_at_half_maximum': 8
     }
 


### PR DESCRIPTION
This PR harmonises wording regarding how group IDs/labels are explained/used in Clinica.

`<group_id>`/`<group_label>` now follows BIDS naming convention similar to `<session_id>` (e.g. `ses-M00`) / `<session_label>` (e.g. `M00`).