### PR TITLE
Fix dwi t1

### DIFF
--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_utils.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_utils.py
@@ -167,7 +167,7 @@ def ants_combine_transform(fix_image, moving_image, ants_warp_affine):
     out_warped = os.path.abspath("out_warped.nii.gz")
 
     cmd = (
-        f"antsApplyTransforms -o {out_warp_field} -i {moving_image} -r {fix_image} "
+        f"antsApplyTransforms -o [{out_warp_field},1] -i {moving_image} -r {fix_image} "
         f"-t {ants_warp_affine[0]} -t {ants_warp_affine[1]} -t {ants_warp_affine[2]}"
     )
     os.system(cmd)
@@ -179,17 +179,6 @@ def ants_combine_transform(fix_image, moving_image, ants_warp_affine):
     os.system(cmd1)
 
     return out_warp_field, out_warped
-
-
-# def create_jacobian_determinant_image(imageDimension, deformationField, outputImage):
-#     import os
-
-#     outputImage = os.path.abspath(outputImage)
-
-#     cmd = f"CreateJacobianDeterminantImage {str(imageDimension)} {deformationField} {outputImage}"
-#     os.system(cmd)
-
-#     return outputImage
 
 
 def init_input_node(t1w, dwi, bvec, bval, dwi_json):

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_utils.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_utils.py
@@ -88,7 +88,6 @@ def change_itk_transform_type(input_affine_file):
             else:
                 new_file_lines.append(line)
 
-
     updated_affine_file = os.path.join(os.getcwd(), "updated_affine.txt")
 
     with open(updated_affine_file, "wt") as f:
@@ -168,29 +167,29 @@ def ants_combine_transform(fix_image, moving_image, ants_warp_affine):
     out_warped = os.path.abspath("out_warped.nii.gz")
 
     cmd = (
-        f"antsApplyTransforms -o [out_warp_field.nii.gz,1] -i {moving_image} -r {fix_image} "
-        f"-t {ants_warp_affine[0]} {ants_warp_affine[1]} {ants_warp_affine[2]}"
+        f"antsApplyTransforms -o {out_warp_field} -i {moving_image} -r {fix_image} "
+        f"-t {ants_warp_affine[0]} -t {ants_warp_affine[1]} -t {ants_warp_affine[2]}"
     )
     os.system(cmd)
 
     cmd1 = (
-        f"antsApplyTransforms -o out_warped.nii.gz -i {moving_image} -r {fix_image} "
-        f"-t {ants_warp_affine[0]} {ants_warp_affine[1]} {ants_warp_affine[2]}"
+        f"antsApplyTransforms -o {out_warped} -i {moving_image} -r {fix_image} "
+        f"-t {ants_warp_affine[0]} -t {ants_warp_affine[1]} -t {ants_warp_affine[2]}"
     )
     os.system(cmd1)
 
     return out_warp_field, out_warped
 
 
-def create_jacobian_determinant_image(imageDimension, deformationField, outputImage):
-    import os
+# def create_jacobian_determinant_image(imageDimension, deformationField, outputImage):
+#     import os
 
-    outputImage = os.path.abspath(outputImage)
+#     outputImage = os.path.abspath(outputImage)
 
-    cmd = f"CreateJacobianDeterminantImage {str(imageDimension)} {deformationField} {outputImage}"
-    os.system(cmd)
+#     cmd = f"CreateJacobianDeterminantImage {str(imageDimension)} {deformationField} {outputImage}"
+#     os.system(cmd)
 
-    return outputImage
+#     return outputImage
 
 
 def init_input_node(t1w, dwi, bvec, bval, dwi_json):

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
@@ -108,7 +108,6 @@ def epi_pipeline(name="susceptibility_distortion_correction_using_t1"):
     from .dwi_preprocessing_using_t1_utils import (
         ants_combine_transform,
         change_itk_transform_type,
-        create_jacobian_determinant_image,
         expend_matrix_list,
         rotate_bvecs,
     )

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
@@ -179,15 +179,6 @@ def epi_pipeline(name="susceptibility_distortion_correction_using_t1"):
         name="warp_filed",
     )
 
-    # jacobian = pe.MapNode(
-    #     interface=niu.Function(
-    #         input_names=["imageDimension", "deformationField", "outputImage"],
-    #         output_names=["outputImage"],
-    #         function=create_jacobian_determinant_image,
-    #     ),
-    #     iterfield=["deformationField"],
-    #     name="jacobian",
-    # )
     jacobian = pe.MapNode(
         interface=ants.CreateJacobianDeterminantImage(),
         iterfield=["deformationField"],


### PR DESCRIPTION
Dwi_preprocessing_using_t1 isn't currently working because of the deprecation of a few commands used in the code. This PR fixes the problem.