### PR TITLE
Install dcm2niix through conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,10 @@
 name: clinica_env
 channels:
   - defaults
+  - conda-forge
 dependencies:
   - python=3.7
   - pip
   - pip:
       - -r requirements.txt
+  - dcm2niix


### PR DESCRIPTION
Probably easier to deploy `dcm2niix` alongside `clinica` using conda instead of following additional instructions to build your own version or fetch a binary + exposing it somewhere in `$PATH`.