### PR TITLE
Fix PET entity parsing in iotools

### DIFF
--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -557,7 +557,7 @@ def compute_missing_mods(bids_dir, out_dir, output_prefix=""):
     subjects_paths_lists.sort()
 
     if len(subjects_paths_lists) == 0:
-        raise IOError("No subjects found or dataset not BIDS complaint.")
+        raise IOError("No subjects found or dataset not BIDS compliant.")
     # Check the modalities available for each session
     for ses in sessions_found:
         for sub_path in subjects_paths_lists:

--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -808,7 +808,7 @@ def center_all_nifti(bids_dir, output_dir, modality, center_all_files=False):
     from glob import glob
     from os import listdir
     from os.path import basename, isdir, isfile, join
-    from shutil import copy, copy2, copytree
+    from shutil import copy, copytree
 
     from clinica.utils.exceptions import ClinicaBIDSError
     from clinica.utils.inputs import check_bids_folder

--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -325,7 +325,8 @@ def find_mods_and_sess(bids_dir):
                 for pet_path in list_pet_paths:
                     pet_name = pet_path.split(os.sep)[-1].split(".")[0]
                     pet_name_tokens = pet_name.split("_")
-                    pet_acq = pet_name_tokens[3]
+                    # FIXME: Use an appropriate parser for entity extraction.
+                    pet_acq = pet_name_tokens[2]
                     if "pet" in mods_dict:
                         if "pet_" + pet_acq not in mods_dict["pet"]:
                             mods_dict["pet"].append("pet_" + pet_acq)

--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -1158,6 +1158,7 @@ def get_world_coordinate_of_center(nii_volume):
 
     import nibabel as nib
     import numpy as np
+    from nibabel.filebasedimages import ImageFileError
 
     from clinica.utils.stream import cprint
 
@@ -1166,7 +1167,7 @@ def get_world_coordinate_of_center(nii_volume):
 
     try:
         orig_nifti = nib.load(nii_volume)
-    except nib.filebasedimages.ImageFileError:
+    except ImageFileError:
         cprint(
             msg=f"File {nii_volume} could not be read by nibabel. Is it a valid NIfTI file ?",
             lvl="warning",

--- a/test/nonregression/iotools/test_run_utils.py
+++ b/test/nonregression/iotools/test_run_utils.py
@@ -10,7 +10,6 @@ import warnings
 from os import PathLike, fspath
 from pathlib import Path
 from test.nonregression.testing_tools import (
-    clean_folder,
     create_list_hashes,
     identical_subject_list,
     same_missing_modality_tsv,

--- a/test/nonregression/iotools/test_run_utils.py
+++ b/test/nonregression/iotools/test_run_utils.py
@@ -54,8 +54,6 @@ def run_createmergefile(
 ) -> None:
     import shutil
     from filecmp import cmp
-    from os import remove
-    from os.path import abspath, dirname, join
 
     import pandas as pd
 

--- a/test/nonregression/testing_tools.py
+++ b/test/nonregression/testing_tools.py
@@ -165,14 +165,14 @@ def same_missing_modality_tsv(file1, file2):
 
     # Extract data and form lists for both files
     subjects1 = list(df1.participant_id)
-    pet_AV45_1 = list(df1["pet_acq-AV45"])
-    pet_FDG_1 = list(df1["pet_acq-FDG"])
+    pet_AV45_1 = list(df1["pet_trc-18FAV45"])
+    pet_FDG_1 = list(df1["pet_trc-18FFDG"])
     t1w1 = list(df1.t1w)
     func_task_rest1 = list(df1["func_task-rest"])
 
     subjects2 = list(df2.participant_id)
-    pet_AV45_2 = list(df2["pet_acq-AV45"])
-    pet_FDG_2 = list(df2["pet_acq-FDG"])
+    pet_AV45_2 = list(df2["pet_trc-18FAV45"])
+    pet_FDG_2 = list(df2["pet_trc-18FFDG"])
     t1w2 = list(df2.t1w)
     func_task_rest2 = list(df2["func_task-rest"])
 


### PR DESCRIPTION
Entity parsing in some iotools rely on positional location of tokens, which is very fragile. This PR adjusts the location to the new standards adopted for PET, but a long term solution should be to resort to entity prefix parsing instead.

Requires synchronization of data for CI to pass.