### PR TITLE
Run project-wide format before release

### DIFF
--- a/clinica/iotools/bids_dataset_description.py
+++ b/clinica/iotools/bids_dataset_description.py
@@ -2,8 +2,8 @@ from enum import Enum
 from typing import IO
 
 import attr
-from cattr.preconf.json import make_converter
 from cattr.gen import make_dict_unstructure_fn, override
+from cattr.preconf.json import make_converter
 
 BIDS_VERSION = "1.6.0"
 

--- a/clinica/iotools/converters/aibl_to_bids/aibl_to_bids.py
+++ b/clinica/iotools/converters/aibl_to_bids/aibl_to_bids.py
@@ -26,7 +26,9 @@ def convert_images(path_to_dataset, path_to_csv, bids_dir, overwrite=False):
             if not exists(str(file)):
                 error_string = error_string + str(file) + "\n"
     if error_string != "":
-        cprint(msg=f"The following file were not converted: {error_string}", lvl="warning")
+        cprint(
+            msg=f"The following file were not converted: {error_string}", lvl="warning"
+        )
 
 
 def convert_clinical_data(bids_dir, path_to_csv):

--- a/clinica/iotools/converters/habs_to_bids/habs_to_bids.py
+++ b/clinica/iotools/converters/habs_to_bids/habs_to_bids.py
@@ -5,7 +5,6 @@ from typing import Dict, List, Optional, Tuple
 import pandas as pd
 from pandas import DataFrame, Series
 
