### PR TITLE
Restrict nipype updates to the current major version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # ***** Requirements with Version Specifiers *****
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers
 nibabel >= 2.3.3
-nipype >= 1.4.0
+nipype >= 1.4.0, < 2.0.0
 pybids == 0.5.1
 argcomplete >= 1.9.4
 pandas >= 0.24.2


### PR DESCRIPTION
I know the nipype team is actively working on the next major version of nipype. We might want to avoid accidental updates to it considering it's a critical dependency.