### PR TITLE
Stop on first fail during regression testing

### DIFF
--- a/Jenkinsfile_nonregression
+++ b/Jenkinsfile_nonregression
@@ -9,6 +9,7 @@ pipeline {
   agent none
   stages {
     stage('Checkout') {
+      failFast true
       parallel {
         stage('Linux') {
           agent {


### PR DESCRIPTION
Considering the duration of the regression tests, perhaps it would be worth failing on first error?

For instance [here] the PET pipelines failed on MacOS early, while the Linux are still going a few hours later.

It's just a proposal, perhaps the current behavior is what we want.