### PR TITLE
Disable DWI tests waiting for fix

### DIFF
--- a/Jenkinsfile_nonregression
+++ b/Jenkinsfile_nonregression
@@ -184,6 +184,42 @@ pipeline {
                 }
               }
             }
+            /* stage('DWI:nonreg') {
+              environment {
+                PATH = "/usr/local/Modules/bin:$PATH"
+                WORK_DIR = "/mnt/data/ci/working_dir_linux/DWI"
+                INPUT_DATA_DIR = "/mnt/data_ci"
+                TMP_DIR = "/mnt/data/ci/tmp"
+                }
+              steps {
+                sh '''
+                  source "${CONDA_HOME}/etc/profile.d/conda.sh"
+                  conda activate "${WORKSPACE}/env"
+                  mkdir -p $WORK_DIR
+                  source /usr/local/Modules/init/profile.sh
+                  module load clinica.all
+                  cd test
+                  poetry run pytest \
+                    --junitxml=./test-reports/nonregression_linux_dwi.xml \
+                    --verbose \
+                    --working_directory=$WORK_DIR \
+                    --input_data_directory=$INPUT_DATA_DIR \
+                    --basetemp=$TMP_DIR \
+                    --disable-warnings \
+                    --timeout=0 \
+                    -n 4 \
+                    ./nonregression/pipelines/test_run_pipelines_dwi.py
+                '''
+              }
+              post {
+                always {
+                  junit 'test/test-reports/*.xml'
+                }
+                success {
+                  sh 'rm -rf ${WORK_DIR}'
+                }
+              }
+            } */
           }
           post {
             always {
@@ -361,6 +397,41 @@ pipeline {
                 }
               }
             }
+        /* stage('DWI:nonreg') {
+              environment {
+                WORK_DIR = "/Volumes/data/working_dir_mac/DWI"
+                INPUT_DATA_DIR = "/Volumes/data_ci"
+                TMP_DIR = "/Volumes/data/tmp"
+              }
+              steps {
+                sh '''
+                  source "${CONDA_HOME}/etc/profile.d/conda.sh"
+                  conda activate "${WORKSPACE}/env"
+                  source "${BREW_PREFIX}/opt/modules/init/bash"
+                  mkdir -p $WORK_DIR
+                  module load clinica.all
+                  cd test
+                  poetry run pytest \
+                    --junitxml=./test-reports/nonregression_mac_dwi.xml \
+                    --verbose \
+                    --working_directory=$WORK_DIR \
+                    --input_data_directory=$INPUT_DATA_DIR \
+                    --basetemp=$TMP_DIR \
+                    --disable-warnings \
+                    --timeout=0 \
+                    -n 4 \
+                    ./nonregression/pipelines/test_run_pipelines_dwi.py
+                '''
+              }
+              post {
+                always {
+                  junit 'test/test-reports/*.xml'
+                }
+                success {
+                  sh 'rm -rf ${WORK_DIR}/*'
+                }
+              }
+            } */
           }
           post {
             always {

--- a/Jenkinsfile_nonregression
+++ b/Jenkinsfile_nonregression
@@ -184,42 +184,6 @@ pipeline {
                 }
               }
             }
-            stage('DWI:nonreg') {
-              environment {
-                PATH = "/usr/local/Modules/bin:$PATH"
-                WORK_DIR = "/mnt/data/ci/working_dir_linux/DWI"
-                INPUT_DATA_DIR = "/mnt/data_ci"
-                TMP_DIR = "/mnt/data/ci/tmp"
-                }
-              steps {
-                sh '''
-                  source "${CONDA_HOME}/etc/profile.d/conda.sh"
-                  conda activate "${WORKSPACE}/env"
-                  mkdir -p $WORK_DIR
-                  source /usr/local/Modules/init/profile.sh
-                  module load clinica.all
-                  cd test
-                  poetry run pytest \
-                    --junitxml=./test-reports/nonregression_linux_dwi.xml \
-                    --verbose \
-                    --working_directory=$WORK_DIR \
-                    --input_data_directory=$INPUT_DATA_DIR \
-                    --basetemp=$TMP_DIR \
-                    --disable-warnings \
-                    --timeout=0 \
-                    -n 4 \
-                    ./nonregression/pipelines/test_run_pipelines_dwi.py
-                '''
-              }
-              post {
-                always {
-                  junit 'test/test-reports/*.xml'
-                }
-                success {
-                  sh 'rm -rf ${WORK_DIR}'
-                }
-              }
-            }
           }
           post {
             always {
@@ -386,41 +350,6 @@ pipeline {
                     --timeout=0 \
                     -n 4 \
                     ./nonregression/pipelines/test_run_pipelines_anat.py
-                '''
-              }
-              post {
-                always {
-                  junit 'test/test-reports/*.xml'
-                }
-                success {
-                  sh 'rm -rf ${WORK_DIR}/*'
-                }
-              }
-            }
-            stage('DWI:nonreg') {
-              environment {
-                WORK_DIR = "/Volumes/data/working_dir_mac/DWI"
-                INPUT_DATA_DIR = "/Volumes/data_ci"
-                TMP_DIR = "/Volumes/data/tmp"
-              }
-              steps {
-                sh '''
-                  source "${CONDA_HOME}/etc/profile.d/conda.sh"
-                  conda activate "${WORKSPACE}/env"
-                  source "${BREW_PREFIX}/opt/modules/init/bash"
-                  mkdir -p $WORK_DIR
-                  module load clinica.all
-                  cd test
-                  poetry run pytest \
-                    --junitxml=./test-reports/nonregression_mac_dwi.xml \
-                    --verbose \
-                    --working_directory=$WORK_DIR \
-                    --input_data_directory=$INPUT_DATA_DIR \
-                    --basetemp=$TMP_DIR \
-                    --disable-warnings \
-                    --timeout=0 \
-                    -n 4 \
-                    ./nonregression/pipelines/test_run_pipelines_dwi.py
                 '''
               }
               post {


### PR DESCRIPTION
DWI tests currently fail on weekly non regression tests, preventing other tests from completing. This PR disables these tests until a fix has been found.