### PR TITLE
Remove superfluous code in T1Linear pipeline

### DIFF
--- a/clinica/pipelines/t1_linear/t1_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/t1_linear_pipeline.py
@@ -289,7 +289,6 @@ class T1Linear(cpe.Pipeline):
                 # Connect to DataSink
                 (image_id_node, self.output_node, [("image_id", "image_id")]),
                 (ants_registration_node, self.output_node, [("out_matrix", "affine_mat")]),
-                (n4biascorrection, self.output_node, [("output_image", "outfile_corr")]),
                 (ants_registration_node, self.output_node, [("warped_image", "outfile_reg")]),
                 (self.input_node, print_end_message, [("t1w", "t1w")]),
             ]

--- a/clinica/pipelines/t1_linear/t1_linear_utils.py
+++ b/clinica/pipelines/t1_linear/t1_linear_utils.py
@@ -2,14 +2,6 @@ def get_substitutions_datasink(bids_file):
 
     substitutions_ls = [  # registration
         (
-            f"{bids_file}_T1w_corrected.nii.gz",
-            f"{bids_file}_desc-BiasCorrected_T1w.nii.gz",
-        ),
-        (
-            f"{bids_file}Warped_cropped_intensity_norm.nii.gz",
-            f"{bids_file}_space-MNI152NLin2009cSym_res-1x1x1_intensity_norm_T1w.nii.gz",
-        ),
-        (
             f"{bids_file}Warped_cropped.nii.gz",
             f"{bids_file}_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_T1w.nii.gz",
         ),


### PR DESCRIPTION
This PR removes superflous node connections and substitutions from a past behaviour where the output of the intermediate bias field corrected image used to be saved as an output of the workflow. Now that this is no longer the case (not even with a parameter), it is worth getting rid of the dead code which only adds confusion to the process of transitionning the output of T1Linear to a BIDS compliant format.