### PR TITLE
Disable macos non-regression tests in Jenkinsfile_nonregression

### DIFF
--- a/Jenkinsfile_nonregression
+++ b/Jenkinsfile_nonregression
@@ -257,42 +257,43 @@ pipeline {
                 '''
               }
             }
-            // stage("PET:nonreg") {
-            //   environment {
-            //     WORK_DIR = "/Volumes/data/working_dir_mac/PET"
-            //     INPUT_DATA_DIR = "/Volumes/data_ci"
-            //    TMP_DIR = "/Volumes/data/tmp"
-            //   }
-            //   steps {
-            //     sh '''
-            //       source "${CONDA_HOME}/etc/profile.d/conda.sh"
-            //       conda activate "${WORKSPACE}/env"
-            //       source /usr/local/opt/modules/init/bash
-            //       mkdir -p $WORK_DIR
-            //       module load clinica.all
-            //       cd test
-            //       poetry run pytest \
-            //         --junitxml=./test-reports/nonregression_mac_pet.xml \
-            //         --verbose \
-            //         --working_directory=$WORK_DIR \
-            //         --input_data_directory=$INPUT_DATA_DIR \
-            //         --basetemp=$TMP_DIR \
-            //         --disable-warnings \
-            //         --timeout=0 \
-            //         -n 4 \
-            //         ./nonregression/pipelines/test_run_pipelines_pet.py
-            //     '''
-            //   }
-            //   post {
-            //     always {
-            //       junit 'test/test-reports/*.xml'
-            //     }
-            //     success {
-            //       sh 'rm -rf ${WORK_DIR}/*'
-            //     }
-            //   }
-            // }
-            /* stage('Stats:nonreg') {
+            /* 
+            stage("PET:nonreg") {
+               environment {
+                 WORK_DIR = "/Volumes/data/working_dir_mac/PET"
+                 INPUT_DATA_DIR = "/Volumes/data_ci"
+                TMP_DIR = "/Volumes/data/tmp"
+               }
+               steps {
+                 sh '''
+                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
+                   conda activate "${WORKSPACE}/env"
+                   source /usr/local/opt/modules/init/bash
+                   mkdir -p $WORK_DIR
+                   module load clinica.all
+                   cd test
+                   poetry run pytest \
+                     --junitxml=./test-reports/nonregression_mac_pet.xml \
+                     --verbose \
+                     --working_directory=$WORK_DIR \
+                     --input_data_directory=$INPUT_DATA_DIR \
+                     --basetemp=$TMP_DIR \
+                     --disable-warnings \
+                     --timeout=0 \
+                     -n 4 \
+                     ./nonregression/pipelines/test_run_pipelines_pet.py
+                 '''
+               }
+               post {
+                 always {
+                   junit 'test/test-reports/*.xml'
+                 }
+                 success {
+                   sh 'rm -rf ${WORK_DIR}/*'
+                }
+               }
+             }
+            stage('Stats:nonreg') {
               environment {
                 WORK_DIR = "/Volumes/data/working_dir_mac/Stats"
                 INPUT_DATA_DIR = "/Volumes/data_ci"
@@ -397,7 +398,7 @@ pipeline {
                 }
               }
             }
-        /* stage('DWI:nonreg') {
+          stage('DWI:nonreg') {
               environment {
                 WORK_DIR = "/Volumes/data/working_dir_mac/DWI"
                 INPUT_DATA_DIR = "/Volumes/data_ci"


### PR DESCRIPTION
The non-regression tests fails because of a environment set-up problem in macos. Last run of scheduled tests failed to finish on linux as well. This PR comments out all the tests on macos temporarily to pinpoint the issue.