### PR TITLE
Correct the name of the test so the same one is not tested twice

### DIFF
--- a/test/nonregression/pipelines/test_run_pipelines_stats.py
+++ b/test/nonregression/pipelines/test_run_pipelines_stats.py
@@ -44,7 +44,7 @@ def test_run_stats(cmdopt, tmp_path, test_name):
         run_StatisticsVolume(input_dir, tmp_out_dir, ref_dir, working_dir)
 
     elif test_name == "StatisticsVolumeCorrection":
-        run_StatisticsVolume(input_dir, tmp_out_dir, ref_dir, working_dir)
+        run_StatisticsVolumeCorrection(input_dir, tmp_out_dir, ref_dir, working_dir)
 
     else:
         print(f"Test {test_name} not available.")


### PR DESCRIPTION
StatisticVolumeCorrection was not tested if the name is specified.