### PR TITLE
Tighten the check on the session id values

### DIFF
--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -721,7 +721,7 @@ def create_adni_sessions_dict(
     # Nv/None refer to sessions whose session is undefined. "sc" is the screening session with unreliable (incomplete)
     # data.
     df_subj_session = df_subj_session[
-        df_subj_session.session_id.str.contains("ses-M\d*")
+        df_subj_session.session_id.str.contains("ses-M\d+")
     ]
     write_adni_sessions_tsv(df_subj_session, bids_subjs_paths)
 

--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -720,10 +720,9 @@ def create_adni_sessions_dict(
 
     # Nv/None refer to sessions whose session is undefined. "sc" is the screening session with unreliable (incomplete)
     # data.
-    df_subj_session = df_subj_session[
-        (~df_subj_session.session_id.isin(["ses-Nv", "sc", None]))
-    ]
-
+     df_subj_session = df_subj_session[
+        df_subj_session.session_id.str.contains("ses-M\d*")
+     ]
     write_adni_sessions_tsv(df_subj_session, bids_subjs_paths)
 
 

--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -720,9 +720,9 @@ def create_adni_sessions_dict(
 
     # Nv/None refer to sessions whose session is undefined. "sc" is the screening session with unreliable (incomplete)
     # data.
-     df_subj_session = df_subj_session[
+    df_subj_session = df_subj_session[
         df_subj_session.session_id.str.contains("ses-M\d*")
-     ]
+    ]
     write_adni_sessions_tsv(df_subj_session, bids_subjs_paths)
 
 


### PR DESCRIPTION
Some unwanted `session_id` values were copied from ADNI's metadata. This fix tighten the check on the format of the `session_id`