### PR TITLE
Add missing else branch to scan file writer

### DIFF
--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -515,7 +515,8 @@ def write_scans_tsv(bids_dir, bids_ids, scans_dict):
                             if "-" in carac
                         }
                         f_type = description_dict["acq"].upper()
-
+                    else:
+                        continue
                     row_to_append = pd.DataFrame(
                         scans_dict[bids_id][session_name][f_type], index=[0]
                     )


### PR DESCRIPTION
Missing else branch may lead to `f_type`key being undefined.

Add a `continue` statement to keep iterating nonetheless. 