### PR TITLE
Fix unexpected argument in non-regression tests

### DIFF
--- a/test/nonregression/pipelines/test_run_pipelines_anat.py
+++ b/test/nonregression/pipelines/test_run_pipelines_anat.py
@@ -443,7 +443,7 @@ def test_run_T1Linear(cmdopt):
     out_folder = join(root, "out")
     ref_folder = join(root, "ref")
 
-    compare_folders(out_folder, ref_folder, shared_folder_name="caps")
+    compare_folders(out_folder, ref_folder, tmp_path="caps")
 
     clean_folder(join(root, "out", "caps"), recreate=False)
     clean_folder(join(working_dir, "T1Linear"), recreate=False)

--- a/test/nonregression/pipelines/test_run_pipelines_dl.py
+++ b/test/nonregression/pipelines/test_run_pipelines_dl.py
@@ -82,7 +82,7 @@ def test_run_DLPrepareData(cmdopt):
     out_folder = join(root, "out")
     ref_folder = join(root, "ref")
 
-    compare_folders(out_folder, ref_folder, shared_folder_name="caps")
+    compare_folders(out_folder, ref_folder, tmp_path="caps")
 
     clean_folder(join(root, "out", "caps"), recreate=False)
     clean_folder(join(working_dir, "DeepLearningPrepareData"), recreate=False)

--- a/test/nonregression/pipelines/test_run_pipelines_pet.py
+++ b/test/nonregression/pipelines/test_run_pipelines_pet.py
@@ -106,7 +106,7 @@ def test_run_PETLinear(cmdopt):
     out_folder = join(root, "out")
     ref_folder = join(root, "ref")
 
-    compare_folders(out_folder, ref_folder, shared_folder_name="caps")
+    compare_folders(out_folder, ref_folder, tmp_path="caps")
 
     clean_folder(join(root, "out", "caps"), recreate=False)
     clean_folder(join(working_dir, "PETLinear"), recreate=False)


### PR DESCRIPTION
`shared_folder_name` no longer exists