### PR TITLE
Raise minimum Python version to 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ environment and activate it before installing clinica (you can also use
 `virtualenv`):
 
 ```sh
-conda create --name clinicaEnv python=3.7
+conda create --name clinicaEnv python=3.8
 conda activate clinicaEnv
 ```
 

--- a/clinica/__init__.py
+++ b/clinica/__init__.py
@@ -12,9 +12,9 @@ version = __version__
 # version = pkg_resources.require("Clinica")[0].version
 # __version__ = version
 
-# python 3.6 minimum version is required
-if sys.version_info < (3, 6):
-    print(f"Clinica {__version__} requires Python 3.6")
+# Python 3.8 minimum version is required.
+if sys.version_info < (3, 8):
+    print(f"Clinica {__version__} requires Python 3.8")
     sys.exit(1)
 
 # Note: The following lines have been commented for speed purposes.

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: clinica_env
 channels:
   - defaults
 dependencies:
-  - python=3.7
+  - python=3.8
   - pip
   - pip:
       - -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ skip_gitignore = true
 
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py38', 'py39']
 include = '\.pyi?$'
 force-exclude = '''
 /(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,17 +6,17 @@ nipype >= 1.4.0, < 2.0.0
 argcomplete >= 1.9.4
 pandas >= 0.24.2
 jinja2 >= 2.10.1
-xvfbwrapper == 0.2.9
-numpy >= 1.17
-scikit-learn == 0.23
+xvfbwrapper
+numpy
+scikit-learn
 nilearn >= 0.6.0
 colorlog >= 5
-xgboost == 0.80
+xgboost
 xlrd >= 1.2.0, < 2.0.0
-scipy == 1.2.3
+scipy
 matplotlib
 niflow-nipype1-workflows
-scikit-image == 0.16.2
+scikit-image >= 0.16.2
 torch > 1.0
 torchvision
 pydicom

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ numpy
 scikit-learn
 nilearn >= 0.6.0
 colorlog >= 5
-xgboost
+xgboost < 1
 xlrd >= 1.2.0, < 2.0.0
 scipy
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,5 @@ setup(
     ],
     install_requires=install_requires,
     extras_require={"test": ["pytest", "coverage"]},
-    python_requires=">=3.6,<3.8",
+    python_requires=">=3.8,<3.10",
 )


### PR DESCRIPTION
Python 3.8 was released end of 2019 and is the default version the [current Ubuntu LTS](https://packages.ubuntu.com/focal/python3). It brought some significant [improvement](https://docs.python.org/3/whatsnew/3.8.html) compared to Python 3.7 some of which would strongly benefit current and future development of Clinica, including:

- Significant performance increase on file tree manipulation through the use of native kernel calls
- Better ergonomics for `shutil.copytree` which is used by our converters for merging BIDS datasets
- Stabilization of `asyncio.run` (which the backend for the future webapp will use extensively)
- Significant perfomance increase of the runtime overall

