### PR TITLE
Replace exception by warning in determine_caps_or_bids

### DIFF
--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -54,7 +54,7 @@ def determine_caps_or_bids(input_dir):
         ) > 0 or isdir(join(input_dir, "groups")):
             return False
         else:
-            cprint(f"{Fore.YELLOW} [Warning] We were unable to validate the CAPS directory structure{Fore.RESET}")
+            cprint(f"{Fore.YELLOW}[Warning] Could not determine if {input_dir} is a CAPS or BIDS directory. Clinica will asume this is a CAPS directory.{Fore.RESET}")
             return False
 
     else:
@@ -73,7 +73,7 @@ def determine_caps_or_bids(input_dir):
             if isdir(join(input_dir, "groups")):
                 return False
             else:
-                cprint(f"{Fore.YELLOW} [Warning] We were unable to validate the CAPS directory structure{Fore.RESET}")
+                cprint(f"{Fore.YELLOW}[Warning] Could not determine if {input_dir} is a CAPS or BIDS directory. Clinica will asume this is a CAPS directory.{Fore.RESET}")
                 return False
 
 

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -40,6 +40,9 @@ def determine_caps_or_bids(input_dir):
     """
     from os import listdir
     from os.path import isdir, join
+    from colorama import Fore
+
+    from clinica.utils.stream import cprint
 
     if isdir(join(input_dir, "subjects")):
         if len(
@@ -51,9 +54,8 @@ def determine_caps_or_bids(input_dir):
         ) > 0 or isdir(join(input_dir, "groups")):
             return False
         else:
-            raise RuntimeError(
-                f"Could not determine if {input_dir} is a CAPS or BIDS directory"
-            )
+            cprint(f"{Fore.YELLOW} [Warning] We were unable to validate the CAPS directory structure{Fore.RESET}")
+            return False
 
     else:
         if (
@@ -71,9 +73,8 @@ def determine_caps_or_bids(input_dir):
             if isdir(join(input_dir, "groups")):
                 return False
             else:
-                raise RuntimeError(
-                    f"Could not determine if {input_dir} is a CAPS or BIDS directory"
-                )
+                cprint(f"{Fore.YELLOW} [Warning] We were unable to validate the CAPS directory structure{Fore.RESET}")
+                return False
 
 
 def check_bids_folder(bids_directory):


### PR DESCRIPTION
Fix issue #169 by replacing exception by warning message if the CAPS directory structure was not recognized.
