### PR TITLE
Filter rows with invalid session IDs in ADNI converter

### DIFF
--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -707,9 +707,14 @@ def create_adni_sessions_dict(
             df_filtered = filter_subj_bids(df_file, location, bids_ids).copy()
 
             if not df_filtered.empty:
+                # Get session ID from visit code.
                 df_filtered["session_id"] = df_filtered.apply(
                     lambda x: get_visit_id(x, location), axis=1
                 )
+
+                # Filter rows with invalid session IDs.
+                df_filtered.dropna(subset="session_id", inplace=True)
+
                 if location == "ADNIMERGE.csv":
                     df_filtered["AGE"] = df_filtered.apply(
                         lambda x: update_age(x), axis=1


### PR DESCRIPTION
Mapping from visit code to session ID may not be exhaustive enough, or invalid
visit codes may be present. In this case, null session IDs are produced and can
cause failures downstream. Filtering rows containing those invalid session IDs
provides safer guarantees to the rest of the processing.

Closes #632 