### PR TITLE
Remove duplicate columns if found

### DIFF
--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -157,7 +157,7 @@ def create_merge_file(
                 )
 
                 # remove duplicated columns
-                row_df = row_df.loc[:, ~row_df.columns.duplicated()]
+                row_df = row_df.loc[:, ~row_df.columns.duplicated(keep="last")]
 
                 merged_df = merged_df.append(row_df)
 

--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -155,6 +155,10 @@ def create_merge_file(
                 row_df = pd.concat(
                     [row_participant_df, row_session_df, row_scans_df], axis=1
                 )
+
+                # remove duplicated columns
+                row_df = row_df.loc[:, ~row_df.columns.duplicated()]
+
                 merged_df = merged_df.append(row_df)
 
     # Put participant_id and session_id first


### PR DESCRIPTION
Following [Issue 478](https://github.com/aramis-lab/clinica/issues/478), `merge-tsv` is not currently robust to duplicate columns in the tsv files. 

A quick fix is to drop duplicates if found. Open to other suggestions.