### PR TITLE
[MAINT] Remove deprecated pandas append method in ìotools`

### DIFF
--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -575,7 +575,7 @@ def write_scans_tsv(bids_dir, bids_ids, scans_dict):
                     )
                     # Insert the column filename as first value
                     row_to_append.insert(0, "filename", path.join(mod_name, file_name))
-                    scans_df = scans_df.append(row_to_append)
+                    scans_df = pd.concat([scans_df, row_to_append])
 
             scans_df = scans_df.set_index("filename").fillna("n/a")
             scans_df.to_csv(

--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -109,7 +109,7 @@ def create_merge_file(
                 row_session_df = pd.DataFrame([[session]], columns=["session_id"])
 
                 row_df = pd.concat([row_participant_df, row_session_df], axis=1)
-                merged_df = merged_df.append(row_df)
+                merged_df = pd.concat([merged_df, row_df])
 
         else:
             sessions_df = pd.read_csv(
@@ -172,7 +172,7 @@ def create_merge_file(
                 # remove duplicated columns
                 row_df = row_df.loc[:, ~row_df.columns.duplicated(keep="last")]
 
-                merged_df = merged_df.append(row_df)
+                merged_df = pd.concat([merged_df, row_df])
 
     # Put participant_id and session_id first
     col_list = merged_df.columns.values.tolist()


### PR DESCRIPTION
The Pandas Dataframe `append` method is [deprecated since 1.4.0](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.append.html#pandas.DataFrame.append).
This PR proposes to remove the deprecation warnings in a couple places in `iotools` by using the recommended `pd.concat` instead.