### PR TITLE
Sort conversion_version folders when above 9

### DIFF
--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -815,7 +815,7 @@ def create_adni_scans_files(conversion_path, bids_subjs_paths):
         for folder in os.listdir(conversion_path)
         if folder[0] == "v" and path.isdir(path.join(conversion_path, folder))
     ]
-    conversion_versions.sort()
+    conversion_version = sorted(conversion_versions, key=lambda x: int(x.split("v")[1]))
     older_version = conversion_versions[-1]
     converted_dict = dict()
     for tsv_path in os.listdir(path.join(conversion_path, older_version)):


### PR DESCRIPTION
When the number of folders in `conversion_info` exceeded 9, the `adni-to-bids` converter was sorting the subfolders wrong (because of the way strings such as `v10` are sorted before `v9`). This would lead to inconsistent states and potential crashes. This PR fixes this issue.