### PR TITLE
Fix BIDS compliance of HABS converter

### DIFF
--- a/clinica/iotools/converters/habs_to_bids/habs_to_bids.py
+++ b/clinica/iotools/converters/habs_to_bids/habs_to_bids.py
@@ -200,7 +200,7 @@ def write_bids(
         .rename(
             columns={
                 "BiologicalSex": "sex",
-                "YrsOfEd": "education",
+                "YrsOfEd": "years_of_education",
             }
         )
         .xs("ses-M00", level="session_id")

--- a/clinica/iotools/converters/habs_to_bids/habs_to_bids.py
+++ b/clinica/iotools/converters/habs_to_bids/habs_to_bids.py
@@ -195,31 +195,17 @@ def write_bids(
     from clinica.iotools.bids_dataset_description import BIDSDatasetDescription
 
     participants = (
-        clinical_data["Demographics"][
-            [
-                "BiologicalSex",
-                "YrsOfEd",
-                "Race",
-                "Ethnicity",
-                "Holingshead",
-                "APOE_haplotype",
-                "E4_Status",
-            ]
-        ]
+        clinical_data["Demographics"]
+        .drop(columns="NP_Age")
         .rename(
             columns={
                 "BiologicalSex": "sex",
                 "YrsOfEd": "education",
-                "Race": "race",
-                "Ethnicity": "ethnicity",
-                "Holingshead": "holingshead",
-                "APOE_haplotype": "apoe_haplotype",
-                "E4_Status": "e4_status",
             }
         )
         .xs("ses-M00", level="session_id")
         .reset_index(level="date", drop=True)
-    )
+    ).rename(columns=str.lower)
 
     with fsspec.open(str(rawdata / "dataset_description.json"), mode="wt") as f:
         BIDSDatasetDescription(name="HABS").write(to=f)
@@ -237,7 +223,7 @@ def write_bids(
             .rename(columns={"HABS_DX": "diagnostic"})
             .reset_index(level="date", drop=True)
         )
-    )
+    ).rename(columns=str.lower)
 
     for participant_id, dataframe in sessions.groupby(["participant_id"]):
         sessions_file = rawdata / participant_id / f"{participant_id}_sessions.tsv"

--- a/clinica/iotools/converters/habs_to_bids/habs_to_bids.py
+++ b/clinica/iotools/converters/habs_to_bids/habs_to_bids.py
@@ -197,7 +197,6 @@ def write_bids(
     participants = (
         clinical_data["Demographics"][
             [
-                "NP_Age",
                 "BiologicalSex",
                 "YrsOfEd",
                 "Race",
@@ -209,7 +208,6 @@ def write_bids(
         ]
         .rename(
             columns={
-                "NP_Age": "age",
                 "BiologicalSex": "sex",
                 "YrsOfEd": "education",
                 "Race": "race",


### PR DESCRIPTION
Some more compliance related fixes for HABS:

- Only store `age` attribute at the session level
   Instead of both at the participant and session levels, which is not compliant with BIDS inheritance principle.

- Column names in tabular data all lowercase
   This is a recommandation from the BIDS specification to store tabular columns in `snake_case`.

- Use `years_of_education` instead of `education`
   Improves interpretation of this specific metadata attribute.