### PR TITLE
Bugfix when using a nipype node with the container_from_file() function

### DIFF
--- a/clinica/pipelines/pet_volume/pet_volume_pipeline.py
+++ b/clinica/pipelines/pet_volume/pet_volume_pipeline.py
@@ -185,7 +185,10 @@ class PETVolume(cpe.Pipeline):
 
         if self.parameters["pvc_psf_tsv"] is not None:
             iterables_psf = read_psf_information(
-                self.parameters["pvc_psf_tsv"], self.subjects, self.sessions, self.parameters["acq_label"]
+                self.parameters["pvc_psf_tsv"],
+                self.subjects,
+                self.sessions,
+                self.parameters["acq_label"],
             )
             self.parameters["apply_pvc"] = True
         else:
@@ -292,7 +295,7 @@ class PETVolume(cpe.Pipeline):
         # =====================================
         container_path = npe.Node(
             nutil.Function(
-                input_names=["pet_filename"],
+                input_names=["bids_or_caps_filename"],
                 output_names=["container"],
                 function=container_from_filename,
             ),
@@ -386,8 +389,8 @@ class PETVolume(cpe.Pipeline):
         # fmt: off
         self.connect(
             [
-                (self.input_node, container_path, [("pet_image", "pet_filename")]),
-                (container_path, write_images_node, [(("container", fix_join, f"group-{self.parameters['group_label']}"), "container")]),
+                (self.input_node, container_path, [("pet_image", "bids_or_caps_filename")]),
+                (container_path, write_images_node, [(("container", fix_join, "pet", "preprocessing", f"group-{self.parameters['group_label']}"), "container")]),
                 (self.output_node, write_images_node, [(("pet_t1_native", zip_nii, True), "pet_t1_native"),
                                                        (("pet_mni", zip_nii, True), "pet_mni"),
                                                        (("pet_suvr", zip_nii, True), "pet_suvr"),
@@ -399,7 +402,7 @@ class PETVolume(cpe.Pipeline):
                                                        (("pet_pvc_suvr", zip_nii, True), "pet_pvc_suvr"),
                                                        (("pet_pvc_suvr_masked", zip_nii, True), "pet_pvc_suvr_masked"),
                                                        (("pet_pvc_suvr_masked_smoothed", zip_nii, True), "pet_pvc_suvr_masked_smoothed")]),
-                (container_path, write_atlas_node, [(("container", fix_join, f"group-{self.parameters['group_label']}"), "container")]),
+                (container_path, write_atlas_node, [(("container", fix_join, "pet", "preprocessing", f"group-{self.parameters['group_label']}"), "container")]),
                 (self.output_node, write_atlas_node, [("atlas_statistics", "atlas_statistics"),
                                                       ("pvc_atlas_statistics", "pvc_atlas_statistics")]),
             ]

--- a/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
+++ b/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
@@ -134,7 +134,7 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
             print_end_pipeline,
             zip_list_files,
             get_tissue_tuples,
-            ApplySegmentationDeformation
+            ApplySegmentationDeformation,
         )
 
         if spm_standalone_is_available():
@@ -175,9 +175,7 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
 
         # Apply segmentation deformation to T1 (into MNI space)
         # =====================================================
-        t1_to_mni = npe.Node(
-            ApplySegmentationDeformation(), name="3-T1wToMni"
-        )
+        t1_to_mni = npe.Node(ApplySegmentationDeformation(), name="3-T1wToMni")
 
         # Print end message
         # =================
@@ -219,7 +217,7 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
         # =====================================
         container_path = npe.Node(
             nutil.Function(
-                input_names=["t1w_filename"],
+                input_names=["bids_or_caps_filename"],
                 output_names=["container"],
                 function=container_from_filename,
             ),
@@ -263,8 +261,8 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
         # fmt: off
         self.connect(
             [
-                (self.input_node, container_path, [("t1w", "t1w_filename")]),
-                (container_path, write_node, [(("container", fix_join, ""), "container")]),
+                (self.input_node, container_path, [("t1w", "bids_or_caps_filename")]),
+                (container_path, write_node, [(("container", fix_join, "t1", "spm", "segmentation"), "container")]),
                 (self.output_node, write_node, [(("native_class_images", zip_list_files, True), "native_space"),
                                                 (("dartel_input_images", zip_list_files, True), "dartel_input")]),
                 (self.output_node, write_node, [(("inverse_deformation_field", zip_nii, True), "inverse_deformation_field")]),


### PR DESCRIPTION
Bugfix detected in non-regression test for `PETVolume` and  `T1VolumeTissueSegmentation`: wrong input name for nipype nodes when using the `container_from_file()` function.