### PR TITLE
Fix working directory for pet-surface

### DIFF
--- a/clinica/pipelines/pet_surface/pet_surface_pipeline.py
+++ b/clinica/pipelines/pet_surface/pet_surface_pipeline.py
@@ -406,7 +406,9 @@ class PetSurface(cpe.Pipeline):
         full_pipe.inputs.session_id = self.sessions
         full_pipe.inputs.caps_dir = self.caps_directory
         full_pipe.inputs.pvc_psf_tsv = self.parameters["pvc_psf_tsv"]
-        full_pipe.inputs.working_directory_subjects = self.base_dir
+        full_pipe.inputs.working_directory_subjects = os.path.join(
+            self.base_dir, self.name
+        )
         full_pipe.inputs.acq_label = self.parameters["acq_label"]
         full_pipe.inputs.suvr_reference_region = self.parameters[
             "suvr_reference_region"


### PR DESCRIPTION
This PR makes the `pet-surface` pipeline write to its reserved folder (like other PET pipelines do), instead of the root working directory directly.