### PR TITLE
Enh bye freesurfer conv

### DIFF
--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -774,6 +774,7 @@ def run_dcm2niix(command):
         cprint(
             msg=(
                 "DICOM to BIDS conversion with dcm2niix failed:\n"
+                f"command: {command}\n"
                 f"{output_dcm2niix.stdout.decode('utf-8')}"
             ),
             lvl="warning",

--- a/clinica/iotools/converters/aibl_to_bids/aibl_to_bids_cli.py
+++ b/clinica/iotools/converters/aibl_to_bids/aibl_to_bids_cli.py
@@ -31,10 +31,9 @@ def cli(
         convert_clinical_data,
         convert_images,
     )
-    from clinica.utils.check_dependency import check_dcm2niix, check_freesurfer
+    from clinica.utils.check_dependency import check_dcm2niix
 
     check_dcm2niix()
-    check_freesurfer()
 
     makedirs(bids_directory, exist_ok=True)
 

--- a/clinica/iotools/converters/aibl_to_bids/aibl_utils.py
+++ b/clinica/iotools/converters/aibl_to_bids/aibl_utils.py
@@ -224,32 +224,6 @@ def dicom_to_nii(subject, output_path, output_filename, image_path):
     nifti_file = os.path.join(output_path, output_filename + ".nii.gz")
 
     if not exists(nifti_file):
-        # Use mri_convert from freesurfer as fallback
-        dicom_image = listdir_nohidden(image_path)
-        dicom_image = [dcm for dcm in dicom_image if dcm.endswith(".dcm")]
-        try:
-            dicom_image = os.path.join(image_path, dicom_image[0])
-        except IndexError:
-            cprint(
-                msg=f"DICOM files not found in the following directory: {image_path}",
-                lvl="warning",
-            )
-
-        # it requires the installation of Freesurfer (checked at the beginning)
-        command = "mri_convert " + dicom_image + " " + nifti_file
-        if exists(os.path.expandvars("$FREESURFER_HOME/bin/mri_convert")):
-            subprocess.run(
-                command,
-                shell=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-        else:
-            cprint(
-                f"mri_convert (from FreeSurfer) not detected. {nifti_file} not created..."
-            )
-
-    if not exists(nifti_file):
         cprint(nifti_file + " should have been created but this did not happen")
     return nifti_file
 

--- a/docs/Converters/ADNI2BIDS.md
+++ b/docs/Converters/ADNI2BIDS.md
@@ -18,7 +18,7 @@
 
 ## Dependencies
 
-If you only installed the core of Clinica, this pipeline needs the installation of the **dcm2niix** DICOM to NIfTI converter and **FreeSurfer**.
+If you only installed the core of Clinica, this pipeline needs the installation of the **dcm2niix** DICOM to NIfTI converter.
 You can find how to install these software packages on the [installation](../../#installing-clinica-from-source) page.
 
 ## Downloading ADNI

--- a/docs/Converters/AIBL2BIDS.md
+++ b/docs/Converters/AIBL2BIDS.md
@@ -21,7 +21,7 @@
 
 ## Dependencies
 
-If you only installed the core of Clinica, this pipeline needs the installation of the **dcm2niix** DICOM to NIfTI converter and **FreeSurfer**.
+If you only installed the core of Clinica, this pipeline needs the installation of the **dcm2niix** DICOM to NIfTI converter.
 You can find how to install these software packages on the [installation](../../#installing-clinica-from-source) page.
 
 ### Downloading AIBL

--- a/docs/Converters/NIFD2BIDS.md
+++ b/docs/Converters/NIFD2BIDS.md
@@ -7,7 +7,7 @@
 
 ## Dependencies
 
-If you only installed the core of Clinica, this pipeline needs the installation of the **dcm2niix** DICOM to NIfTI converter and **FreeSurfer**.
+If you only installed the core of Clinica, this pipeline needs the installation of the **dcm2niix** DICOM to NIfTI converter.
 You can find how to install these software packages on the [installation](../../#installing-clinica-from-source) page.
 
 ## Downloading NIFD

--- a/docs/Third-party.md
+++ b/docs/Third-party.md
@@ -3,24 +3,20 @@
 
 ## Converters
 
-If you want to run the `convert <dataset>-to-bids` commands (e.g. `adni-to-bids`), you may have to install the [**dcm2niix**](https://github.com/rordenlab/dcm2niix), [**dcm2nii**](https://www.nitrc.org/frs/?group_id=152) and/or [**FreeSurfer**](http://surfer.nmr.mgh.harvard.edu/) tools.
+If you want to run the `convert <dataset>-to-bids` commands (e.g. `adni-to-bids`), you may have to install the [**dcm2niix**](https://github.com/rordenlab/dcm2niix) tool.
 
-|                   | dcm2niix | FreeSurfer |
-|:------------------|:--------:|:----------:|
-| `adni-to-bids`    |    x     |            |
-| `aibl-to-bids`    |    x     |     x      |
-| `nifd-to-bids`    |    x     |            |
-| `oasis-to-bids`   |          |            |
+|                   | dcm2niix |
+|:------------------|:--------:|
+| `adni-to-bids`    |    x     |
+| `aibl-to-bids`    |    x     |
+| `nifd-to-bids`    |    x     |
+| `oasis-to-bids`   |          |
 
 Please refer to each tool’s website for installation instructions:
 
 - [**dcm2niix**](https://github.com/rordenlab/dcm2niix)
   - Download [here](https://github.com/rordenlab/dcm2niix) and follow the installation instructions on the same page.
   - For Mac users: use Homebrew to install `dcm2niix` with `brew install dcm2niix`.
-- [**FreeSurfer 6.0**](http://surfer.nmr.mgh.harvard.edu/)
-  - For Linux users, download and install FreeSurfer following the instructions on the [wiki](http://surfer.nmr.mgh.harvard.edu/fswiki/DownloadAndInstall).
-  Please note that on Ubuntu you will need to install the packages `tcsh` and `libjpeg62` (a `sudo apt-get install tcsh libjpeg62` should do the job).
-  - For Mac users, download [here](http://surfer.nmr.mgh.harvard.edu/fswiki/DownloadAndInstall) and follow the instructions on the FreeSurfer [wiki](https://surfer.nmr.mgh.harvard.edu/fswiki/MacOsInstall).
 
 Do not forget to check the installations following each tool’s guidelines.
 


### PR DESCRIPTION
Remove the usage of FreeSurfer as a fallback for dcm2niix conversion in the `aibl-to-bids` converter.

To do:

- [x]  test the aibl database to see whether FreeSurfer is used and is useful to convert. 3 conversion are done using FreeSurfer. 
- [x] Download them again to be sure they were not updated and now work.
- [ ] If they still do not work-> Indicate these cases to dcm2niix so they can fix them.
