### PR TITLE
Fix typo in merge_tsv CLI

### DIFF
--- a/clinica/iotools/utils/cli.py
+++ b/clinica/iotools/utils/cli.py
@@ -175,7 +175,7 @@ def create_subjects_visits(bids_directory: str, output_tsv: str) -> None:
 )
 @click.option(
     "-p",
-    "--pipeline",
+    "--pipelines",
     multiple=True,
     type=click.Choice(["t1-freesurfer", "t1-volume", "pet-volume"]),
     help="Pipeline to merge to the ouput TSV file. All pipelines are merged by default.",


### PR DESCRIPTION
The optional argument "pipelines" was missing an 's' and thus causing Clinica to crash when invoking merge-tsv