### PR TITLE
Open TSV files in text mode in NIFD and OASIS-3

### DIFF
--- a/clinica/iotools/converters/nifd_to_bids/nifd_utils.py
+++ b/clinica/iotools/converters/nifd_to_bids/nifd_utils.py
@@ -339,13 +339,13 @@ def write_bids(
 
     # Ensure BIDS hierarchy is written first.
     with fs.transaction:
-        with fs.open(to / "participants.tsv", "wb") as participant_file:
+        with fs.open(to / "participants.tsv", "w") as participant_file:
             write_to_tsv(participants, participant_file)
 
         for participant_id, sessions_group in sessions.groupby("participant_id"):
             sessions_group = sessions_group.droplevel("participant_id")
             sessions_filepath = to / participant_id / f"{participant_id}_sessions.tsv"
-            with fs.open(sessions_filepath, "wb") as sessions_file:
+            with fs.open(sessions_filepath, "w") as sessions_file:
                 write_to_tsv(sessions_group, sessions_file)
 
     # Perform import of imaging data next.

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -310,13 +310,13 @@ def write_bids(
 
     # Ensure BIDS hierarchy is written first.
     with fs.transaction:
-        with fs.open(to / "participants.tsv", "wb") as participant_file:
+        with fs.open(to / "participants.tsv", "w") as participant_file:
             write_to_tsv(participants, participant_file)
 
         for participant_id, sessions_group in sessions.groupby("participant_id"):
             sessions_group = sessions_group.droplevel("participant_id")
             sessions_filepath = to / participant_id / f"{participant_id}_sessions.tsv"
-            with fs.open(sessions_filepath, "wb") as sessions_file:
+            with fs.open(sessions_filepath, "w") as sessions_file:
                 write_to_tsv(sessions_group, sessions_file)
 
     # Perform import of imaging data next.


### PR DESCRIPTION
Binary write mode was only introduced in Pandas version 1.2. Use text mode instead for compatibility with Python 3.6 (Pandas version 1.1.x).