### PR TITLE
Update call to clinica_file_reader with new signature

### DIFF
--- a/clinica/pipelines/pet_linear/pet_linear_pipeline.py
+++ b/clinica/pipelines/pet_linear/pet_linear_pipeline.py
@@ -141,7 +141,7 @@ class PETLinear(cpe.Pipeline):
         # Inputs from t1-linear pipeline
         # Transformation files from T1w files to MNI:
         try:
-            t1w_to_mni_transformation_files = clinica_file_reader(
+            t1w_to_mni_transformation_files, _ = clinica_file_reader(
                 self.subjects, self.sessions, self.caps_directory, T1W_TO_MNI_TRANSFORM
             )
         except ClinicaException as e:


### PR DESCRIPTION
[PR#524](https://github.com/aramis-lab/clinica/pull/524) changed the return type of `clinica_file_reader()` but did not update the a call of this function in `pet-linear` this caused the pipeline to run indefinitely. This PR fixes this issue.