### PR TITLE
Promote GitHub discussions for new support requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
   <a href="http://www.clinica.run">Homepage</a> |
   <a href="https://aramislab.paris.inria.fr/clinica/docs/public/latest/">Documentation</a> |
   <a href="https://doi.org/10.3389/fninf.2021.689675">Paper</a> |
-  <a href="https://groups.google.com/forum/#!forum/clinica-user">Forum</a> |
+  <a href="https://github.com/aramis-lab/clinica/discussions">Forum</a> |
   See also:
   <a href="#related-repositories">AD-ML</a>,
   <a href="#related-repositories">AD-DL</a>
@@ -133,9 +133,9 @@ with Alzheimer's disease and healthy controls from the ADNI database:
 
 ## Support
 
-- [Report an issue on GitHub](https://github.com/aramis-lab/clinica/issues)
-- Use the [Clinica Google
-  Group](https://groups.google.com/forum/#!forum/clinica-user) to ask for help!
+- Check for [past answers](https://groups.google.com/forum/#!forum/clinica-user) in the old Clinica Google Group
+- Start a [discussion](https://github.com/aramis-lab/clinica/discussions) on Github
+- Report an [issue](https://github.com/aramis-lab/clinica/issues) on GitHub
 
 ## Contributing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,8 +95,9 @@ Find on [this page](ClinicaConferences) the presentations and demo materials use
 
 ## Support
 
-- [Report an issue on GitHub](https://github.com/aramis-lab/clinica/issues)
-- Use the [Clinica Google Group](https://groups.google.com/forum/#!forum/clinica-user) to ask for help!
+- Check for [past answers](https://groups.google.com/forum/#!forum/clinica-user) in the old Clinica Google Group
+- Start a [discussion](https://github.com/aramis-lab/clinica/discussions) on Github
+- Report an [issue](https://github.com/aramis-lab/clinica/issues) on GitHub
 
 ## License
 


### PR DESCRIPTION
As discussed in our last group meeting, the plan is to freeze our Google group and transition to using GitHub discussions for handling support requests.

GitHub discussions is now stable, provides a better experience for writing support requests, and is not under threat of joining the evergrowing Google [graveyard](https://killedbygoogle.com/).

This PR invites users to first check past answers from Google group, but start new requests on GitHub discussions. This way both channels can still co-exist until we decide on a freeze date for the Google group.
