### PR TITLE
Revert gunzip use

### DIFF
--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -932,13 +932,13 @@ def get_wf(
     import nipype.interfaces.io as nio
     import nipype.interfaces.utility as niu
     import nipype.pipeline.engine as pe
-    from nipype.algorithms.misc import Gunzip
     from nipype.interfaces.freesurfer import ApplyVolTransform, MRIConvert, Tkregister2
     from nipype.interfaces.fsl import Merge
     from nipype.interfaces.petpvc import PETPVC
     from nipype.interfaces.spm import Coregister, Normalize12
 
     import clinica.pipelines.pet_surface.pet_surface_utils as utils
+    from clinica.utils.filemanip import unzip_nii
     from clinica.utils.pet import get_suvr_mask, read_psf_information
     from clinica.utils.spm import get_tpm
     from clinica.utils.stream import cprint
@@ -956,7 +956,14 @@ def get_wf(
     print_begin_image(subject_id + "_" + session_id)
 
     # Creation of workflow
-    unzip_pet = pe.Node(interface=Gunzip(), name="unzip_pet")
+    # 1 Creation of node
+    unzip_pet = pe.Node(
+        niu.Function(
+            input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+        ),
+        name="unzip_pet",
+    )
+
     unzip_orig_nu = unzip_pet.clone(name="unzip_orig_nu")
 
     unzip_mask = unzip_pet.clone(name="unzip_mask")

--- a/clinica/pipelines/pet_volume/pet_volume_pipeline.py
+++ b/clinica/pipelines/pet_volume/pet_volume_pipeline.py
@@ -416,9 +416,9 @@ class PETVolume(cpe.Pipeline):
         import nipype.interfaces.spm.utils as spmutils
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
-        from nipype.algorithms.misc import Gunzip
         from nipype.interfaces.petpvc import PETPVC
 
+        from clinica.utils.filemanip import unzip_nii
         from clinica.utils.spm import spm_standalone_is_available, use_spm_standalone
 
         from .pet_volume_utils import (
@@ -448,22 +448,45 @@ class PETVolume(cpe.Pipeline):
 
         # Unzipping
         # =========
-        unzip_pet_image = npe.Node(interface=Gunzip(), name="unzip_pet_image")
+        unzip_pet_image = npe.Node(
+            nutil.Function(
+                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+            ),
+            name="unzip_pet_image",
+        )
 
         unzip_t1_image_native = npe.Node(
-            interface=Gunzip(), name="unzip_t1_image_native"
+            nutil.Function(
+                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+            ),
+            name="unzip_t1_image_native",
         )
 
-        unzip_flow_fields = npe.Node(interface=Gunzip(), name="unzip_flow_fields")
+        unzip_flow_fields = npe.Node(
+            nutil.Function(
+                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+            ),
+            name="unzip_flow_fields",
+        )
 
         unzip_dartel_template = npe.Node(
-            interface=Gunzip(), name="unzip_dartel_template"
+            nutil.Function(
+                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+            ),
+            name="unzip_dartel_template",
         )
 
-        unzip_reference_mask = npe.Node(interface=Gunzip(), name="unzip_reference_mask")
+        unzip_reference_mask = npe.Node(
+            nutil.Function(
+                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+            ),
+            name="unzip_reference_mask",
+        )
 
         unzip_mask_tissues = npe.MapNode(
-            interface=Gunzip(),
+            nutil.Function(
+                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+            ),
             name="unzip_mask_tissues",
             iterfield=["in_file"],
         )
@@ -591,7 +614,11 @@ class PETVolume(cpe.Pipeline):
             # Unzipping
             # =========
             unzip_pvc_mask_tissues = npe.MapNode(
-                interface=Gunzip(),
+                nutil.Function(
+                    input_names=["in_file"],
+                    output_names=["out_file"],
+                    function=unzip_nii,
+                ),
                 name="unzip_pvc_mask_tissues",
                 iterfield=["in_file"],
             )

--- a/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
+++ b/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
@@ -278,12 +278,19 @@ class StatisticsVolume(cpe.Pipeline):
 
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
-        from nipype.algorithms.misc import Gunzip
 
         import clinica.pipelines.statistics_volume.statistics_volume_utils as utils
+        from clinica.utils.filemanip import unzip_nii
 
         # SPM cannot handle zipped files
-        unzip_node = npe.Node(interface=Gunzip(), name="unzip_node")
+        unzip_node = npe.Node(
+            nutil.Function(
+                input_names=["in_file"],
+                output_names=["output_files"],
+                function=unzip_nii,
+            ),
+            name="unzip_node",
+        )
 
         # Get indexes of the 2 groups, based on the contrast column of the tsv file
         get_groups = npe.Node(
@@ -433,7 +440,7 @@ class StatisticsVolume(cpe.Pipeline):
         self.connect(
             [
                 (self.input_node, unzip_node, [("input_files", "in_file")]),
-                (unzip_node, model_creation, [("out_file", "file_list")]),
+                (unzip_node, model_creation, [("output_files", "file_list")]),
                 (get_groups, model_creation, [("idx_group1", "idx_group1")]),
                 (get_groups, model_creation, [("idx_group2", "idx_group2")]),
                 (model_creation, run_spm_model_creation, [("script_file", "m_file")]),

--- a/clinica/pipelines/t1_volume_create_dartel/t1_volume_create_dartel_pipeline.py
+++ b/clinica/pipelines/t1_volume_create_dartel/t1_volume_create_dartel_pipeline.py
@@ -210,9 +210,10 @@ class T1VolumeCreateDartel(cpe.Pipeline):
     def build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.spm as spm
+        import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
-        from nipype.algorithms.misc import Gunzip
 
+        from clinica.utils.filemanip import unzip_nii
         from clinica.utils.spm import spm_standalone_is_available, use_spm_standalone
 
         if spm_standalone_is_available():
@@ -221,7 +222,9 @@ class T1VolumeCreateDartel(cpe.Pipeline):
         # Unzipping
         # =========
         unzip_node = npe.MapNode(
-            interface=Gunzip(),
+            nutil.Function(
+                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+            ),
             name="unzip_node",
             iterfield=["in_file"],
         )

--- a/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
+++ b/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
@@ -214,8 +214,8 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
         import nipype.interfaces.spm as spm
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
-        from nipype.algorithms.misc import Gunzip
 
+        from clinica.utils.filemanip import unzip_nii
         from clinica.utils.spm import spm_standalone_is_available, use_spm_standalone
 
         from ..t1_volume_dartel2mni import (
@@ -228,17 +228,23 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
         # Unzipping
         # =========
         unzip_tissues_node = npe.MapNode(
-            interface=Gunzip(),
+            nutil.Function(
+                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+            ),
             name="unzip_tissues_node",
             iterfield=["in_file"],
         )
         unzip_flowfields_node = npe.MapNode(
-            interface=Gunzip(),
+            nutil.Function(
+                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+            ),
             name="unzip_flowfields_node",
             iterfield=["in_file"],
         )
         unzip_template_node = npe.Node(
-            interface=Gunzip(),
+            nutil.Function(
+                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+            ),
             name="unzip_template_node",
         )
 

--- a/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_pipeline.py
+++ b/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_pipeline.py
@@ -167,20 +167,25 @@ class T1VolumeRegisterDartel(cpe.Pipeline):
 
     def build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
+        import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
-        from nipype.algorithms.misc import Gunzip
 
         import clinica.pipelines.t1_volume_register_dartel.t1_volume_register_dartel_utils as utils
+        from clinica.utils.filemanip import unzip_nii
 
         # Unzipping
         # =========
         unzip_dartel_input_node = npe.MapNode(
-            interface=Gunzip(),
+            nutil.Function(
+                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+            ),
             name="unzip_dartel_input_node",
             iterfield=["in_file"],
         )
         unzip_templates_node = npe.Node(
-            interface=Gunzip(),
+            nutil.Function(
+                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+            ),
             name="unzip_templates_node",
         )
         # DARTEL with existing template

--- a/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
+++ b/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
@@ -121,9 +121,8 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
         import nipype.interfaces.spm as spm
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
-        from nipype.algorithms.misc import Gunzip
 
-        from clinica.utils.filemanip import zip_nii
+        from clinica.utils.filemanip import unzip_nii, zip_nii
         from clinica.utils.nipype import container_from_filename, fix_join
         from clinica.utils.spm import spm_standalone_is_available, use_spm_standalone
 
@@ -152,7 +151,12 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
 
         # Unzipping
         # =========
-        unzip_node = npe.Node(interface=Gunzip(), name="1-UnzipT1w")
+        unzip_node = npe.Node(
+            nutil.Function(
+                input_names=["in_file"], output_names=["out_file"], function=unzip_nii
+            ),
+            name="1-UnzipT1w",
+        )
 
         # Unified Segmentation
         # ====================

--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -28,6 +28,28 @@ def zip_nii(in_file: str, same_dir: bool = False):
     return out_file
 
 
+def unzip_nii(in_file: str):
+    from nipype.algorithms.misc import Gunzip
+    from nipype.utils.filemanip import split_filename
+    from traits.trait_base import _Undefined
+
+    if (in_file is None) or isinstance(in_file, _Undefined):
+        return None
+
+    if not isinstance(in_file, str):  # type(in_file) is list:
+        return [unzip_nii(f) for f in in_file]
+
+    _, base, ext = split_filename(in_file)
+
+    # Not compressed
+    if ext[-3:].lower() != ".gz":
+        return in_file
+    # Compressed
+    gunzip = Gunzip(in_file=in_file)
+    gunzip.run()
+    return gunzip.aggregate_outputs().out_file
+
+
 def save_participants_sessions(participant_ids, session_ids, out_folder, out_file=None):
     """Save <participant_ids> <session_ids> in <out_folder>/<out_file> TSV file."""
     import os


### PR DESCRIPTION
As mentioned in Issue #707 , `t1-volume` currently hangs because of a a regression introduced in PR #650 (handling of lists as inputs). This PR reverts that PR and #656 which was a followup. If time allows, we can introduce `Gunzip` again by accounting lists as inputs as well.
