### PR TITLE
Fix dwi-connectome CLI

### DIFF
--- a/clinica/pipelines/dwi_connectome/dwi_connectome_cli.py
+++ b/clinica/pipelines/dwi_connectome/dwi_connectome_cli.py
@@ -13,6 +13,7 @@ pipeline_name = "dwi-connectome"
 @cli_param.option_group.option(
     "-nt",
     "--n_tracks",
+    type=int,
     default=1e6,
     show_default=True,
     help="Set the desired number of streamlines to generate the tractography and connectome.",


### PR DESCRIPTION
When running the `dwi-connectome` pipeline, I had the following error:

```
❯ clinica -v run dwi-connectome caps -np 2 -wd wd
2021-10-12 20:55:10,288:INFO:The pipeline will be run on the following subject(s): HMTC20110506MEMEPPAT27|M00
Traceback (most recent call last):
  File "/Users/alexandre.routier/Software/Miniconda3/envs/ClinicaDev/bin/clinica", line 5, in <module>
    main()
  File "/Users/alexandre.routier/Projects/Git/GitHub/alexandreroutier/clinica/clinica/cmdline.py", line 76, in main
    cli()
  File "/Users/alexandre.routier/Software/Miniconda3/envs/ClinicaDev/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/alexandre.routier/Software/Miniconda3/envs/ClinicaDev/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/alexandre.routier/Software/Miniconda3/envs/ClinicaDev/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/alexandre.routier/Software/Miniconda3/envs/ClinicaDev/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/alexandre.routier/Software/Miniconda3/envs/ClinicaDev/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/alexandre.routier/Software/Miniconda3/envs/ClinicaDev/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/alexandre.routier/Projects/Git/GitHub/alexandreroutier/clinica/clinica/pipelines/dwi_connectome/dwi_connectome_cli.py", line 53, in cli
    if n_procs
  File "/Users/alexandre.routier/Projects/Git/GitHub/alexandreroutier/clinica/clinica/pipelines/engine.py", line 261, in run
    self.build()
  File "/Users/alexandre.routier/Projects/Git/GitHub/alexandreroutier/clinica/clinica/pipelines/engine.py", line 25, in func_wrapper
    res = func(self, *args, **kwargs)
  File "/Users/alexandre.routier/Projects/Git/GitHub/alexandreroutier/clinica/clinica/pipelines/engine.py", line 232, in build
    self.build_core_nodes()
  File "/Users/alexandre.routier/Projects/Git/GitHub/alexandreroutier/clinica/clinica/pipelines/dwi_connectome/dwi_connectome_pipeline.py", line 418, in build_core_nodes
    tck_gen_node.inputs.select = self.parameters["n_tracks"]
  File "/Users/alexandre.routier/Software/Miniconda3/envs/ClinicaDev/lib/python3.7/site-packages/traits/base_trait_handler.py", line 75, in error
    object, name, self.full_info(object, name, value), value
traits.trait_errors.TraitError: The 'select' trait of a TractographyInputSpec instance must be an integer, but a value of 1000000.0 <class 'float'> was specified.
```

I simply set type to `int` for `n_track` argument.