### PR TITLE
[INFRA] Test basic install on all supported Python versions

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.8", "3.9", "3.10"]
-    name: ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    name: Install on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - '*'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test_install:
     runs-on: ${{ matrix.os }}
@@ -23,15 +27,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
         name: 'Setup python'
-      - shell: bash {0}
-        name: 'Display Python version'
+      - name: 'Display Python version'
         run: python -c "import sys; print(sys.version)"
-      - shell: bash {0}
+      - name: 'Install poetry'
         run: |
           python -m pip install poetry
-        name: 'Install poetry'
-      - shell: bash {0}
+      - name: 'Install Clinica'
         run: |
           poetry install
-        name: 'Install Clinica'
 

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -1,0 +1,37 @@
+name: 'test install'
+
+on:
+  push:
+    branches:
+      - "dev"
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test_install:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+        python-version: ["3.8", "3.9", "3.10"]
+    name: ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+        name: 'Setup python'
+      - shell: bash {0}
+        name: 'Display Python version'
+        run: python -c "import sys; print(sys.version)"
+      - shell: bash {0}
+        run: |
+          python -m pip install poetry
+        name: 'Install poetry'
+      - shell: bash {0}
+        run: |
+          poetry install
+        name: 'Install Clinica'
+


### PR DESCRIPTION
After reviewing #677 I thought it'd be great to test basic install on all supported platforms and python versions in order to spot these dependency issues early on.
This PR investigates the use of a GitHub action to do that.
Note: I will remove the trigger on pull requests once this is working and only test on push to the dev branch.