### PR TITLE
Add missing trailing slash to ANTSPATH

### DIFF
--- a/docs/Third-party.md
+++ b/docs/Third-party.md
@@ -87,7 +87,7 @@ export LANG=en_US.UTF-8
 source /path/to/your/Miniconda/etc/profile.d/conda.sh
 
 # ANTs
-export ANTSPATH="/path/to/your/ANTs"
+export ANTSPATH="/path/to/your/ANTs/"
 export PATH=${ANTSPATH}:${PATH}
 
 # FreeSurfer


### PR DESCRIPTION
As mentioned in the upstream instructions in their [wiki](https://github.com/ANTsX/ANTs/wiki/Compiling-ANTs-on-Linux-and-Mac-OS#post-installation-set-environment-variables-path-and-antspath).