### PR TITLE
Update requirements from dev to install nipy in macOS

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,8 @@
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers
 
 -r requirements.txt
-nipy >= 0.4.2
+nipy == 0.4.2
+numpy>=1.17,<=1.19
 isort
 black
 pre-commit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 #   See https://www.python.org/dev/peps/pep-0440/#version-specifiers
 
 -r requirements.txt
-nipy == 0.4.2
+# nipy == 0.4.2
 numpy>=1.17,<=1.19
 isort
 black


### PR DESCRIPTION
Fix version for `numpy` and `nipy` in order to solve temporary installation of the latter package in MacOS CI machines.