### PR TITLE
Skip empty dirs in compare_folders()

### DIFF
--- a/test/nonregression/testing_tools.py
+++ b/test/nonregression/testing_tools.py
@@ -236,6 +236,8 @@ def tree(dir: Path, file_out: Path):
     print(type(dir))
     file_content = ""
     for path in sorted(dir.rglob("*")):
+        if path.is_dir() and not any(path.iterdir()):
+            continue
         depth = len(path.relative_to(dir).parts)
         spacer = "    " * depth
         file_content = file_content + f"{spacer}+ {path.name}\n"

--- a/test/nonregression/testing_tools.py
+++ b/test/nonregression/testing_tools.py
@@ -233,6 +233,8 @@ def tree(dir: Path, file_out: Path):
 
     # Create a file (file_out) with a visual tree representing the file
     # hierarchy at a given directory
+    # Note: does not display empty directories
+
     print(type(dir))
     file_content = ""
     for path in sorted(dir.rglob("*")):


### PR DESCRIPTION
Quick fix for non-regression tests to skip empty directories when comparing