### PR TITLE
Automate management of stale issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,3 +13,4 @@ jobs:
           stale-issue-message: 'This issue is stale because it has been inactive for 14 days. Remove the `stale` label or comment or it will be closed in 14 days.'
           days-before-stale: 14
           days-before-close: 14
+          start-date: '2022-01-01T00:00:00Z'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,6 +12,7 @@ jobs:
         with:
           stale-issue-message: 'This issue is stale because it has been inactive for 14 days. Remove the `stale` label or comment or it will be closed in 14 days.'
           stale-issue-label: 'inactive'
+          exempt-issue-labels: 'awaiting-feedback'
           days-before-stale: 14
           days-before-close: 14
           start-date: '2022-01-01T00:00:00Z'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/stale@v4
         with:
           stale-issue-message: 'This issue is stale because it has been inactive for 14 days. Remove the `stale` label or comment or it will be closed in 14 days.'
+          stale-issue-label: 'inactive'
           days-before-stale: 14
           days-before-close: 14
           start-date: '2022-01-01T00:00:00Z'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,4 +1,4 @@
-name: 'Close stale issues'
+name: 'Close inactive issues'
 
 on:
   schedule:
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'This issue is stale because it has been inactive for 14 days. Remove the `stale` label or comment or it will be closed in 14 days.'
+          stale-issue-message: 'This issue is considered stale because it has not received further activity for the last 14 days. You may remove the `inactive` label or add a comment, otherwise it will be closed after the next 14 days.'
           stale-issue-label: 'inactive'
           exempt-issue-labels: 'awaiting-feedback'
           days-before-stale: 14

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,15 @@
+name: 'Close stale issues'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'This issue is stale because it has been inactive for 14 days. Remove the `stale` label or comment or it will be closed in 14 days.'
+          days-before-stale: 14
+          days-before-close: 14


### PR DESCRIPTION
Issues are automatically labelled `stale` after 14 days of inactivity.
Issues are automatically closed after further 14 days of inactivity.

See: https://github.com/actions/stale