### PR TITLE
Parallel file reader

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: check-yaml
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -198,7 +198,10 @@ def clinica_file_reader(
                                                         file
         raise_exception: if True (normal behavior), an exception is raised if errors happen. If not, we return the file
                         list as it is
-        n_procs: number of cores used to run in parallel.
+        n_procs: int, optional
+            Number of cores used to run in parallel with Joblib.
+            If set to 0, subjects and sessions will be processed sequentially.
+            Default=0.
 
     Returns:
          list of files respecting the subject/session order provided in input,

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -181,7 +181,7 @@ def clinica_file_reader(
     input_directory,
     information,
     raise_exception=True,
-    n_procs=0,
+    n_procs: int = 1,
 ):
     """Read files in BIDS or CAPS directory based on participant ID(s).
 
@@ -199,9 +199,8 @@ def clinica_file_reader(
         raise_exception: if True (normal behavior), an exception is raised if errors happen. If not, we return the file
                         list as it is
         n_procs: int, optional
-            Number of cores used to run in parallel with Joblib.
-            If set to 0, subjects and sessions will be processed sequentially.
-            Default=0.
+            Number of cores used to fetch files in parallel (defaults to 1).
+            If set to 1, subjects and sessions will be processed sequentially.
 
     Returns:
          list of files respecting the subject/session order provided in input,
@@ -325,7 +324,7 @@ def clinica_file_reader(
     if len(subjects) == 0:
         return [], ""
 
-    if n_procs > 0:
+    if n_procs > 1:
         # results is the list containing the results
         shared_results = manager.list()
         # error is the list of the errors that happen during the whole process

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -175,6 +175,51 @@ def check_caps_folder(caps_directory):
         raise ClinicaCAPSError(error_string)
 
 
+def find_sub_ses_pattern_path(
+        input_directory: str,
+        subject: str,
+        session: str,
+        error_encountered: list,
+        results: list,
+        is_bids: bool,
+        pattern: str,
+):
+    """Appends the output path corresponding to subject, session and pattern in results.
+
+    If an error is encountered, its corresponding message is added to the list error_encountered.
+
+    Args:
+        input_directory: path to the root of the input directory (BIDS or CAPS).
+        subject: name given to the folder of a participant (ex: sub-ADNI002S0295).
+        session: name given to the folder of a session (ex: ses-M00).
+        error_encountered: list in which errors encountered in this function are added.
+        results: list in which the output path corresponding to subject, session and pattern is added.
+        is_bids: True if input_dir is a bids, False if input_dir is a CAPS.
+        pattern: define the pattern of the final file.
+    """
+    from os.path import join
+
+    if is_bids:
+        origin_pattern = join(input_directory, subject, session)
+    else:
+        origin_pattern = join(input_directory, "subjects", subject, session)
+
+    current_pattern = join(origin_pattern, "**/", pattern)
+    current_glob_found = insensitive_glob(current_pattern, recursive=True)
+
+    # Error handling if more than 1 file are found, or when no file is found
+    if len(current_glob_found) > 1:
+        error_str = f"\t*  ({subject} | {session}): More than 1 file found:\n"
+        for found_file in current_glob_found:
+            error_str += f"\t\t{found_file}\n"
+        error_encountered.append(error_str)
+    elif len(current_glob_found) == 0:
+        error_encountered.append(f"\t* ({subject} | {session}): No file found\n")
+    # Otherwise the file found is added to the result
+    else:
+        results.append(current_glob_found[0])
+
+
 def clinica_file_reader(
     subjects,
     sessions,
@@ -260,38 +305,13 @@ def clinica_file_reader(
 
     """
     from multiprocessing import Manager
-    from os.path import join
 
     from joblib import Parallel, delayed
 
     from clinica.utils.exceptions import (
         ClinicaBIDSError,
         ClinicaCAPSError,
-        ClinicaException,
     )
-
-    manager = Manager()
-
-    def find_sub_ses_pattern(input_directory, sub, ses, error_encountered, results):
-        if is_bids:
-            origin_pattern = join(input_directory, sub, ses)
-        else:
-            origin_pattern = join(input_directory, "subjects", sub, ses)
-
-        current_pattern = join(origin_pattern, "**/", pattern)
-        current_glob_found = insensitive_glob(current_pattern, recursive=True)
-
-        # Error handling if more than 1 file are found, or when no file is found
-        if len(current_glob_found) > 1:
-            error_str = f"\t*  ({sub} | {ses}): More than 1 file found:\n"
-            for found_file in current_glob_found:
-                error_str += f"\t\t{found_file}\n"
-            error_encountered.append(error_str)
-        elif len(current_glob_found) == 0:
-            error_encountered.append(f"\t* ({sub} | {ses}): No file found\n")
-        # Otherwise the file found is added to the result
-        else:
-            results.append(current_glob_found[0])
 
     assert isinstance(
         information, dict
@@ -325,13 +345,12 @@ def clinica_file_reader(
         return [], ""
 
     if n_procs > 1:
-        # results is the list containing the results
+        manager = Manager()
         shared_results = manager.list()
-        # error is the list of the errors that happen during the whole process
         shared_error_encountered = manager.list()
         Parallel(n_jobs=n_procs)(
-            delayed(find_sub_ses_pattern)(
-                input_directory, sub, ses, shared_error_encountered, shared_results
+            delayed(find_sub_ses_pattern_path)(
+                input_directory, sub, ses, shared_error_encountered, shared_results, is_bids, pattern
             )
             for sub, ses in zip(subjects, sessions)
         )
@@ -341,7 +360,7 @@ def clinica_file_reader(
         error_encountered = list()
         results = list()
         for sub, ses in zip(subjects, sessions):
-            find_sub_ses_pattern(input_directory, sub, ses, error_encountered, results)
+            find_sub_ses_pattern_path(input_directory, sub, ses, error_encountered, results, is_bids, pattern)
 
     # We do not raise an error, so that the developper can gather all the problems before Clinica crashes
     error_message = (

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -176,13 +176,13 @@ def check_caps_folder(caps_directory):
 
 
 def find_sub_ses_pattern_path(
-        input_directory: str,
-        subject: str,
-        session: str,
-        error_encountered: list,
-        results: list,
-        is_bids: bool,
-        pattern: str,
+    input_directory: str,
+    subject: str,
+    session: str,
+    error_encountered: list,
+    results: list,
+    is_bids: bool,
+    pattern: str,
 ):
     """Appends the output path corresponding to subject, session and pattern in results.
 
@@ -308,10 +308,7 @@ def clinica_file_reader(
 
     from joblib import Parallel, delayed
 
-    from clinica.utils.exceptions import (
-        ClinicaBIDSError,
-        ClinicaCAPSError,
-    )
+    from clinica.utils.exceptions import ClinicaBIDSError, ClinicaCAPSError
 
     assert isinstance(
         information, dict
@@ -350,7 +347,13 @@ def clinica_file_reader(
         shared_error_encountered = manager.list()
         Parallel(n_jobs=n_procs)(
             delayed(find_sub_ses_pattern_path)(
-                input_directory, sub, ses, shared_error_encountered, shared_results, is_bids, pattern
+                input_directory,
+                sub,
+                ses,
+                shared_error_encountered,
+                shared_results,
+                is_bids,
+                pattern,
             )
             for sub, ses in zip(subjects, sessions)
         )
@@ -360,7 +363,9 @@ def clinica_file_reader(
         error_encountered = list()
         results = list()
         for sub, ses in zip(subjects, sessions):
-            find_sub_ses_pattern_path(input_directory, sub, ses, error_encountered, results, is_bids, pattern)
+            find_sub_ses_pattern_path(
+                input_directory, sub, ses, error_encountered, results, is_bids, pattern
+            )
 
     # We do not raise an error, so that the developper can gather all the problems before Clinica crashes
     error_message = (


### PR DESCRIPTION
Hello :)

I am currently using the `extract` function of ClinicaDL which relies on `clinica_file_reader`, and on a large data set this takes forever.
This is why I propose to parallelize the `clinica_file_reader` with `joblib`.
I also changed the version of black used for the environment installation of pre-commit as I encountered the same error as in https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click (now it works).

Tell me if you need more explanations or if you think this should be done differently.
Best,