### PR TITLE
Uncomment DWI non regression tests for linux

### DIFF
--- a/Jenkinsfile_nonregression
+++ b/Jenkinsfile_nonregression
@@ -184,7 +184,7 @@ pipeline {
                 }
               }
             }
-            /* stage('DWI:nonreg') {
+            stage('DWI:nonreg') {
               environment {
                 PATH = "/usr/local/Modules/bin:$PATH"
                 WORK_DIR = "/mnt/data/ci/working_dir_linux/DWI"
@@ -219,7 +219,7 @@ pipeline {
                   sh 'rm -rf ${WORK_DIR}'
                 }
               }
-            } */
+            } 
           }
           post {
             always {
@@ -326,7 +326,7 @@ pipeline {
                   sh 'rm -rf ${WORK_DIR}/*'
                 }
               }
-            } */
+            } 
             stage('ML:nonreg') {
               environment {
                 WORK_DIR = "/Volumes/data/working_dir_mac/ML"


### PR DESCRIPTION
CI data were updated and DWI tests can now normally run well. MacOS tests were not yet un-commented as it is yet left to decide what do do about ML tests not succeeding. 