### PR TITLE
Add readthedocs deployment

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "miniconda3-4.7"
 
 mkdocs:
   configuration: mkdocs.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.8"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+conda:
+  environment: docs/environment.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,12 +7,16 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "miniconda3-4.7"
+    python: '3'
 
 mkdocs:
   configuration: mkdocs.yml
 
-conda:
-  environment: docs/environment.yml
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,4 +1,3 @@
-name: clinica_docs
 channels:
   - defaults
   - conda-forge


### PR DESCRIPTION
This PR adds support for deploying Clinica's documentation in readthedocs, initially, for testing purposes.