### PR TITLE
Add pydicom to the requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ niflow-nipype1-workflows
 scikit-image == 0.16.2
 torch > 1.0
 torchvision
+pydicom


### PR DESCRIPTION
Pydicom dependency was recently introduced but the package was not added to the requirements file. Closes #228.