### PR TITLE
Update unitest with swi folder in bidsignore

### DIFF
--- a/test/unittests/iotools/test_bids_utils.py
+++ b/test/unittests/iotools/test_bids_utils.py
@@ -104,7 +104,7 @@ def expected_content(name: str) -> str:
         return expected_readme_content()
     elif name == "bids-validator":
         return expected_validator_content()
-    return "\n".join(["conversion_info/"])
+    return "\n".join(["swi/", "conversion_info/"])
 
 
 @pytest.mark.parametrize("name,writer", MODALITY_AGNOSTIC_FILE_WRITERS.items())


### PR DESCRIPTION
After changes in UKB to `.bidsignore` the unittest failed on `test_write_modality_agnostic_files`. This PR updates the test with `swi/` that was added to `.bidsignore` writer.