### PR TITLE
add skip-question parameter to the tests

### DIFF
--- a/test/nonregression/pipelines/test_run_pipelines_anat.py
+++ b/test/nonregression/pipelines/test_run_pipelines_anat.py
@@ -143,10 +143,12 @@ def run_T1VolumeTissueSegmentation(
         T1VolumeTissueSegmentation,
     )
 
+    parameters = {"skip_question": False}
     pipeline = T1VolumeTissueSegmentation(
         bids_directory=fspath(input_dir / "bids"),
         caps_directory=fspath(output_dir / "caps"),
         tsv_file=fspath(input_dir / "subjects.tsv"),
+        parameters=parameters,
         base_dir=fspath(working_dir),
     )
     pipeline.build()

--- a/test/nonregression/pipelines/test_run_pipelines_pet.py
+++ b/test/nonregression/pipelines/test_run_pipelines_pet.py
@@ -40,6 +40,7 @@ def run_PETVolume(
         "group_label": "UnitTest",
         "acq_label": "fdg",
         "suvr_reference_region": "pons",
+        "skip_question": False,
     }
     pipeline = PETVolume(
         bids_directory=fspath(input_dir / "bids"),
@@ -132,6 +133,7 @@ def run_PETSurfaceCrossSectional(
         "suvr_reference_region": "pons",
         "pvc_psf_tsv": fspath(input_dir / "subjects.tsv"),
         "longitudinal": False,
+        "skip_question": False,
     }
     pipeline = PetSurface(
         bids_directory=fspath(input_dir / "bids"),


### PR DESCRIPTION
The skip-question parameter is missing from a few tests, causing them to crash, and therefore making the test unconclusive