### PR TITLE
Fix NA value normalization in AIBL writer

### DIFF
--- a/clinica/iotools/converters/aibl_to_bids/aibl_utils.py
+++ b/clinica/iotools/converters/aibl_to_bids/aibl_utils.py
@@ -731,7 +731,8 @@ def create_participants_df_AIBL(
         else:
             participant_df["sex"][i] = "F"
 
-    participant_df.replace("-4", "n/a")
+    # Normalize known NA values.
+    participant_df.replace(-4, "n/a", inplace=True)
 
     # Delete all the rows of the subjects that are not available in the BIDS dataset
     if delete_non_bids_info:


### PR DESCRIPTION
Found this while fixing warnings in AIBL writer. `replace` does not work inplace by default so it was not doing anything.

Before:
```
sub-AIBL1607	1607	1943	M	1	-4	-4
sub-AIBL1608	1608	1935	M	1	4	3
sub-AIBL1609	1609	1947	F	1	-4	-4
sub-AIBL1610	1610	1932	M	2	4	3
sub-AIBL1611	1611	1940	F	2	-4	-4
sub-AIBL1613	1613	1939	M	2	3	3
sub-AIBL1614	1614	1940	M	1	-4	-4
sub-AIBL1615	1615	1932	M	1	3	3
sub-AIBL1616	1616	1937	F	1	4	3
sub-AIBL1618	1618	1947	M	1	3	3
```

After:
```
sub-AIBL1607	1607	1943	M	1	n/a	n/a
sub-AIBL1608	1608	1935	M	1	4	3
sub-AIBL1609	1609	1947	F	1	n/a	n/a
sub-AIBL1610	1610	1932	M	2	4	3
sub-AIBL1611	1611	1940	F	2	n/a	n/a
sub-AIBL1613	1613	1939	M	2	3	3
sub-AIBL1614	1614	1940	M	1	n/a	n/a
sub-AIBL1615	1615	1932	M	1	3	3
sub-AIBL1616	1616	1937	F	1	4	3
sub-AIBL1618	1618	1947	M	1	3	3
```