### PR TITLE
Drop minimum version for xgboost

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ numpy >= 1.17
 scikit-learn == 0.23
 nilearn >= 0.6.0
 colorlog >= 5
-xgboost < 1
+xgboost
 xlrd >= 1.2.0, < 2.0.0
 scipy == 1.2.3
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ numpy >= 1.17
 scikit-learn == 0.23
 nilearn >= 0.6.0
 colorlog >= 5
-xgboost == 0.80
+xgboost < 1
 xlrd >= 1.2.0, < 2.0.0
 scipy == 1.2.3
 matplotlib


### PR DESCRIPTION
- Avoid strict version pinning, which is not recommended
- A newer version of CMake is required for xgboost 1.x, which is not available in our MacOS CI