### PR TITLE
Remove Conda badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
     <img src="https://badge.fury.io/py/clinica.svg" alt="PyPI version">
   </a>
   <a href="https://aramislab.paris.inria.fr/clinica/docs/public/latest/Installation/">
-    <img src="https://anaconda.org/aramislab/clinica/badges/installer/conda.svg" alt="conda install">
   </a>
   <a href="https://aramislab.paris.inria.fr/clinica/docs/public/latest/Installation/">
     <img src="https://anaconda.org/aramislab/clinica/badges/platforms.svg" alt="platform">


### PR DESCRIPTION
The but of this PR is also to test github actions to clean Conda environments at the CI machines.