### PR TITLE
Normalize subprocess calls to dcm2niix

### DIFF
--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -761,7 +761,13 @@ def json_from_dcm(dcm_dir, json_path):
         cprint(msg=f"No DICOM found at {dcm_dir}", lvl="warning")
 
 
-def run_dcm2niix(command):
+def run_dcm2niix(
+    input_dir: str,
+    output_dir: str,
+    output_fmt: str,
+    compress: bool = False,
+    bids_sidecar: bool = True,
+) -> None:
     """Runs the dcm2niix command using a subprocess.
 
     Args: the dcm2niix command with the right arguments.
@@ -770,8 +776,14 @@ def run_dcm2niix(command):
 
     from clinica.utils.stream import cprint
 
-    output_dcm2niix = subprocess.run(command, shell=True, capture_output=True)
-    if output_dcm2niix.returncode != 0:
+    command = ["dcm2niix", "-w", "0", "-f", output_fmt, "-o", output_dir]
+    command += ["-9", "-z", "y"] if compress else ["-z", "n"]
+    command += ["-b", "y", "-ba", "y"] if bids_sidecar else ["-b", "n"]
+    command += [input_dir]
+
+    completed_process = subprocess.run(command, capture_output=True)
+
+    if completed_process.returncode != 0:
         cprint(
             msg=(
                 "DICOM to BIDS conversion with dcm2niix failed:\n"

--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -1179,8 +1179,13 @@ def create_file(image, modality, total, bids_dir, mod_to_update):
             zip_image = "y"
 
         if image.Is_Dicom:
-            command = f"dcm2niix -w 0 -b {generate_json} -z {zip_image} -o {output_path} -f {output_filename} {image_path}"
-            run_dcm2niix(command)
+            run_dcm2niix(
+                input_dir=image_path,
+                output_dir=output_path,
+                output_fmt=output_filename,
+                compress=True if zip_image == "y" else False,
+                bids_sidecar=True if generate_json == "y" else False,
+            )
 
             # If "_t" - the trigger delay time - exists in dcm2niix output filename, we remove it
             exception_t = glob(path.join(output_path, output_filename + "_t[0-9]*"))

--- a/clinica/iotools/converters/aibl_to_bids/aibl_utils.py
+++ b/clinica/iotools/converters/aibl_to_bids/aibl_utils.py
@@ -216,8 +216,13 @@ def dicom_to_nii(subject, output_path, output_filename, image_path):
             raise
 
     # if image.Is_Dicom:
-    command = f"dcm2niix -b n -z y -o {output_path} -f {output_filename} {image_path}"
-    run_dcm2niix(command)
+    run_dcm2niix(
+        input_dir=image_path,
+        output_dir=output_path,
+        output_fmt=output_filename,
+        compress=True,
+        bids_sidecar=False,
+    )
 
     nifti_file = os.path.join(output_path, output_filename + ".nii.gz")
 

--- a/clinica/iotools/converters/nifd_to_bids/nifd_utils.py
+++ b/clinica/iotools/converters/nifd_to_bids/nifd_utils.py
@@ -296,6 +296,7 @@ def convert_dicom(sourcedata_dir: PathLike, bids_filename: PathLike) -> None:
     from pathlib import Path
 
     from fsspec.implementations.local import LocalFileSystem
+    from clinica.iotools.bids_utils import run_dcm2niix
 
     output_fmt = str(Path(bids_filename).name).replace(".nii.gz", "")
     output_dir = str(Path(bids_filename).parent)
@@ -307,9 +308,12 @@ def convert_dicom(sourcedata_dir: PathLike, bids_filename: PathLike) -> None:
     fs.makedirs(output_dir)
 
     # Run conversion with dcm2niix with anonymization and maximum compression.
-    subprocess.run(
-        f"dcm2niix -9 -b y -ba y -f {output_fmt} -o {output_dir} -z i {sourcedata_dir}",
-        shell=True,
+    run_dcm2niix(
+        input_dir=sourcedata_dir,
+        output_dir=output_dir,
+        output_fmt=output_fmt,
+        compress=True,
+        bids_sidecar=True,
     )
 
 


### PR DESCRIPTION
All calls to dcm2niix now transit through the `run_dcm2niix` helper
function. Do not use shell=True to allow proper escaping of white
spacing in path arguments.

Closes #527 