### PR TITLE
Cleanup warnings in non-regression tests

### DIFF
--- a/test/nonregression/iotools/test_run_utils.py
+++ b/test/nonregression/iotools/test_run_utils.py
@@ -10,7 +10,6 @@ import warnings
 from os import PathLike, fspath
 from pathlib import Path
 from test.nonregression.testing_tools import (
-    clean_folder,
     create_list_hashes,
     identical_subject_list,
     same_missing_modality_tsv,
@@ -37,15 +36,17 @@ def test_name(request):
 def run_createsubjectsession(
     input_dir: PathLike, output_dir: PathLike, ref_dir: PathLike
 ) -> None:
+    from pathlib import Path
+
     from clinica.iotools.utils import data_handling as dt
 
-    # Arrage
+    # Arrange
     tsv_name = "subject_session_list.tsv"
     # Act - Create subject_session file
-    dt.create_subs_sess_list(input_dir / "bids", output_dir, tsv_name)
+    dt.create_subs_sess_list(str(Path(input_dir) / "bids"), str(output_dir), tsv_name)
     # Assert
-    out_tsv = fspath(output_dir / tsv_name)
-    ref_tsv = fspath(ref_dir / tsv_name)
+    out_tsv = fspath(Path(output_dir) / tsv_name)
+    ref_tsv = fspath(Path(ref_dir) / tsv_name)
     assert identical_subject_list(out_tsv, ref_tsv)
 
 
@@ -54,21 +55,20 @@ def run_createmergefile(
 ) -> None:
     import shutil
     from filecmp import cmp
-    from os import remove
-    from os.path import abspath, dirname, join
+    from pathlib import Path
 
     import pandas as pd
 
     from clinica.iotools.utils import data_handling as dt
 
     # Arrange
-    out_tsv = output_dir / "output_file.tsv"
-    subject_session_tsv = input_dir / "subjects_sessions.tsv"
-    caps_directory = output_dir / "caps"
-    shutil.copytree(input_dir / "caps", caps_directory, copy_function=shutil.copy)
+    out_tsv = Path(output_dir) / "output_file.tsv"
+    subject_session_tsv = Path(input_dir) / "subjects_sessions.tsv"
+    caps_directory = Path(output_dir) / "caps"
+    shutil.copytree(Path(input_dir) / "caps", caps_directory, copy_function=shutil.copy)
     # Act
     dt.create_merge_file(
-        input_dir / "bids",
+        Path(input_dir) / "bids",
         out_tsv,
         caps_dir=caps_directory,
         tsv_file=subject_session_tsv,
@@ -78,7 +78,7 @@ def run_createmergefile(
         group_selection=None,
     )
     # Assert
-    ref_tsv = fspath(ref_dir / "output_file.tsv")
+    ref_tsv = fspath(Path(ref_dir) / "output_file.tsv")
     out_df = pd.read_csv(out_tsv, sep="/")
     ref_df = pd.read_csv(ref_tsv, sep="/")
     assert out_df.equals(ref_df)
@@ -88,10 +88,12 @@ def run_createmergefile(
 def run_computemissingmodalities(
     input_dir: PathLike, output_dir: PathLike, ref_dir: PathLike
 ) -> None:
+    from pathlib import Path
+
     from clinica.iotools.utils import data_handling as dt
 
     output_name = "missing_modalities"
-    bids_dir = input_dir / "bids"
+    bids_dir = Path(input_dir) / "bids"
 
     dt.compute_missing_mods(bids_dir, output_dir, output_name)
 
@@ -104,12 +106,12 @@ def run_computemissingmodalities(
         "missing_modalities_ses-M48.tsv",
     ]
     for i in range(len(filenames)):
-        outname = output_dir / filenames[i]
-        refname = ref_dir / filenames[i]
+        outname = Path(output_dir) / filenames[i]
+        refname = Path(ref_dir) / filenames[i]
         if not outname.exists():
             raise FileNotFoundError(
                 "A file called "
-                + outname
+                + str(outname)
                 + " should have been generated, but it does not exists"
             )
         assert same_missing_modality_tsv(outname, refname)
@@ -118,10 +120,12 @@ def run_computemissingmodalities(
 def run_centernifti(
     input_dir: PathLike, output_dir: PathLike, ref_dir: PathLike
 ) -> None:
+    from pathlib import Path
+
     from clinica.iotools.utils.data_handling import center_all_nifti
 
-    output_dir = output_dir / "bids_centered"
-    bids_dir = input_dir / "bids"
+    output_dir = Path(output_dir) / "bids_centered"
+    bids_dir = Path(input_dir) / "bids"
 
     all_modalities = [
         "t1w",
@@ -144,7 +148,7 @@ def run_centernifti(
         fspath(output_dir), extensions_to_keep=(".nii.gz", ".nii")
     )
     hashes_ref = create_list_hashes(
-        fspath(ref_dir / "bids_centered"), extensions_to_keep=(".nii.gz", ".nii")
+        fspath(Path(ref_dir) / "bids_centered"), extensions_to_keep=(".nii.gz", ".nii")
     )
     assert hashes_out == hashes_ref
 

--- a/test/nonregression/testing_tools.py
+++ b/test/nonregression/testing_tools.py
@@ -13,8 +13,7 @@ def likeliness_measure(file1, file2, threshold1, threshold2, display=False):
                             difference between 2 voxels to be considered different (ex: 1e-4). threshold[1] defines
                             the maximum proportion of voxels that can different for the test to be negative.
         (tuple) threshold2: defines the second criteria to meet.
-        (bool) display: If set to True, will display a useful graph to determine optimal threshold for the
-                        comparison
+        (bool) display: If set to True, will display a useful graph to determine optimal threshold for the comparison.
 
     Returns:
         (bool) True if file1 and file2 can be considered similar enough (meeting criterion expressed in threshold1
@@ -22,7 +21,6 @@ def likeliness_measure(file1, file2, threshold1, threshold2, display=False):
 
     """
     import os
-    from pathlib import Path
 
     import matplotlib.pyplot as plt
     import nibabel as nib
@@ -208,7 +206,7 @@ def same_missing_modality_tsv(file1, file2):
     )
 
 
-def compare_folders(outdir: PathLike, refdir: PathLike, tmp_path) -> bool:
+def compare_folders(outdir: PathLike, refdir: PathLike, tmp_path) -> None:
     from filecmp import cmp
 
     file_out = tmp_path / "file_out.txt"
@@ -227,14 +225,17 @@ def compare_folders(outdir: PathLike, refdir: PathLike, tmp_path) -> bool:
         )
 
 
-def tree(dir: PathLike, file_out: PathLike):
-    # Create a file (file_out) with a visual tree representing the file
-    # hierarchy at a giver directory
-    for path in sorted(dir.rglob("*")):
-        depth = len(path.relative_to(dir).parts)
+def tree(directory: PathLike, file_out: PathLike):
+    """Create a file (file_out) with a visual tree representing the file hierarchy at a given directory."""
+    from pathlib import Path
+
+    file_content = ""
+    for path in sorted(Path(directory).rglob("*")):
+        depth = len(path.relative_to(directory).parts)
         spacer = "    " * depth
-        file_content = f"{spacer}+ {path.name}\n"
-    file_out.write_text(file_content)
+        file_content += f"{spacer}+ {path.name}\n"
+
+    Path(file_out).write_text(file_content)
 
 
 def list_files(startpath, filename=None):
@@ -242,7 +243,7 @@ def list_files(startpath, filename=None):
 
     Args:
         startpath: starting point for the tree listing. Does not list hidden
-        files (to avoid problems with .DS_store for example
+                   files (to avoid problems with .DS_store for example
         filename: if None, display to stdout, otherwise write in the file
 
     Returns:
@@ -257,7 +258,7 @@ def list_files(startpath, filename=None):
     expanded_path = abspath(expanduser(expandvars(startpath)))
     for root, dirs, files in walk(expanded_path):
         level = root.replace(startpath, "").count(sep)
-        indent = " " * 4 * (level)
+        indent = " " * 4 * level
         rootstring = "{}{}/".format(indent, basename(root))
         # Do not deal with hidden files
         if not basename(root).startswith("."):
@@ -293,9 +294,7 @@ def clean_folder(path, recreate=True):
 
 
 def clean_PETLinear(caps_path):
-    from os import listdir, makedirs, path
-    from os.path import abspath, exists
-    from shutil import rmtree
+    from os import listdir, path
 
     # Handle subjects subdirectory
     abs_path_subjs = path.join(caps_path, "subjects")
@@ -329,9 +328,9 @@ def create_list_hashes(path_folder, extensions_to_keep=(".nii.gz", ".tsv", ".jso
     import hashlib
     import os
 
-    def file_as_bytes(file):
-        with file:
-            return file.read()
+    def file_as_bytes(file_):
+        with file_:
+            return file_.read()
 
     all_files = []
     for subdir, dirs, files in os.walk(path_folder):


### PR DESCRIPTION
I was browsing the code for the non-regression tests and noticed a large number of warnings reported by PyCharm.

This merge request fixes the most critical ones.