### PR TITLE
Separate outputs in get_output_fields

### DIFF
--- a/clinica/pipelines/pet_linear/pet_linear_pipeline.py
+++ b/clinica/pipelines/pet_linear/pet_linear_pipeline.py
@@ -43,7 +43,8 @@ class PETLinear(cpe.Pipeline):
             A list of (string) output fields name.
         """
         return [
-            "registered_pet, transform_mat",
+            "registered_pet",
+            "transform_mat",
             "registered_pet_in_t1w",
         ]  # Fill here the list
 


### PR DESCRIPTION
Fix  typo which inadvertently merged outputs  in get_output_fields.