### PR TITLE
ENH: Replace unzip_nii utility with Gunzip interface

### DIFF
--- a/clinica/pipelines/pet_volume/pet_volume_pipeline.py
+++ b/clinica/pipelines/pet_volume/pet_volume_pipeline.py
@@ -416,9 +416,9 @@ class PETVolume(cpe.Pipeline):
         import nipype.interfaces.spm.utils as spmutils
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
+        from nipype.algorithms.misc import Gunzip
         from nipype.interfaces.petpvc import PETPVC
 
-        from clinica.utils.filemanip import unzip_nii
         from clinica.utils.spm import spm_standalone_is_available, use_spm_standalone
 
         from .pet_volume_utils import (
@@ -448,45 +448,22 @@ class PETVolume(cpe.Pipeline):
 
         # Unzipping
         # =========
-        unzip_pet_image = npe.Node(
-            nutil.Function(
-                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
-            ),
-            name="unzip_pet_image",
-        )
+        unzip_pet_image = npe.Node(interface=Gunzip(), name="unzip_pet_image")
 
         unzip_t1_image_native = npe.Node(
-            nutil.Function(
-                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
-            ),
-            name="unzip_t1_image_native",
+            interface=Gunzip(), name="unzip_t1_image_native"
         )
 
-        unzip_flow_fields = npe.Node(
-            nutil.Function(
-                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
-            ),
-            name="unzip_flow_fields",
-        )
+        unzip_flow_fields = npe.Node(interface=Gunzip(), name="unzip_flow_fields")
 
         unzip_dartel_template = npe.Node(
-            nutil.Function(
-                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
-            ),
-            name="unzip_dartel_template",
+            interface=Gunzip(), name="unzip_dartel_template"
         )
 
-        unzip_reference_mask = npe.Node(
-            nutil.Function(
-                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
-            ),
-            name="unzip_reference_mask",
-        )
+        unzip_reference_mask = npe.Node(interface=Gunzip(), name="unzip_reference_mask")
 
         unzip_mask_tissues = npe.MapNode(
-            nutil.Function(
-                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
-            ),
+            interface=Gunzip(),
             name="unzip_mask_tissues",
             iterfield=["in_file"],
         )
@@ -614,11 +591,7 @@ class PETVolume(cpe.Pipeline):
             # Unzipping
             # =========
             unzip_pvc_mask_tissues = npe.MapNode(
-                nutil.Function(
-                    input_names=["in_file"],
-                    output_names=["out_file"],
-                    function=unzip_nii,
-                ),
+                interface=Gunzip(),
                 name="unzip_pvc_mask_tissues",
                 iterfield=["in_file"],
             )

--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -28,28 +28,6 @@ def zip_nii(in_file: str, same_dir: bool = False):
     return out_file
 
 
-def unzip_nii(in_file: str):
-    from nipype.algorithms.misc import Gunzip
-    from nipype.utils.filemanip import split_filename
-    from traits.trait_base import _Undefined
-
-    if (in_file is None) or isinstance(in_file, _Undefined):
-        return None
-
-    if not isinstance(in_file, str):  # type(in_file) is list:
-        return [unzip_nii(f) for f in in_file]
-
-    _, base, ext = split_filename(in_file)
-
-    # Not compressed
-    if ext[-3:].lower() != ".gz":
-        return in_file
-    # Compressed
-    gunzip = Gunzip(in_file=in_file)
-    gunzip.run()
-    return gunzip.aggregate_outputs().out_file
-
-
 def save_participants_sessions(participant_ids, session_ids, out_folder, out_file=None):
     """Save <participant_ids> <session_ids> in <out_folder>/<out_file> TSV file."""
     import os


### PR DESCRIPTION
Follow-up of #650, with one last replacement in the `pet-volume` pipeline.

Also drops the now defunct `unzip_nii` utility function.

As far as `zip_nii` is concerned, we'll have to wait for the next release of `nipype` where I have contributed a [Gzip interface](https://github.com/nipy/nipype/pull/3472) for compression. 