### PR TITLE
Fix default value of modulate flag

### DIFF
--- a/clinica/pipelines/cli_param/option.py
+++ b/clinica/pipelines/cli_param/option.py
@@ -37,9 +37,9 @@ low_bval = option(
 )
 
 modulate = option(
-    "-m",
-    "--modulate",
-    is_flag=True,
+    "--modulate/--no-modulate",
+    default=True,
+    show_default=True,
     help="Modulate output images, no modulation preserves concentrations.",
 )
 

--- a/clinica/pipelines/cli_param/option.py
+++ b/clinica/pipelines/cli_param/option.py
@@ -37,7 +37,8 @@ low_bval = option(
 )
 
 modulate = option(
-    "--modulate/--no-modulate",
+    "--modulate/--no_modulate",
+    "modulate",
     default=True,
     show_default=True,
     help="Modulate output images, no modulation preserves concentrations.",

--- a/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_cli.py
+++ b/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_cli.py
@@ -27,7 +27,7 @@ def cli(
     group_label: str,
     smooth: List[int] = (8,),
     tissues: List[int] = (1, 2, 3),
-    modulate: bool = False,
+    modulate: bool = True,
     voxel_size: Tuple[float, float, float] = (1.5, 1.5, 1.5),
     subjects_sessions_tsv: Optional[str] = None,
     working_directory: Optional[str] = None,

--- a/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_cli.py
+++ b/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_cli.py
@@ -37,7 +37,7 @@ def cli(
     save_warped_modulated: bool = False,
     dartel_tissues: List[int] = (1, 2, 3),
     tissues: List[int] = (1, 2, 3),
-    modulate: bool = False,
+    modulate: bool = True,
     voxel_size: Tuple[float, float, float] = (1.5, 1.5, 1.5),
     subjects_sessions_tsv: Optional[str] = None,
     working_directory: Optional[str] = None,

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_cli.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_cli.py
@@ -14,12 +14,15 @@ pipeline_name = "t1-volume-parcellation"
 @cli_param.option.subjects_sessions_tsv
 @cli_param.option.working_directory
 @cli_param.option.n_procs
+@cli_param.option_group.advanced_pipeline_options
+@cli_param.option.modulate
 def cli(
     caps_directory: str,
     group_label: str,
     subjects_sessions_tsv: Optional[str] = None,
     working_directory: Optional[str] = None,
     n_procs: Optional[int] = None,
+    modulate: bool = True,
 ) -> None:
     """Computation of mean GM concentration for a set of regions.
 
@@ -33,7 +36,7 @@ def cli(
 
     from .t1_volume_parcellation_pipeline import T1VolumeParcellation
 
-    parameters = {"group_label": group_label}
+    parameters = {"group_label": group_label, "modulate": modulate}
 
     pipeline = T1VolumeParcellation(
         caps_directory=caps_directory,

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
@@ -22,6 +22,7 @@ class T1VolumeParcellation(cpe.Pipeline):
         check_group_label(self.parameters["group_label"])
 
         self.parameters.setdefault("atlases", T1_VOLUME_ATLASES)
+        self.parameters.setdefault("modulate", True)
 
     def get_input_fields(self):
         """Specify the list of possible inputs of this pipeline.
@@ -71,7 +72,11 @@ class T1VolumeParcellation(cpe.Pipeline):
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
-                t1_volume_template_tpm_in_mni(self.parameters["group_label"], 1, True),
+                t1_volume_template_tpm_in_mni(
+                    group_label=self.parameters["group_label"],
+                    tissue_number=1,
+                    modulation=self.parameters["modulate"],
+                ),
             )
         except ClinicaException as e:
             final_error_str = "Clinica faced error(s) while trying to read files in your CAPS directory.\n"

--- a/docs/Pipelines/T1_Volume.md
+++ b/docs/Pipelines/T1_Volume.md
@@ -51,10 +51,10 @@ Default value is: `8`.
 Default value is: `1, 2, 3` (GM, WM and CSF are saved).
 - `--dartel_tissues`: a list of integers (possible values range from 1 to 6) that indicates the tissue classes to use for the Dartel template calculation (in order: GM, WM, CSF, bone, soft-tissue, air/background).
 Default value is: `1, 2, 3` (GM, WM and CSF are used).
-- `--modulate`: a boolean.
-If `True` output images are modulated and volumes are preserved.
-If `False` they are not modulated and concentrations are preserved.
-Default value: `True`.
+- `--modulate / --no-modulate`: a flag.
+If enabled, output images are modulated and volumes are preserved.
+If disabled, they are not modulated and concentrations are preserved.
+Default value: `--modulate`.
 
 !!! note
     - The arguments common to all Clinica pipelines are described in [Interacting with clinica](../../InteractingWithClinica).


### PR DESCRIPTION
The switch to Click changed the behavior of the `--modulate` flag which used to be set to true by default. This PR brings back the old behavior. Use `--no-modulate` to explicitly disable modulation.

Here is the corresponding output of the help string:

```sh
clinica run t1-volume -h
[...]
    --modulate / --no-modulate    Modulate output images, no modulation preserves concentrations.  [default: modulate]
```

Closes #351 