### PR TITLE
Update NR test for deeplearning-prepare-data with pet-linear modality

### DIFF
--- a/test/nonregression/pipelines/test_run_pipelines_dl.py
+++ b/test/nonregression/pipelines/test_run_pipelines_dl.py
@@ -30,7 +30,7 @@ def test_run_DLPrepareData(cmdopt):
 
     # Prepare test for different parameters
 
-    modalities = ["t1-linear"]
+    modalities = ["t1-linear", "pet-linear"]
     uncropped_image = [True, False]
 
     image_params = {"extract_method": "image"}
@@ -45,6 +45,7 @@ def test_run_DLPrepareData(cmdopt):
 
     for parameters in data:
         for modality in modalities:
+            parameters["modality"] = modality
             if modality == "pet-linear":
                 parameters["acq_label"] = "av45"
                 parameters["suvr_reference_region"] = "pons2"
@@ -52,7 +53,6 @@ def test_run_DLPrepareData(cmdopt):
                 DLPrepareData_Generic(root, working_dir, parameters)
             else:
                 for flag in uncropped_image:
-                    parameters["modality"] = modality
                     parameters["use_uncropped_image"] = flag
                     DLPrepareData_Generic(root, working_dir, parameters)
 
@@ -79,5 +79,5 @@ def DLPrepareData_Generic(root, working_dir, parameters):
         base_dir=join(working_dir, "DeepLearningPrepareData"),
         parameters=parameters,
     )
-
+    print(f"**{parameters}**")
     pipeline.run(plugin="MultiProc", plugin_args={"n_procs": 4}, bypass_check=True)


### PR DESCRIPTION
Add the pet-linear modality to the non regression test of deeplearning-prepare-data pipeline