### PR TITLE
Raise exception on empty dataframe

### DIFF
--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -715,6 +715,8 @@ def create_adni_sessions_dict(
                 ]
                 df_subj_session = pd.concat([df_subj_session, df_filtered], axis=1)
 
+    if df_subj_session.empty:
+        raise Exception("Empty dataset detected. Clinical data can not be extracted")
     df_subj_session.drop(
         df_subj_session[df_subj_session.session_id == "sc"].index, inplace=True
     )

--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -716,7 +716,7 @@ def create_adni_sessions_dict(
                 df_subj_session = pd.concat([df_subj_session, df_filtered], axis=1)
 
     if df_subj_session.empty:
-        raise Exception("Empty dataset detected. Clinical data can not be extracted")
+        raise ValueError("Empty dataset detected. Clinical data cannot be extracted")
     df_subj_session.drop(
         df_subj_session[df_subj_session.session_id == "sc"].index, inplace=True
     )


### PR DESCRIPTION
Raise explicit exception when creating clinical data and the image folders are not found.