### PR TITLE
Call read_csv from the top-level pandas module

### DIFF
--- a/clinica/pipelines/machine_learning/input.py
+++ b/clinica/pipelines/machine_learning/input.py
@@ -616,7 +616,7 @@ class TsvInput(base.MLInput):
 
         import pandas as pd
 
-        self._dataframe = pd.io.parsers.read_csv(input_params["data_tsv"], sep="\t")
+        self._dataframe = pd.read_csv(input_params["data_tsv"], sep="\t")
 
         if not input_params["columns"]:
             raise Exception("List of columns to use as input can not be empty.")

--- a/clinica/pipelines/machine_learning/region_based_io.py
+++ b/clinica/pipelines/machine_learning/region_based_io.py
@@ -16,14 +16,12 @@ def load_data(image_list, subjects):
 
     subj_average = []
     all_vector = np.array([])
-    read_file = pd.io.parsers.read_csv(image_list[0], sep="\t", usecols=[2], header=0)
+    read_file = pd.read_csv(image_list[0], sep="\t", usecols=[2], header=0)
     read_file = read_file.mean_scalar
     data = np.zeros((len(subjects), len(read_file)))
 
     for i in range(len(image_list)):
-        tsv_file = pd.io.parsers.read_csv(
-            image_list[i], sep="\t", usecols=[2], header=0
-        )
+        tsv_file = pd.read_csv(image_list[i], sep="\t", usecols=[2], header=0)
         subj_average = tsv_file.mean_scalar
         all_vector = np.append(all_vector, subj_average)
     data_temp = np.split(all_vector, len(image_list))
@@ -59,11 +57,11 @@ def features_weights(image_list, dual_coefficients, sv_indices, scaler=None):
 
     sv_images = [image_list[i] for i in sv_indices]
 
-    shape = pd.io.parsers.read_csv(sv_images[0], sep="\t", usecols=[2], header=0)
+    shape = pd.read_csv(sv_images[0], sep="\t", usecols=[2], header=0)
     weights = np.zeros(len(shape))
 
     for i in range(len(sv_images)):
-        subj = pd.io.parsers.read_csv(sv_images[i], sep="\t", usecols=[2], header=0)
+        subj = pd.read_csv(sv_images[i], sep="\t", usecols=[2], header=0)
         subj_data = subj.mean_scalar
         weights += dual_coefficients[i] * subj_data
 

--- a/clinica/pipelines/machine_learning/tsv_based_io.py
+++ b/clinica/pipelines/machine_learning/tsv_based_io.py
@@ -18,7 +18,7 @@ def load_data(images, caps_directory, subjects, sessions, dataset):
 
     """
 
-    df = pd.io.parsers.read_csv(os.path.join(caps_directory), sep="\t")
+    df = pd.read_csv(os.path.join(caps_directory), sep="\t")
 
     all_vector = np.array([])
 

--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -142,7 +142,7 @@ def read_participant_tsv(tsv_file):
             f"\t- Clinica expected the following path to be a file: {tsv_file}\n"
             "\t- If you gave relative path, did you run Clinica on the good folder?"
         )
-    ss_df = pd.io.parsers.read_csv(tsv_file, sep="\t")
+    ss_df = pd.read_csv(tsv_file, sep="\t")
     if "participant_id" not in list(ss_df.columns.values):
         raise ClinicaException(
             f"The TSV file does not contain participant_id column (path: {tsv_file})"

--- a/clinica/utils/participant.py
+++ b/clinica/utils/participant.py
@@ -136,8 +136,8 @@ def have_same_subjects(tsv_file_1, tsv_file_2):
     """Return True if `tsv_file_1` and `tsv_file_2` have the same subjects, False otherwise."""
     import pandas as pd
 
-    tsv_df_1 = pd.io.parsers.read_csv(tsv_file_1, sep="\t")
-    tsv_df_2 = pd.io.parsers.read_csv(tsv_file_2, sep="\t")
+    tsv_df_1 = pd.read_csv(tsv_file_1, sep="\t")
+    tsv_df_2 = pd.read_csv(tsv_file_2, sep="\t")
     image_ids_1 = [
         f"{p_id}_{s_id}"
         for (p_id, s_id) in zip(

--- a/clinica/utils/pet.py
+++ b/clinica/utils/pet.py
@@ -43,7 +43,7 @@ def read_psf_information(pvc_psf_tsv, subject_ids, session_ids, pet_tracer):
     """
     import os
 
-    from pandas.io.parsers import read_csv
+    from pandas import read_csv
 
     if not os.path.isfile(pvc_psf_tsv):
         raise FileNotFoundError(f"Could not find the psf_tsv file {pvc_psf_tsv}")


### PR DESCRIPTION
Using `pd.io.parsers` triggers a `Cannot find reference` warning from code introspection in PyCharm. Anyway, the officially documented import for `read_csv` is the top-level `pandas` module, so we should normalize our code base to it.