### PR TITLE
Remove GA from docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,10 +32,6 @@ extra_css:
   - css/clinica.css
 
 extra:
-  analytics:
-    provider: google
-    property: UA-106080699-1
-
   feature:
     tabs: true
 


### PR DESCRIPTION
The CNIL just ruled Goggle Analytics as breaking GDPR.

https://www.cnil.fr/fr/utilisation-de-google-analytics-et-transferts-de-donnees-vers-les-etats-unis-la-cnil-met-en-demeure