### PR TITLE
Change folder test name

### DIFF
--- a/test/instantiation/test_instantiate_all_pipelines.py
+++ b/test/instantiation/test_instantiate_all_pipelines.py
@@ -17,7 +17,7 @@ def test_instantiate_T1FreeSurferCrossSectional(cmdopt):
     from clinica.pipelines.t1_freesurfer.t1_freesurfer_pipeline import T1FreeSurfer
 
     input_dir = Path(cmdopt["input"])
-    root = input_dir / "T1Freesurfer"
+    root = input_dir / "T1FreeSurfer"
 
     parameters = {
         "recon_all_args": "-qcache",


### PR DESCRIPTION
Folder name for instantiation test T1FreeSurfer has a wrong name (and the test fails if the OS is case sensitive).