### PR TITLE
Split Clinica and Nipype logging

### DIFF
--- a/clinica/cmdline.py
+++ b/clinica/cmdline.py
@@ -32,6 +32,7 @@ def setup_logging(verbose: bool = False) -> None:
     """
     import logging
     import sys
+    from logging.handlers import RotatingFileHandler as RFHandler
 
     import nipype
     from colorlog import ColoredFormatter, StreamHandler
@@ -52,6 +53,8 @@ def setup_logging(verbose: bool = False) -> None:
     clinica_logger.addHandler(console_handler)
 
     # Nipype logger configuration.
+    # Monkey-patch nipype to use Python's RFH logger.
+    nipype.utils.logger.RFHandler = RFHandler
     # Setup debug logging to file.
     nipype.config.enable_debug_mode()
     nipype.config.update_config(

--- a/clinica/cmdline.py
+++ b/clinica/cmdline.py
@@ -3,6 +3,7 @@
 The aim of this module is to execute pipelines from the command line,
 and gives to the user some other utils to work with the pipelines.
 """
+import os
 import sys
 
 import click
@@ -22,47 +23,52 @@ CONTEXT_SETTINGS = dict(
 )
 
 
-def setup_logging(verbosity: int = 0) -> None:
+def setup_logging(verbose: bool = False) -> None:
     """Setup Clinica's logging facilities.
 
     Args:
         verbosity (int): The desired level of verbosity for logging.
             (0 (default): WARNING, 1: INFO, 2: DEBUG)
     """
-    from logging import getLogger
-    from sys import stdout
+    import logging
+    import sys
 
     import nipype
     from colorlog import ColoredFormatter, StreamHandler
 
-    # Cap max verbosity level to 2.
-    verbosity = min(verbosity, 2)
+    logging_level = "DEBUG" if verbose else "INFO"
 
-    # Define the module level logger.
-    logger = getLogger("clinica")
-    logging_level = ["WARNING", "INFO", "DEBUG"][verbosity]
-    logger.setLevel(logging_level)
+    # Root logger configuration.
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging_level)
 
-    # Add console handler with custom formatting.
-    console_handler = StreamHandler(stdout)
+    # Clinica logger configuration.
+    clinica_logger = logging.getLogger("clinica")
+    clinica_logger.setLevel(logging_level)
+    console_handler = StreamHandler(stream=sys.stdout)
     console_handler.setFormatter(
         ColoredFormatter("%(log_color)s%(asctime)s:%(levelname)s:%(message)s")
     )
-    logger.addHandler(console_handler)
+    clinica_logger.addHandler(console_handler)
 
-    # Normalize nipype logging with Clinica's.
-    nipype.config.set("logging", "interface_level", logging_level)
-    nipype.config.set("logging", "workflow_level", logging_level)
+    # Nipype logger configuration.
+    # Setup debug logging to file.
+    nipype.config.enable_debug_mode()
+    nipype.config.update_config(
+        {"logging": {"log_directory": os.getcwd(), "log_to_file": True}}
+    )
     nipype.logging.update_logging(nipype.config)
+    # Disable nipype logging to console.
+    nipype_logger = logging.getLogger("nipype")
+    nipype_logger.removeHandler(nipype_logger.handlers[0])
+    nipype_logger.addHandler(logging.NullHandler())
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.version_option()
-@click.option(
-    "-v", "--verbose", "verbosity", count=True, help="Increase logging verbosity."
-)
-def cli(verbosity: int = 0) -> None:
-    setup_logging(verbosity=verbosity)
+@click.option("-v", "--verbose", is_flag=True, help="Increase logging verbosity.")
+def cli(verbose: bool) -> None:
+    setup_logging(verbose=verbose)
 
 
 cli.add_command(convert_cli)


### PR DESCRIPTION
Nipype's logging can become quite verbose and is only relevant under
abnormal circumstances. Moving its output to a separate file clears the
Clinica console output from unwanted nipype information regardless of
the desired verbosity, whilst providing the necessary debug information
for support requests.

This commit isolates Nipype's logging from Clinica's. Nipype now works
in debug mode and logs its output to a file instead of the console
previously. The verbosity option for Clinica has also been simplified to
two values (INFO and DEBUG) with INFO kept as default.

Closes #363 