### PR TITLE
Remove reference to --force_new_extraction in AIBL converter CLI

### DIFF
--- a/clinica/iotools/converters/aibl_to_bids/aibl_to_bids_cli.py
+++ b/clinica/iotools/converters/aibl_to_bids/aibl_to_bids_cli.py
@@ -34,7 +34,7 @@ class AiblToBidsCLI(ce.CmdParser):
             "--clinical_data_only",
             action="store_true",
             help="(Optional) Given the path to an already existing ADNI BIDS folder, convert only "
-            "the clinical data. Mutually exclusive with --force_new_extraction",
+            "the clinical data.",
         )
 
     def run_command(self, args):


### PR DESCRIPTION
There is no such option in the AIBL converter CLI. I guess it came from a copy-pasta of the ADNI one, where this option is available.