### PR TITLE
NIFD: Fix error reporting when no imaging data found

### DIFF
--- a/clinica/iotools/converters/nifd_to_bids/nifd_utils.py
+++ b/clinica/iotools/converters/nifd_to_bids/nifd_utils.py
@@ -109,13 +109,13 @@ def find_imaging_data(imaging_data_directory: PathLike) -> Iterable[Tuple[str, s
 def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
     from pandas import DataFrame
 
-    imaging_data = DataFrame.from_records(
-        data=find_imaging_data(imaging_data_directory),
-        columns=["image_data_id", "source_dir"],
-        index="image_data_id",
-    ).convert_dtypes()
-
-    if imaging_data.empty:
+    try:
+        imaging_data = DataFrame.from_records(
+            data=find_imaging_data(imaging_data_directory),
+            columns=["image_data_id", "source_dir"],
+            index="image_data_id",
+        ).convert_dtypes()
+    except TypeError:
         raise FileNotFoundError("No imaging data found")
 
     collection_data = find_collection_data(imaging_data_directory)


### PR DESCRIPTION
DataFrame.from_records fails with a TypeError if the source iterator
yields no value instead of creating an empty dataframe. This change
replaces the useless empty dataframe check with an appropiate
try/catch block.