### PR TITLE
Fix typos in PET Introduction page

### DIFF
--- a/docs/Pipelines/PET_Introduction.md
+++ b/docs/Pipelines/PET_Introduction.md
@@ -48,10 +48,10 @@ Reference regions provided by Clinica come from the [Pick atlas](https://www.nit
 
 - `cerebellumPons2`: new in Clinica `v0.4`
 
-In Clinica `v0.4` two new versions of these masks has been introduced: `pons2` and `cerebellumPons2`.
-Indeed we wanted to improve the reference regions mask to fit more the [MNI152NLin2009cSym template](https://bids-specification.readthedocs.io/en/stable/99-appendices/08-coordinate-systems.html#template-based-coordinate-systems) used in linear processing pipelines.
+In Clinica `v0.4` two new versions of these masks have been introduced: `pons2` and `cerebellumPons2`.
+Indeed we wanted to improve the reference regions mask to better fit the [MNI152NLin2009cSym template](https://bids-specification.readthedocs.io/en/stable/99-appendices/08-coordinate-systems.html#template-based-coordinate-systems) used in linear processing pipelines.
 The new masks still come from the [Pick atlas](https://www.nitrc.org/projects/wfu_pickatlas) but with a different processing: we decided to first truncate the mask using SPM12 tissue probability maps to remove voxels overlapping with regions outside the brain (bone, CSF, background...).
-Then we eroded the mask using scipy [`binary_erosion`](https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.ndimage.morphology.binary_erosion.html) with 3 iterations.
+Then, we eroded the mask using scipy [`binary_erosion`](https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.ndimage.morphology.binary_erosion.html) with 3 iterations.
 
 ## Tutorial: How to add new SUVR reference regions to Clinica?
 

--- a/docs/Pipelines/PET_Introduction.md
+++ b/docs/Pipelines/PET_Introduction.md
@@ -38,17 +38,20 @@ This region is chosen according to the tracer and disease studied as it must be 
 
 Clinica `v0.3.8` introduces the possibility for the user to select the reference region for the SUVR map computation.
 
-Reference regions provided by Clinica come from the[Pick atlas](https://www.nitrc.org/projects/wfu_pickatlas) in MNI space and currently are:
+Reference regions provided by Clinica come from the [Pick atlas](https://www.nitrc.org/projects/wfu_pickatlas) in MNI space and currently are:
 
 - `pons`: 6 mm eroded version of the pons region
 
 - `cerebellumPons`: 6 mm eroded version of the cerebellum + pons regions
 
-- `pons2`:  new in clinica `v0.4`
+- `pons2`: new in Clinica `v0.4`
 
-- `cerebellumPons2`: new in clinica `v0.4`
+- `cerebellumPons2`: new in Clinica `v0.4`
 
-In clinica `v0.4` two new versions of these masks has been introduced: `pons2` and `cerebellumPons2`. Indeed we wanted to improve the reference regions maks to fit more the [MNI152NLin2009cSym template](https://bids-specification.readthedocs.io/en/stable/99-appendices/08-coordinate-systems.html#template-based-coordinate-systems) used in linear processing pipelines. The new masks still come from the [Pick atlas](https://www.nitrc.org/projects/wfu_pickatlas) but with a different processing: we decided to first truncate the mask using SPM12 tissue probablity maps to remove voxels overlapping with regions outside the brain (bone, csf, bachground...). Then we eroded the mask using scipy [`binary_erosion`](https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.ndimage.morphology.binary_erosion.html) with 3 iterations.
+In Clinica `v0.4` two new versions of these masks has been introduced: `pons2` and `cerebellumPons2`.
+Indeed we wanted to improve the reference regions mask to fit more the [MNI152NLin2009cSym template](https://bids-specification.readthedocs.io/en/stable/99-appendices/08-coordinate-systems.html#template-based-coordinate-systems) used in linear processing pipelines.
+The new masks still come from the [Pick atlas](https://www.nitrc.org/projects/wfu_pickatlas) but with a different processing: we decided to first truncate the mask using SPM12 tissue probability maps to remove voxels overlapping with regions outside the brain (bone, CSF, background...).
+Then we eroded the mask using scipy [`binary_erosion`](https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.ndimage.morphology.binary_erosion.html) with 3 iterations.
 
 ## Tutorial: How to add new SUVR reference regions to Clinica?
 


### PR DESCRIPTION
Hi,

There are some typos (maks, csf, bachground) on the Wiki.

Alex