### PR TITLE
ci: Add caching support for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,17 +24,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
-        name: 'Setup python'
-      - name: 'Display Python version'
-        run: python -c "import sys; print(sys.version)"
-      - name: 'Install poetry'
-        run: |
-          python -m pip install poetry
+      - uses: snok/install-poetry@v1
+        with:
+          virtualenvs-in-project: true
+      - uses: actions/cache@v2
+        id: cache-venv
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: 'Install Clinica'
-        run: |
-          make install
+        run: make install
       - name: 'Run unit tests'
-        run: |
-          make test
+        run: make test

--- a/clinica/__init__.py
+++ b/clinica/__init__.py
@@ -1,8 +1,4 @@
-try:
-    from importlib.metadata import version
-except ImportError:
-    # Python 3.7 backport module.
-    from importlib_metadata import version
+from importlib.metadata import version
 
 __all__ = ["__version__"]
 


### PR DESCRIPTION
- Use `snok/install-poetry` GH action to deploy Poetry configured with inplace venv support.
- Cache the venv created by Poetry by product of OS, Python version and hash of the lock file.
- Cache miss happens if the Python version changes or the lock file is updated.