### PR TITLE
Add compat module for errno

### DIFF
--- a/clinica/compat.py
+++ b/clinica/compat.py
@@ -1,0 +1,4 @@
+try:
+    import errno
+except ImportError:
+    from os import errno

--- a/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_template_utils.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_template_utils.py
@@ -15,12 +15,12 @@ def init_input_node(caps_dir, participant_id, list_session_ids, output_dir):
     in that case, putting the SUBJECT_DIR inside the system temporary folder so that its path is as short as possible.
     """
     import datetime
-    import errno
     import os
     from tempfile import mkdtemp
 
     from colorama import Fore
 
+    from clinica.compat import errno
     from clinica.utils.longitudinal import get_long_id
     from clinica.utils.stream import cprint
     from clinica.utils.ux import print_begin_image

--- a/clinica/utils/check_dependency.py
+++ b/clinica/utils/check_dependency.py
@@ -24,12 +24,8 @@ def is_binary_present(binary):
     """
     import os
     import subprocess
-    import sys
 
-    if sys.version_info[0] >= 3 and sys.version_info[1] >= 7:
-        import errno
-    else:
-        errno = os.errno
+    from clinica.compat import errno
 
     try:
         devnull = open(os.devnull)


### PR DESCRIPTION
Required to maintain compatibility with Python versions older than 3.7.

Having compatibility code in `<package>/compat.py` is pretty standard.