### PR TITLE
BIDS-Compliance: rename `subjects` dir with name of pipeline

### DIFF
--- a/clinica/pipelines/dwi_dti/dwi_dti_pipeline.py
+++ b/clinica/pipelines/dwi_dti/dwi_dti_pipeline.py
@@ -132,12 +132,14 @@ class DwiDti(cpe.Pipeline):
         # Find container path from filename
         container_path = npe.Node(
             nutil.Function(
-                input_names=["bids_or_caps_filename"],
+                input_names=["bids_or_caps_filename", "output_root_dir_name"],
                 output_names=["container"],
                 function=container_from_filename,
             ),
             name="container_path",
         )
+
+        container_path.inputs.output_root_dir_name = self.name
 
         rename_into_caps = npe.Node(
             nutil.Function(

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
@@ -211,12 +211,14 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
         # =====================================
         container_path = npe.Node(
             nutil.Function(
-                input_names=["bids_or_caps_filename"],
+                input_names=["bids_or_caps_filename", "output_root_dir_name"],
                 output_names=["container"],
                 function=container_from_filename,
             ),
             name="container_path",
         )
+
+        container_path.inputs.output_root_dir_name = self.name
 
         rename_into_caps = npe.Node(
             nutil.Function(

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_pipeline.py
@@ -181,12 +181,14 @@ class DwiPreprocessingUsingT1(cpe.Pipeline):
         # =====================================
         container_path = npe.Node(
             nutil.Function(
-                input_names=["bids_or_caps_filename"],
+                input_names=["bids_or_caps_filename", "output_root_dir_name"],
                 output_names=["container"],
                 function=container_from_filename,
             ),
             name="container_path",
         )
+
+        container_path.inputs.output_root_dir_name = self.name
 
         rename_into_caps = npe.Node(
             nutil.Function(

--- a/clinica/pipelines/pet_linear/pet_linear_pipeline.py
+++ b/clinica/pipelines/pet_linear/pet_linear_pipeline.py
@@ -218,12 +218,15 @@ class PETLinear(cpe.Pipeline):
         )
         container_path = npe.Node(
             interface=nutil.Function(
-                input_names=["bids_or_caps_filename"],
+                input_names=["bids_or_caps_filename", "output_root_dir_name"],
                 output_names=["container"],
                 function=container_from_filename,
             ),
             name="containerPath",
         )
+
+        container_path.inputs.output_root_dir_name = self.name
+
         # fmt: off
         self.connect(
             [

--- a/clinica/pipelines/pet_volume/pet_volume_pipeline.py
+++ b/clinica/pipelines/pet_volume/pet_volume_pipeline.py
@@ -296,12 +296,14 @@ class PETVolume(cpe.Pipeline):
         # =====================================
         container_path = npe.Node(
             nutil.Function(
-                input_names=["bids_or_caps_filename"],
+                input_names=["bids_or_caps_filename", "output_root_dir_name"],
                 output_names=["container"],
                 function=container_from_filename,
             ),
             name="container_path",
         )
+
+        container_path.inputs.output_root_dir_name = self.name
         container_path.inputs.threshold = self.parameters["mask_threshold"]
 
         # Writing all images into CAPS

--- a/clinica/pipelines/t1_linear/t1_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/t1_linear_pipeline.py
@@ -192,12 +192,15 @@ class T1Linear(cpe.Pipeline):
         # Find container path from t1w filename
         container_path = npe.Node(
             nutil.Function(
-                input_names=["bids_or_caps_filename"],
+                input_names=["bids_or_caps_filename", "output_root_dir_name"],
                 output_names=["container"],
                 function=container_from_filename,
             ),
             name="ContainerPath",
         )
+
+        container_path.inputs.output_root_dir_name = self.name
+
         # fmt: off
         self.connect(
             [

--- a/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
+++ b/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
@@ -214,12 +214,14 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
         # =====================================
         container_path = npe.Node(
             nutil.Function(
-                input_names=["bids_or_caps_filename"],
+                input_names=["bids_or_caps_filename", "output_root_dir_name"],
                 output_names=["container"],
                 function=container_from_filename,
             ),
             name="ContainerPath",
         )
+
+        container_path.inputs.output_root_dir_name = self.name
 
         # Writing CAPS
         # ============

--- a/clinica/utils/nipype.py
+++ b/clinica/utils/nipype.py
@@ -2,9 +2,14 @@
 
 In particular, this module currently contains functions used for Nipype DataSink.
 """
+from nipype import config
+
+config.enable_debug_mode()
 
 
-def container_from_filename(bids_or_caps_filename: str) -> str:
+def container_from_filename(
+    bids_or_caps_filename: str, output_root_dir_name: str
+) -> str:
     """Extract container from BIDS or CAPS file.
 
     Args:
@@ -31,7 +36,7 @@ def container_from_filename(bids_or_caps_filename: str) -> str:
         )
     subject = m.group(1)
     session = m.group(2)
-    return os.path.join("subjects", subject, session)
+    return os.path.join(output_root_dir_name, subject, session)
 
 
 def fix_join(path, *paths):


### PR DESCRIPTION
This PR's purpose is to rename the root directory of the derivative outputs from `subjects` into `<pipeline-name>` which is what is recommended for BIDS derivatives. 

As the "subjects" directory is hard-coded in several places in the code, it would require to:

- [x] use the pipeline name in `container_from_filename()`
- [ ] replace hard-coded instances of "subjects" in `clinica/utils/inputs.py`  determine_caps_or_bids. As this is used by `clinica_file_reader` moving forward is delicate. Open to suggestions on this.
- [ ] replace "subjects" in pipelines not handled by `container_from_filename()`(e.g t1-freesurfer, pet-surface`
- [ ] Update the doc to reflect these changes