### PR TITLE
Specify openpyxl as read_excel engine for xlsx

### DIFF
--- a/clinica/iotools/converters/nifd_to_bids/nifd_utils.py
+++ b/clinica/iotools/converters/nifd_to_bids/nifd_utils.py
@@ -13,7 +13,7 @@ def find_clinical_data(clinical_data_directory: PathLike) -> Optional[DataFrame]
     for path in Path(clinical_data_directory).rglob("*.xlsx"):
         try:
             dataframe = (
-                read_excel(path, index_col=[0, 4])
+                read_excel(path, index_col=[0, 4], engine="openpyxl")
                 .rename(columns=lambda x: x.lower().replace(" ", "_"))
                 .rename_axis(index=lambda x: x.lower().replace(" ", "_"))
                 .convert_dtypes()


### PR DESCRIPTION
This is required for Python 3.6 users stuck with Pandas version 1.1.x. Since version 1.2.x (compatible with Python 3.7.1+), this can be omitted.