### PR TITLE
Fix T1VolumeExistingTemplate chained invocation and smooth parameter

### DIFF
--- a/clinica/pipelines/cli_param/option.py
+++ b/clinica/pipelines/cli_param/option.py
@@ -88,7 +88,7 @@ smooth = option(
     "-s",
     "--smooth",
     multiple=True,
-    default=(8,),
+    default=[8],
     show_default=True,
     help="Specify the different isomorphic FWHM in millimeters to smooth the image.",
 )

--- a/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_cli.py
+++ b/clinica/pipelines/t1_volume_existing_template/t1_volume_existing_template_cli.py
@@ -26,7 +26,9 @@ pipeline_name = "t1-volume-existing-template"
 @cli_param.option.tissues
 @cli_param.option.modulate
 @cli_param.option.voxel_size
+@click.pass_context
 def cli(
+    ctx: click.Context,
     bids_directory: str,
     caps_directory: str,
     group_label: str,
@@ -69,7 +71,9 @@ def cli(
     )
 
     cprint("Part 1/4: Running t1-volume-segmentation pipeline")
-    t1_volume_tissue_segmentation_cli.cli(
+
+    ctx.invoke(
+        t1_volume_tissue_segmentation_cli.cli,
         bids_directory=bids_directory,
         caps_directory=caps_directory,
         tissue_classes=tissue_classes,
@@ -83,7 +87,8 @@ def cli(
     )
 
     cprint("Part 2/4: Running t1-volume-register-dartel pipeline")
-    t1_volume_register_dartel_cli.cli(
+    ctx.invoke(
+        t1_volume_register_dartel_cli.cli,
         bids_directory=bids_directory,
         caps_directory=caps_directory,
         group_label=group_label,
@@ -94,7 +99,8 @@ def cli(
     )
 
     cprint("Part 3/4: Running t1-volume-dartel2mni pipeline")
-    t1_volume_dartel2mni_cli.cli(
+    ctx.invoke(
+        t1_volume_dartel2mni_cli.cli,
         bids_directory=bids_directory,
         caps_directory=caps_directory,
         group_label=group_label,
@@ -108,7 +114,8 @@ def cli(
     )
 
     cprint("Part 4/4: Running t1-volume-parcellation pipeline")
-    t1_volume_parcellation_cli.cli(
+    ctx.invoke(
+        t1_volume_parcellation_cli.cli,
         caps_directory=caps_directory,
         group_label=group_label,
         subjects_sessions_tsv=subjects_sessions_tsv,


### PR DESCRIPTION
T1VolumeExistingTemplate chained pipelines were invoked with a deprecated method. Updated to align with T1FreesuferLongitudinal approach.

`smooth`  single element list default  parameter prompted a `Attempted to invoke composite type but nargs has been set to 1` TypeError