### PR TITLE
Fix typo in StatisticsSurface cli

### DIFF
--- a/clinica/pipelines/statistics_surface/statistics_surface_cli.py
+++ b/clinica/pipelines/statistics_surface/statistics_surface_cli.py
@@ -26,7 +26,7 @@ pipeline_name = "statistics-surface"
 @cli_param.option_group.pipeline_specific_options
 @cli_param.option_group.option(
     "-c",
-    "--covariate",
+    "--covariates",
     multiple=True,
     help=(
         "List of covariates. Each covariate must match the column name of the TSV file. "

--- a/clinica/pipelines/statistics_surface/statistics_surface_utils.py
+++ b/clinica/pipelines/statistics_surface/statistics_surface_utils.py
@@ -138,7 +138,7 @@ def covariates_to_design_matrix(contrast, covariates=None):
     """
     if covariates:
         # Convert string to list while handling case where several spaces are present
-        list_covariates = list(set(covariates.split(" ")))
+        list_covariates = list(covariates)
         try:
             list_covariates.remove("")
         except ValueError:

--- a/test/nonregression/pipelines/test_run_pipelines_stats.py
+++ b/test/nonregression/pipelines/test_run_pipelines_stats.py
@@ -20,7 +20,7 @@ warnings.filterwarnings("ignore")
     params=[
         "StatisticsSurface",
         "StatisticsVolume",
-        # "StatisticsVolumeCorrection",
+        "StatisticsVolumeCorrection",
     ]
 )
 def test_name(request):

--- a/test/nonregression/pipelines/test_run_pipelines_stats.py
+++ b/test/nonregression/pipelines/test_run_pipelines_stats.py
@@ -20,7 +20,7 @@ warnings.filterwarnings("ignore")
     params=[
         "StatisticsSurface",
         "StatisticsVolume",
-        "StatisticsVolumeCorrection",
+        # "StatisticsVolumeCorrection",
     ]
 )
 def test_name(request):
@@ -76,7 +76,7 @@ def run_StatisticsSurface(
         "glm_type": "group_comparison",
         "contrast": "group",
         # Optional parameters
-        "covariates": "age sex",
+        "covariates": ["age", "sex"],
     }
     pipeline = StatisticsSurface(
         caps_directory=fspath(caps_dir),


### PR DESCRIPTION
the command line argument `covariate` was spelled without an `s` but used as `covariates` in the call to cli()