-
 PROTOCOL_TO_BIDS = {
     "3DFLAIR": {"datatype": "anat", "modality": "FLAIR"},
     "ADNI_1X-MPRAGE": {"datatype": "anat", "modality": "T1w"},
@@ -192,6 +191,7 @@ def write_bids(
 ):
     import fsspec
     from pandas import notna
+
     from clinica.iotools.bids_dataset_description import BIDSDatasetDescription
 
     participants = (

--- a/clinica/iotools/converters/nifd_to_bids/nifd_utils.py
+++ b/clinica/iotools/converters/nifd_to_bids/nifd_utils.py
@@ -296,6 +296,7 @@ def convert_dicom(sourcedata_dir: PathLike, bids_filename: PathLike) -> None:
     from pathlib import Path
 
     from fsspec.implementations.local import LocalFileSystem
+
     from clinica.iotools.bids_utils import run_dcm2niix
 
     output_fmt = str(Path(bids_filename).name).replace(".nii.gz", "")
@@ -337,6 +338,7 @@ def write_bids(
     from pathlib import Path
 
     from fsspec.implementations.local import LocalFileSystem
+
     from clinica.iotools.bids_dataset_description import BIDSDatasetDescription
 
     to = Path(to)

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -304,6 +304,7 @@ def write_bids(
     from pathlib import Path
 
     from fsspec.implementations.local import LocalFileSystem
+
     from clinica.iotools.bids_dataset_description import BIDSDatasetDescription
 
     to = Path(to)

--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -192,11 +192,11 @@ def create_merge_file(
     if caps_dir is not None:
         # Call the different pipelines
         from .pipeline_handling import (
-            pet_volume_pipeline,
-            t1_freesurfer_pipeline,
-            t1_freesurfer_longitudinal_pipeline,
-            t1_volume_pipeline,
             dwi_dti_pipeline,
+            pet_volume_pipeline,
+            t1_freesurfer_longitudinal_pipeline,
+            t1_freesurfer_pipeline,
+            t1_volume_pipeline,
         )
 
         pipeline_options = {
@@ -936,6 +936,7 @@ def check_relative_volume_location_in_world_coordinate_system(
     from os.path import abspath, basename
 
     import numpy as np
+
     from clinica.utils.stream import cprint
 
     center_coordinate_1 = [get_world_coordinate_of_center(file) for file in nifti_list1]

--- a/clinica/iotools/utils/pipeline_handling.py
+++ b/clinica/iotools/utils/pipeline_handling.py
@@ -5,6 +5,7 @@ import os
 from glob import glob
 from os import path
 from typing import Tuple
+
 import pandas as pd
 
 
@@ -119,11 +120,12 @@ def t1_freesurfer_longitudinal_pipeline(
          final_df: a DataFrame containing the information of the bids and the pipeline
     """
 
+    from pathlib import Path
+
     from clinica.iotools.converters.adni_to_bids.adni_utils import (
         replace_sequence_chars,
     )
     from clinica.utils.stream import cprint
-    from pathlib import Path
 
     # Ensures that df is correctly indexed
     try:

--- a/clinica/pipelines/dwi_dti/dwi_dti_utils.py
+++ b/clinica/pipelines/dwi_dti/dwi_dti_utils.py
@@ -56,7 +56,9 @@ def extract_bids_identifier_from_caps_filename(caps_dwi_filename: str) -> str:
     m = re.search(r"(sub-[a-zA-Z0-9]+)_(ses-[a-zA-Z0-9]+).*_dwi", caps_dwi_filename)
 
     if not m:
-        raise ValueError(f"Input filename {caps_dwi_filename} is not in a CAPS compliant format.")
+        raise ValueError(
+            f"Input filename {caps_dwi_filename} is not in a CAPS compliant format."
+        )
     bids_identifier = m.group(0)
 
     return bids_identifier
@@ -71,7 +73,9 @@ def get_caps_filenames(caps_dwi_filename: str):
         caps_dwi_filename,
     )
     if not m:
-        raise ValueError(f"Input filename {caps_dwi_filename} is not in a CAPS compliant format.")
+        raise ValueError(
+            f"Input filename {caps_dwi_filename} is not in a CAPS compliant format."
+        )
 
     caps_prefix = m.group(0)
     bids_source = f"{m.group(1)}_{m.group(2)}_dwi"

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_utils.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_utils.py
@@ -119,6 +119,7 @@ def init_input_node(
     import datetime
 
     import nibabel as nib
+
     from clinica.utils.dwi import bids_dir_to_fsl_dir, check_dwi_volume
     from clinica.utils.filemanip import extract_metadata_from_json, get_subject_id
     from clinica.utils.stream import cprint
@@ -132,9 +133,7 @@ def init_input_node(
         check_dwi_volume(dwi, bvec, bval)
     except ValueError as e:
         now = datetime.datetime.now().strftime("%H:%M:%S")
-        error_msg = (
-            f"[{now}] Error: Number of DWIs, b-vals and b-vecs mismatch for {image_id.replace('_', ' | ')}"
-        )
+        error_msg = f"[{now}] Error: Number of DWIs, b-vals and b-vecs mismatch for {image_id.replace('_', ' | ')}"
         cprint(error_msg, lvl="error")
         raise ValueError(e)
 

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_utils.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_utils.py
@@ -88,7 +88,6 @@ def change_itk_transform_type(input_affine_file):
             else:
                 new_file_lines.append(line)
 
-
     updated_affine_file = os.path.join(os.getcwd(), "updated_affine.txt")
 
     with open(updated_affine_file, "wt") as f:

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
@@ -3,6 +3,7 @@ def eddy_fsl_pipeline(low_bval, use_cuda, initrand, name="eddy_fsl"):
     import nipype.interfaces.utility as niu
     import nipype.pipeline.engine as pe
     from nipype.interfaces.fsl.epi import Eddy
+
     from clinica.utils.dwi import generate_acq_file, generate_index_file
 
     inputnode = pe.Node(
@@ -105,8 +106,12 @@ def epi_pipeline(name="susceptibility_distortion_correction_using_t1"):
     import nipype.pipeline.engine as pe
 
     from .dwi_preprocessing_using_t1_utils import (
-        ants_combine_transform, change_itk_transform_type,
-        create_jacobian_determinant_image, expend_matrix_list, rotate_bvecs)
+        ants_combine_transform,
+        change_itk_transform_type,
+        create_jacobian_determinant_image,
+        expend_matrix_list,
+        rotate_bvecs,
+    )
 
     inputnode = pe.Node(
         niu.IdentityInterface(fields=["T1", "DWI", "bvec"]), name="inputnode"
@@ -273,8 +278,9 @@ def b0_flirt_pipeline(num_b0s, name="b0_coregistration"):
     """
     import nipype.interfaces.utility as niu
     import nipype.pipeline.engine as pe
-    from clinica.utils.dwi import merge_volumes_tdim
     from nipype.interfaces import fsl
+
+    from clinica.utils.dwi import merge_volumes_tdim
 
     inputnode = pe.Node(niu.IdentityInterface(fields=["in_file"]), name="inputnode")
     fslroi_ref = pe.Node(fsl.ExtractROI(args="0 1"), name="b0_reference")

--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -947,7 +947,9 @@ def get_wf(
     # Check that the PET file is a 3D volume
     img = nib.load(pet)
     if len(img.shape) == 4:
-        error_msg = f"Clinica does not handle 4D volumes for {subject_id} | {session_id}"
+        error_msg = (
+            f"Clinica does not handle 4D volumes for {subject_id} | {session_id}"
+        )
         cprint(error_msg, lvl="error")
         raise NotImplementedError(error_msg)
 

--- a/clinica/pipelines/pet_volume/pet_volume_utils.py
+++ b/clinica/pipelines/pet_volume/pet_volume_utils.py
@@ -11,7 +11,9 @@ def init_input_node(pet_nii):
     # Check that the PET file is a 3D volume
     img = nib.load(pet_nii)
     if len(img.shape) == 4:
-        error_msg = f"Clinica does not handle 4D volumes for {image_id.replace('_', ' | ')}"
+        error_msg = (
+            f"Clinica does not handle 4D volumes for {image_id.replace('_', ' | ')}"
+        )
         cprint(error_msg, lvl="error")
         raise NotImplementedError(error_msg)
 

--- a/clinica/pipelines/t1_freesurfer_longitudinal/longitudinal_utils.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/longitudinal_utils.py
@@ -52,7 +52,9 @@ def read_part_sess_long_ids_from_tsv(tsv_file):
 
     def check_key_in_data_frame(file, data_frame, key):
         if key not in list(data_frame.columns.values):
-            raise ClinicaException(f"The TSV file does not contain {key} column (path: {file})")
+            raise ClinicaException(
+                f"The TSV file does not contain {key} column (path: {file})"
+            )
 
     check_key_in_data_frame(tsv_file, df, "participant_id")
     check_key_in_data_frame(tsv_file, df, "session_id")

--- a/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_correction_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_correction_pipeline.py
@@ -90,7 +90,10 @@ class T1FreeSurferLongitudinalCorrection(cpe.Pipeline):
                 cprint(f"{image_id.replace('_', ' | ')}", lvl="warning")
             if self.overwrite_caps:
                 output_folder = "<CAPS>/subjects/<participant_id>/<session_id>/t1/<long_id>/freesurfer_longitudinal/"
-                cprint(msg=f"Output folders in {output_folder} will be recreated.", lvl="warning")
+                cprint(
+                    msg=f"Output folders in {output_folder} will be recreated.",
+                    lvl="warning",
+                )
             else:
                 cprint("Image(s) will be ignored by Clinica.", lvl="warning")
                 input_ids = [

--- a/clinica/utils/atlas.py
+++ b/clinica/utils/atlas.py
@@ -106,9 +106,10 @@ class JHUDTI811mm(AtlasAbstract):
     def get_atlas_labels():
         import os
 
+        import nipype.interfaces.fsl as fsl
+
         from .check_dependency import check_environment_variable
         from .inputs import _sha256
-        import nipype.interfaces.fsl as fsl
 
         fsl_dir = check_environment_variable("FSLDIR", "FSL")
         atlas_labels = os.path.join(

--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -184,8 +184,9 @@ def read_participant_tsv(tsv_file):
 
 def extract_metadata_from_json(json_file, list_keys):
     """Extract fields from JSON file."""
-    import json
     import datetime
+    import json
+
     from clinica.utils.exceptions import ClinicaException
 
     list_values = []
@@ -200,9 +201,7 @@ def extract_metadata_from_json(json_file, list_keys):
         )
     except KeyError as e:
         now = datetime.datetime.now().strftime("%H:%M:%S")
-        error_message = (
-            f"[{now}] Error: Clinica could not find the e key in the following JSON file: {json_file}"
-        )
+        error_message = f"[{now}] Error: Clinica could not find the e key in the following JSON file: {json_file}"
         raise ClinicaException(error_message)
     finally:
         file.close()

--- a/clinica/utils/input_files.py
+++ b/clinica/utils/input_files.py
@@ -424,15 +424,15 @@ def pet_linear_nii(acq_label, suvr_reference_region, uncropped_image):
 
     if uncropped_image:
         description = ""
-    else :
+    else:
         description = "_desc-Crop"
 
     information = {
         "pattern": os.path.join(
             "pet_linear",
-            f"*_acq-{acq_label}_pet_space-MNI152NLin2009cSym{description}_res-1x1x1_suvr-{suvr_reference_region}_pet.nii.gz"
+            f"*_acq-{acq_label}_pet_space-MNI152NLin2009cSym{description}_res-1x1x1_suvr-{suvr_reference_region}_pet.nii.gz",
         ),
         "description": "",
-        "needed_pipeline": "pet-linear"
+        "needed_pipeline": "pet-linear",
     }
     return information

--- a/clinica/utils/ux.py
+++ b/clinica/utils/ux.py
@@ -16,7 +16,9 @@ def print_images_to_process(list_participant_id, list_session_id):
         list_participant_id, list_session_id
     )
 
-    cprint(f"The pipeline will be run on the following {len(list_participant_id)} image(s):")
+    cprint(
+        f"The pipeline will be run on the following {len(list_participant_id)} image(s):"
+    )
     for i in range(0, min(len(unique_participants), LINES_TO_DISPLAY)):
         sessions_i_th_participant = ", ".join(
             s_id for s_id in sessions_per_participant[i]
@@ -89,18 +91,24 @@ def print_failed_images(cli_name, image_ids):
     )
 
     cprint(msg=f"The {cli_name} pipeline finished with errors.", lvl="error")
-    cprint(msg=f"CAPS outputs were not found for {len(image_ids)} image(s):", lvl="error")
+    cprint(
+        msg=f"CAPS outputs were not found for {len(image_ids)} image(s):", lvl="error"
+    )
     for i in range(0, min(len(unique_participants), LINES_TO_DISPLAY)):
         sessions_i_th_participant = ", ".join(
             s_id for s_id in sessions_per_participant[i]
         )
-        cprint(msg=f"{unique_participants[i]} | {sessions_i_th_participant}", lvl="error")
+        cprint(
+            msg=f"{unique_participants[i]} | {sessions_i_th_participant}", lvl="error"
+        )
 
     if len(unique_participants) > LINES_TO_DISPLAY:
         sessions_last_participant = ", ".join(
             s_id for s_id in sessions_per_participant[-1]
         )
-        cprint(msg=f"{unique_participants[-1]} | {sessions_last_participant}", lvl="error")
+        cprint(
+            msg=f"{unique_participants[-1]} | {sessions_last_participant}", lvl="error"
+        )
 
 
 def print_crash_files_and_exit(log_file, working_directory):


### PR DESCRIPTION
The current state of the code does not lint without errors, meaning code style drifted from the expected config.

This PR runs a project-wide format to normalize the formatting back to a state where it lints without errors.