### PR TITLE
Fix the pet_volume test

### DIFF
--- a/test/nonregression/pipelines/test_run_pipelines_pet.py
+++ b/test/nonregression/pipelines/test_run_pipelines_pet.py
@@ -61,7 +61,7 @@ def run_PETVolume(
         "sub-ADNI128S4832",
     ]
     out_files = [
-        (
+        fspath(
             output_dir
             / "caps"
             / "subjects"
@@ -75,7 +75,7 @@ def run_PETVolume(
         for sub in subjects
     ]
     ref_files = [
-        (
+        fspath(
             ref_dir
             / (
                 sub


### PR DESCRIPTION
The test does not work since ref_files and out_files are currently list of Path, not accepted. by nibabel.
To overcome this, we use fspath to transform the list of paths into list of strings, the same way it is done in the other tests.