### PR TITLE
Enable FreeSurfer to run with missing files

### DIFF
--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
@@ -32,7 +32,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
 
         image_ids = []
         if os.path.isdir(caps_directory):
-            preproc_files = clinica_file_reader(
+            preproc_files, _ = clinica_file_reader(
                 subjects, sessions, caps_directory, DWI_PREPROC_NII, False
             )
             image_ids = extract_image_ids(preproc_files)
@@ -426,9 +426,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
         # Step 4: Bias correction
         # =======================
         # Use implementation detailed in (Jeurissen et al., 2014)
-        bias = npe.Node(
-            mrtrix3.DWIBiasCorrect(use_ants=True), name="4-RemoveBias"
-        )
+        bias = npe.Node(mrtrix3.DWIBiasCorrect(use_ants=True), name="4-RemoveBias")
 
         # Step 5: Final brainmask
         # =======================

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_pipeline.py
@@ -38,7 +38,7 @@ class DwiPreprocessingUsingT1(cpe.Pipeline):
 
         image_ids = []
         if os.path.isdir(caps_directory):
-            preproc_files = clinica_file_reader(
+            preproc_files, _ = clinica_file_reader(
                 subjects, sessions, caps_directory, DWI_PREPROC_NII, False
             )
             image_ids = extract_image_ids(preproc_files)
@@ -306,9 +306,7 @@ class DwiPreprocessingUsingT1(cpe.Pipeline):
         # Susceptibility distortion correction using T1w image
         sdc = epi_pipeline(name="SusceptibilityDistortionCorrection")
         # Remove bias correction from (Jeurissen et al., 2014)
-        bias = npe.Node(
-            mrtrix3.DWIBiasCorrect(use_ants=True), name="RemoveBias"
-        )
+        bias = npe.Node(mrtrix3.DWIBiasCorrect(use_ants=True), name="RemoveBias")
         # Compute b0 mask on corrected avg b0
         compute_avg_b0 = npe.Node(
             nutil.Function(
@@ -321,9 +319,7 @@ class DwiPreprocessingUsingT1(cpe.Pipeline):
         compute_avg_b0.inputs.low_bval = self.parameters["low_bval"]
 
         # Compute brain mask from reference b0
-        mask_avg_b0 = npe.Node(
-            fsl.BET(mask=True, robust=True), name="MaskB0"
-        )
+        mask_avg_b0 = npe.Node(fsl.BET(mask=True, robust=True), name="MaskB0")
 
         # Print end message
         print_end_message = npe.Node(

--- a/clinica/pipelines/machine_learning/input.py
+++ b/clinica/pipelines/machine_learning/input.py
@@ -194,7 +194,7 @@ class CAPSVoxelBasedInput(CAPSInput):
                 use_pvc_data=self._input_params["use_pvc_data"],
                 fwhm=self._input_params["fwhm"],
             )
-            self._images = clinica_file_reader(
+            self._images, _ = clinica_file_reader(
                 self._subjects,
                 self._sessions,
                 self._input_params["caps_directory"],

--- a/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
+++ b/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
@@ -119,7 +119,7 @@ class SpatialSVM(cpe.Pipeline):
             )
 
         try:
-            input_image = clinica_file_reader(
+            input_image, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,

--- a/clinica/pipelines/pet_linear/pet_linear_pipeline.py
+++ b/clinica/pipelines/pet_linear/pet_linear_pipeline.py
@@ -116,7 +116,7 @@ class PETLinear(cpe.Pipeline):
         # pet file:
         PET_NII = bids_pet_nii(self.parameters["acq_label"])
         try:
-            pet_files = clinica_file_reader(
+            pet_files, _ = clinica_file_reader(
                 self.subjects, self.sessions, self.bids_directory, PET_NII
             )
         except ClinicaException as e:
@@ -128,7 +128,7 @@ class PETLinear(cpe.Pipeline):
 
         # T1w file:
         try:
-            t1w_files = clinica_file_reader(
+            t1w_files, _ = clinica_file_reader(
                 self.subjects, self.sessions, self.bids_directory, T1W_NII
             )
         except ClinicaException as e:

--- a/clinica/pipelines/pet_surface/pet_surface_pipeline.py
+++ b/clinica/pipelines/pet_surface/pet_surface_pipeline.py
@@ -91,7 +91,7 @@ class PetSurface(cpe.Pipeline):
 
         all_errors = []
         try:
-            read_parameters_node.inputs.pet = clinica_file_reader(
+            read_parameters_node.inputs.pet, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.bids_directory,
@@ -101,7 +101,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.orig_nu = clinica_file_reader(
+            read_parameters_node.inputs.orig_nu, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
@@ -112,7 +112,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.white_surface_right = clinica_file_reader(
+            read_parameters_node.inputs.white_surface_right, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
@@ -122,7 +122,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.white_surface_left = clinica_file_reader(
+            read_parameters_node.inputs.white_surface_left, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
@@ -133,7 +133,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.destrieux_left = clinica_file_reader(
+            read_parameters_node.inputs.destrieux_left, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
@@ -144,7 +144,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.destrieux_right = clinica_file_reader(
+            read_parameters_node.inputs.destrieux_right, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
@@ -155,7 +155,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.desikan_left = clinica_file_reader(
+            read_parameters_node.inputs.desikan_left, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
@@ -166,7 +166,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.desikan_right = clinica_file_reader(
+            read_parameters_node.inputs.desikan_right, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
@@ -229,7 +229,7 @@ class PetSurface(cpe.Pipeline):
         all_errors = []
         try:
 
-            read_parameters_node.inputs.pet = clinica_file_reader(
+            read_parameters_node.inputs.pet, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.bids_directory,
@@ -239,7 +239,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.orig_nu = clinica_file_reader(
+            read_parameters_node.inputs.orig_nu, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
@@ -249,7 +249,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.white_surface_right = clinica_file_reader(
+            read_parameters_node.inputs.white_surface_right, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
@@ -259,7 +259,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.white_surface_left = clinica_file_reader(
+            read_parameters_node.inputs.white_surface_left, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
@@ -269,7 +269,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.destrieux_left = clinica_file_reader(
+            read_parameters_node.inputs.destrieux_left, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
@@ -279,7 +279,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.destrieux_right = clinica_file_reader(
+            read_parameters_node.inputs.destrieux_right, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
@@ -289,7 +289,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.desikan_left = clinica_file_reader(
+            read_parameters_node.inputs.desikan_left, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
@@ -299,7 +299,7 @@ class PetSurface(cpe.Pipeline):
             all_errors.append(e)
 
         try:
-            read_parameters_node.inputs.desikan_right = clinica_file_reader(
+            read_parameters_node.inputs.desikan_right, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,

--- a/clinica/pipelines/pet_volume/pet_volume_pipeline.py
+++ b/clinica/pipelines/pet_volume/pet_volume_pipeline.py
@@ -135,7 +135,9 @@ class PETVolume(cpe.Pipeline):
 
         # Native T1w-MRI
         try:
-            t1w_bids, (self.subjects, self.sessions, self.bids_directory, T1W_NII)
+            t1w_bids, _ = clinica_file_reader(
+                self.subjects, self.sessions, self.bids_directory, T1W_NII
+            )
         except ClinicaException as e:
             all_errors.append(e)
 

--- a/clinica/pipelines/pet_volume/pet_volume_pipeline.py
+++ b/clinica/pipelines/pet_volume/pet_volume_pipeline.py
@@ -124,7 +124,7 @@ class PETVolume(cpe.Pipeline):
 
         # PET from BIDS directory
         try:
-            pet_bids = clinica_file_reader(
+            pet_bids, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.bids_directory,
@@ -145,7 +145,7 @@ class PETVolume(cpe.Pipeline):
         tissues_input = []
         for tissue_number in self.parameters["mask_tissues"]:
             try:
-                current_file = clinica_file_reader(
+                current_file, _ = clinica_file_reader(
                     self.subjects,
                     self.sessions,
                     self.caps_directory,
@@ -199,7 +199,7 @@ class PETVolume(cpe.Pipeline):
             pvc_tissues_input = []
             for tissue_number in self.parameters["pvc_mask_tissues"]:
                 try:
-                    current_file = clinica_file_reader(
+                    current_file, _ = clinica_file_reader(
                         self.subjects,
                         self.sessions,
                         self.caps_directory,

--- a/clinica/pipelines/pet_volume/pet_volume_pipeline.py
+++ b/clinica/pipelines/pet_volume/pet_volume_pipeline.py
@@ -135,9 +135,7 @@ class PETVolume(cpe.Pipeline):
 
         # Native T1w-MRI
         try:
-            t1w_bids = clinica_file_reader(
-                self.subjects, self.sessions, self.bids_directory, T1W_NII
-            )
+            t1w_bids, (self.subjects, self.sessions, self.bids_directory, T1W_NII)
         except ClinicaException as e:
             all_errors.append(e)
 
@@ -164,7 +162,7 @@ class PETVolume(cpe.Pipeline):
 
         # Flowfields
         try:
-            flowfields_caps = clinica_file_reader(
+            flowfields_caps, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,

--- a/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
+++ b/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
@@ -137,7 +137,7 @@ class StatisticsVolume(cpe.Pipeline):
             )
 
         try:
-            input_files = clinica_file_reader(
+            input_files, _ = clinica_file_reader(
                 self.subjects, self.sessions, self.caps_directory, information_dict
             )
         except ClinicaException as e:

--- a/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
@@ -137,15 +137,14 @@ class T1FreeSurfer(cpe.Pipeline):
         # T1w file:
         try:
             t1w_files = clinica_file_reader(
-                self.subjects, self.sessions, self.bids_directory, T1W_NII
+                self.subjects, self.sessions, self.bids_directory, T1W_NII, False
             )
         except ClinicaException as e:
             err_msg = (
                 "Clinica faced error(s) while trying to read files in your BIDS directory.\n"
                 + str(e)
             )
-            raise ClinicaBIDSError(err_msg)
-
+            print(ClinicaBIDSError(err_msg))
         # Save subjects to process in <WD>/<Pipeline.name>/participants.tsv
         folder_participants_tsv = os.path.join(self.base_dir, self.name)
         save_participants_sessions(

--- a/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
@@ -144,9 +144,8 @@ class T1FreeSurfer(cpe.Pipeline):
                 "Clinica faced error(s) while trying to read files in your BIDS directory.\n"
                 + str(e)
             )
-        print("t1w_files_pipeline:  ", t1w_files)
         if error_message != "":
-            print(error_message)
+            cprint(error_message, lvl="warning")
         if t1w_files == []:
             raise ClinicaException("Empty Dataset")
 

--- a/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
@@ -146,7 +146,7 @@ class T1FreeSurfer(cpe.Pipeline):
             )
         if error_message != "":
             cprint(error_message, lvl="warning")
-        if t1w_files == []:
+        if not t1w_files:
             raise ClinicaException("Empty Dataset")
 
         # Save subjects to process in <WD>/<Pipeline.name>/participants.tsv

--- a/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
@@ -144,7 +144,7 @@ class T1FreeSurfer(cpe.Pipeline):
                 "Clinica faced error(s) while trying to read files in your BIDS directory.\n"
                 + str(e)
             )
-        if error_message != "":
+        if error_message:
             cprint(error_message, lvl="warning")
         if not t1w_files:
             raise ClinicaException("Empty Dataset")

--- a/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
@@ -29,7 +29,7 @@ class T1FreeSurfer(cpe.Pipeline):
 
         image_ids = []
         if os.path.isdir(caps_directory):
-            t1_freesurfer_files = clinica_file_reader(
+            t1_freesurfer_files, _ = clinica_file_reader(
                 subjects, sessions, caps_directory, T1_FS_DESTRIEUX, False
             )
             image_ids = extract_image_ids(t1_freesurfer_files)
@@ -136,7 +136,7 @@ class T1FreeSurfer(cpe.Pipeline):
         # ========================
         # T1w file:
         try:
-            t1w_files = clinica_file_reader(
+            t1w_files, error_message = clinica_file_reader(
                 self.subjects, self.sessions, self.bids_directory, T1W_NII, False
             )
         except ClinicaException as e:
@@ -144,7 +144,12 @@ class T1FreeSurfer(cpe.Pipeline):
                 "Clinica faced error(s) while trying to read files in your BIDS directory.\n"
                 + str(e)
             )
-            print(ClinicaBIDSError(err_msg))
+        print("t1w_files_pipeline:  ", t1w_files)
+        if error_message != "":
+            print(error_message)
+        if t1w_files == []:
+            raise ClinicaException("Empty Dataset")
+
         # Save subjects to process in <WD>/<Pipeline.name>/participants.tsv
         folder_participants_tsv = os.path.join(self.base_dir, self.name)
         save_participants_sessions(

--- a/clinica/pipelines/t1_freesurfer_atlas/t1_freeesurfer_atlas_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer_atlas/t1_freeesurfer_atlas_pipeline.py
@@ -59,10 +59,10 @@ class T1FreeSurferAtlas(cpe.Pipeline):
                         "needed_pipeline": "t1-freesurfer",
                     }
                 )
-                t1_freesurfer_output = clinica_file_reader(
+                t1_freesurfer_output, _ = clinica_file_reader(
                     subjects, sessions, caps_directory, T1_FS_DESTRIEUX, False
                 )
-                t1_freesurfer_files = clinica_file_reader(
+                t1_freesurfer_files, _ = clinica_file_reader(
                     subjects, sessions, caps_directory, atlas_info, False
                 )
 

--- a/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_template_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_template_pipeline.py
@@ -27,7 +27,7 @@ class T1FreeSurferTemplate(cpe.Pipeline):
 
         image_ids = []
         if os.path.isdir(caps_directory):
-            t1_freesurfer_files = clinica_file_reader(
+            t1_freesurfer_files, _ = clinica_file_reader(
                 list_participant_id,
                 list_long_id,
                 caps_directory,
@@ -120,7 +120,10 @@ class T1FreeSurferTemplate(cpe.Pipeline):
                 cprint(f"{p_id} | {l_id}", lvl="warning")
             if self.overwrite_caps:
                 output_folder = "<CAPS>/subjects/<participant_id>/<long_id>/freesurfer_unbiased_template/"
-                cprint(f"Output folders in {output_folder} will be recreated.", lvl="warning")
+                cprint(
+                    f"Output folders in {output_folder} will be recreated.",
+                    lvl="warning",
+                )
             else:
                 cprint("Participant(s) will be ignored by Clinica.", lvl="warning")
                 input_ids = [

--- a/clinica/pipelines/t1_linear/t1_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/t1_linear_pipeline.py
@@ -31,7 +31,7 @@ class T1Linear(cpe.Pipeline):
 
         image_ids = []
         if os.path.isdir(caps_directory):
-            cropped_files = clinica_file_reader(
+            cropped_files, _ = clinica_file_reader(
                 subjects, sessions, caps_directory, T1W_LINEAR_CROPPED, False
             )
             image_ids = extract_image_ids(cropped_files)
@@ -135,7 +135,7 @@ class T1Linear(cpe.Pipeline):
         # ========================
         # T1w file:
         try:
-            t1w_files = clinica_file_reader(
+            t1w_files, _ = clinica_file_reader(
                 self.subjects, self.sessions, self.bids_directory, T1W_NII
             )
         except ClinicaException as e:

--- a/clinica/pipelines/t1_volume_create_dartel/t1_volume_create_dartel_pipeline.py
+++ b/clinica/pipelines/t1_volume_create_dartel/t1_volume_create_dartel_pipeline.py
@@ -90,7 +90,7 @@ class T1VolumeCreateDartel(cpe.Pipeline):
         d_input = []
         for tissue_number in self.parameters["dartel_tissues"]:
             try:
-                current_file = clinica_file_reader(
+                current_file, _ = clinica_file_reader(
                     self.subjects,
                     self.sessions,
                     self.caps_directory,
@@ -113,7 +113,9 @@ class T1VolumeCreateDartel(cpe.Pipeline):
 
         if len(self.subjects):
             print_images_to_process(self.subjects, self.sessions)
-            cprint("Computational time for DARTEL creation will depend on the number of images.")
+            cprint(
+                "Computational time for DARTEL creation will depend on the number of images."
+            )
             print_begin_image(f"group-{self.parameters['group_label']}")
 
         # fmt: off

--- a/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
+++ b/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
@@ -86,7 +86,7 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
         tissues_input = []
         for tissue_number in self.parameters["tissues"]:
             try:
-                native_space_tpm = clinica_file_reader(
+                native_space_tpm, _ = clinica_file_reader(
                     self.subjects,
                     self.sessions,
                     self.caps_directory,
@@ -107,7 +107,7 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
         # Flow Fields
         # ===========
         try:
-            read_input_node.inputs.flowfield_files = clinica_file_reader(
+            read_input_node.inputs.flowfield_files, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
@@ -66,7 +66,7 @@ class T1VolumeParcellation(cpe.Pipeline):
             )
 
         try:
-            gm_mni = clinica_file_reader(
+            gm_mni, _ = clinica_file_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,

--- a/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_pipeline.py
+++ b/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_pipeline.py
@@ -64,7 +64,7 @@ class T1VolumeRegisterDartel(cpe.Pipeline):
         d_input = []
         for tissue_number in self.parameters["tissues"]:
             try:
-                current_file = clinica_file_reader(
+                current_file, _ = clinica_file_reader(
                     self.subjects,
                     self.sessions,
                     self.caps_directory,

--- a/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
+++ b/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
@@ -81,7 +81,7 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
         # ========================
         # T1w file:
         try:
-            t1w_files = clinica_file_reader(
+            t1w_files, _ = clinica_file_reader(
                 self.subjects, self.sessions, self.bids_directory, T1W_NII
             )
         except ClinicaException as e:

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -317,36 +317,23 @@ def clinica_file_reader(
             results.append(current_glob_found[0])
 
     # We do not raise an error, so that the developper can gather all the problems before Clinica crashes
-    if len(error_encountered) > 0 and raise_exception is True:
-        error_message = (
-            f"Clinica encountered {len(error_encountered)} "
-            f"problem(s) while getting {information['description']}:\n"
-        )
-        if "needed_pipeline" in information.keys():
-            if information["needed_pipeline"]:
-                error_message += (
-                    "Please note that the following clinica pipeline(s) must "
-                    f"have run to obtain these files: {information['needed_pipeline']}\n"
-                )
+    error_message = (
+        f"Clinica encountered {len(error_encountered)} "
+        f"problem(s) while getting {information['description']}:\n"
+    )
+    if "needed_pipeline" in information.keys():
+        if information["needed_pipeline"]:
+            error_message += (
+                "Please note that the following clinica pipeline(s) must "
+                f"have run to obtain these files: {information['needed_pipeline']}\n"
+            )
         for msg in error_encountered:
             error_message += msg
+    if len(error_encountered) > 0 and raise_exception is True:
         if is_bids:
             raise ClinicaBIDSError(error_message)
         else:
             raise ClinicaCAPSError(error_message)
-    if len(error_encountered) > 0 and raise_exception is False:
-        error_message = (
-            f"Clinica encountered {len(error_encountered)} "
-            f"problem(s) while getting {information['description']}:\n"
-        )
-        if "needed_pipeline" in information.keys():
-            if information["needed_pipeline"]:
-                error_message += (
-                    "Please note that the following clinica pipeline(s) must "
-                    f"have run to obtain these files: {information['needed_pipeline']}\n"
-                )
-        for msg in error_encountered:
-            error_message += msg
     return results, error_message
 
 

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -327,8 +327,8 @@ def clinica_file_reader(
                 "Please note that the following clinica pipeline(s) must "
                 f"have run to obtain these files: {information['needed_pipeline']}\n"
             )
-        for msg in error_encountered:
-            error_message += msg
+    for msg in error_encountered:
+        error_message += msg
     if len(error_encountered) > 0 and raise_exception is True:
         if is_bids:
             raise ClinicaBIDSError(error_message)

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -329,6 +329,20 @@ def clinica_file_reader(
             raise ClinicaBIDSError(error_message)
         else:
             raise ClinicaCAPSError(error_message)
+    if len(error_encountered) > 0 and raise_exception is False:
+        error_message = (
+            f"Clinica encountered {len(error_encountered)} "
+            f"problem(s) while getting {information['description']}:\n"
+        )
+        if "needed_pipeline" in information.keys():
+            if information["needed_pipeline"]:
+                error_message += (
+                    "Please note that the following clinica pipeline(s) must "
+                    f"have run to obtain these files: {information['needed_pipeline']}\n"
+                )
+        for msg in error_encountered:
+            error_message += msg
+        print("Error message: ", error_message)
     return results
 
 
@@ -356,7 +370,7 @@ def clinica_list_of_files_reader(
     Returns:
         List[List[str]]: List of list of found files following order of `list_information`
     """
-    from .exceptions import ClinicaException, ClinicaBIDSError
+    from .exceptions import ClinicaBIDSError, ClinicaException
 
     all_errors = []
     list_found_files = []

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -253,7 +253,11 @@ def clinica_file_reader(
     """
     from os.path import join
 
-    from clinica.utils.exceptions import ClinicaBIDSError, ClinicaCAPSError
+    from clinica.utils.exceptions import (
+        ClinicaBIDSError,
+        ClinicaCAPSError,
+        ClinicaException,
+    )
 
     assert isinstance(
         information, dict
@@ -288,6 +292,7 @@ def clinica_file_reader(
 
     # results is the list containing the results
     results = []
+    error_message = ""
     # error is the list of the errors that happen during the whole process
     error_encountered = []
     for sub, ses in zip(subjects, sessions):
@@ -342,8 +347,7 @@ def clinica_file_reader(
                 )
         for msg in error_encountered:
             error_message += msg
-        print("Error message: ", error_message)
-    return results
+    return results, error_message
 
 
 def clinica_list_of_files_reader(
@@ -383,7 +387,7 @@ def clinica_list_of_files_reader(
                     bids_or_caps_directory,
                     info_file,
                     True,
-                )
+                )[0]
             )
         except ClinicaException as e:
             list_found_files.append([])


### PR DESCRIPTION
Clinica's file reader current version doesn't allow to visualize missing files (*T1w.nii.gz) and to run the pipeline at the same time.
To enable this and give more flexibility, we return the error message containing the missing files and the results together. the message will be empty if no files are missing. 