### PR TITLE
Add merge_tsv() required target var in CLI

### DIFF
--- a/clinica/iotools/utils/cli.py
+++ b/clinica/iotools/utils/cli.py
@@ -175,7 +175,8 @@ def create_subjects_visits(bids_directory: str, output_tsv: str) -> None:
 )
 @click.option(
     "-p",
-    "--pipelines",
+    "--pipeline",
+    "pipelines",
     multiple=True,
     type=click.Choice(["t1-freesurfer", "t1-volume", "pet-volume"]),
     help="Pipeline to merge to the ouput TSV file. All pipelines are merged by default.",


### PR DESCRIPTION
After discussion with @ghisvail, specifying the target var explicitly seems to be a better option as the pipelines are specified one by one. 