### PR TITLE
Do not let nipype check for updates

### DIFF
--- a/clinica/cmdline.py
+++ b/clinica/cmdline.py
@@ -59,7 +59,10 @@ def setup_logging(verbose: bool = False) -> None:
     # Setup debug logging to file.
     nipype.config.enable_debug_mode()
     nipype.config.update_config(
-        {"logging": {"log_directory": os.getcwd(), "log_to_file": True}}
+        {
+            "logging": {"log_directory": os.getcwd(), "log_to_file": True},
+            "execution": {"check_version": False},
+        },
     )
     nipype.logging.update_logging(nipype.config)
     # Disable nipype logging to console.


### PR DESCRIPTION
This feature leads to unnecessary spamming in the debug logs.

See: https://github.com/nipy/nipype/blob/master/nipype/utils/config.py#L64