### PR TITLE
Add missing source entities to scans file in HABS converter

### DIFF
--- a/clinica/iotools/converters/habs_to_bids/habs_to_bids.py
+++ b/clinica/iotools/converters/habs_to_bids/habs_to_bids.py
@@ -279,5 +279,5 @@ def write_bids(
 
         dataframe = dataframe.drop(columns=["source_zipfile", "source_filename"])
 
-        with fsspec.open(bids_basedir / "scans.tsv", mode="wb") as f:
+        with fsspec.open(bids_basedir / f"{bids_prefix}_scans.tsv", mode="wb") as f:
             write_to_tsv(dataframe, f)


### PR DESCRIPTION
Before:

```
ref/
├── dataset_description.json
├── participants.tsv
└── sub-HABS1NIBUB
    ├── ses-M00
    │   ├── anat
    │   │   ├── sub-HABS1NIBUB_ses-M00_FLAIR.nii.gz
    │   │   └── sub-HABS1NIBUB_ses-M00_T1w.nii.gz
    │   ├── pet
    │   │   └── sub-HABS1NIBUB_ses-M00_trc-11CPIB_pet.nii.gz
    │   └── scans.tsv
    ├── ses-M36
    │   ├── anat
    │   │   ├── sub-HABS1NIBUB_ses-M36_FLAIR.nii.gz
    │   │   └── sub-HABS1NIBUB_ses-M36_T1w.nii.gz
    │   ├── pet
    │   │   └── sub-HABS1NIBUB_ses-M36_trc-11CPIB_pet.nii.gz
    │   └── scans.tsv
    ├── ses-M60
    │   ├── anat
    │   │   ├── sub-HABS1NIBUB_ses-M60_FLAIR.nii.gz
    │   │   └── sub-HABS1NIBUB_ses-M60_T1w.nii.gz
    │   ├── pet
    │   │   └── sub-HABS1NIBUB_ses-M60_trc-11CPIB_pet.nii.gz
    │   └── scans.tsv
    └── sub-HABS1NIBUB_sessions.tsv
```

After:

```
ref/
├── dataset_description.json
├── participants.tsv
└── sub-HABS1NIBUB
    ├── ses-M00
    │   ├── anat
    │   │   ├── sub-HABS1NIBUB_ses-M00_FLAIR.nii.gz
    │   │   └── sub-HABS1NIBUB_ses-M00_T1w.nii.gz
    │   ├── pet
    │   │   └── sub-HABS1NIBUB_ses-M00_trc-11CPIB_pet.nii.gz
    │   └── sub-HABS1NIBUB_ses-M00_scans.tsv
    ├── ses-M36
    │   ├── anat
    │   │   ├── sub-HABS1NIBUB_ses-M36_FLAIR.nii.gz
    │   │   └── sub-HABS1NIBUB_ses-M36_T1w.nii.gz
    │   ├── pet
    │   │   └── sub-HABS1NIBUB_ses-M36_trc-11CPIB_pet.nii.gz
    │   └── sub-HABS1NIBUB_ses-M36_scans.tsv
    ├── ses-M60
    │   ├── anat
    │   │   ├── sub-HABS1NIBUB_ses-M60_FLAIR.nii.gz
    │   │   └── sub-HABS1NIBUB_ses-M60_T1w.nii.gz
    │   ├── pet
    │   │   └── sub-HABS1NIBUB_ses-M60_trc-11CPIB_pet.nii.gz
    │   └── sub-HABS1NIBUB_ses-M60_scans.tsv
    └── sub-HABS1NIBUB_sessions.tsv
```