### PR TITLE
Add a forgotten output to clinica_file_reader

### DIFF
--- a/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
@@ -147,7 +147,7 @@ class T1FreeSurfer(cpe.Pipeline):
         if error_message:
             cprint(error_message, lvl="warning")
         if not t1w_files:
-            raise ClinicaException("Empty Dataset")
+            raise ClinicaException("Empty dataset or already processed")
 
         # Save subjects to process in <WD>/<Pipeline.name>/participants.tsv
         folder_participants_tsv = os.path.join(self.base_dir, self.name)

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -288,7 +288,7 @@ def clinica_file_reader(
         sessions
     ), "Subjects and sessions must have the same length"
     if len(subjects) == 0:
-        return []
+        return [], ""
 
     # results is the list containing the results
     results = []


### PR DESCRIPTION
When clinica_file_reader is called, if the inputs and outputs are the same (meaning the inputs have already been processed),  the function will exit early with a return.  One output of this return was missing.