### PR TITLE
Bound xldr version to use a package before the 2.0.0 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ scikit-learn == 0.23
 nilearn >= 0.6.0
 colorama >= 0.4.1
 xgboost == 0.80
-xlrd >= 1.2.0
+xlrd >= 1.2.0, < 2.0.0
 scipy == 1.2.3
 matplotlib
 niflow-nipype1-workflows


### PR DESCRIPTION
Bound version of xldr in the requirements file (>=1.2.0, < 2.0.0). From version 2.0.0, XLXS file are not supported ([see here](https://github.com/pandas-dev/pandas/issues/38410)).