### PR TITLE
Add import pathlib to nonregression tests

### DIFF
--- a/test/nonregression/pipelines/test_run_pipelines_dwi.py
+++ b/test/nonregression/pipelines/test_run_pipelines_dwi.py
@@ -7,6 +7,7 @@ different functions available in Clinica
 
 import warnings
 from os import fspath
+from pathlib import Path
 from test.nonregression.testing_tools import *
 
 import pytest

--- a/test/nonregression/pipelines/test_run_pipelines_ml.py
+++ b/test/nonregression/pipelines/test_run_pipelines_ml.py
@@ -7,6 +7,7 @@ different functions available in Clinica
 
 import warnings
 from os import fspath
+from pathlib import Path
 from test.nonregression.testing_tools import *
 
 import pytest

--- a/test/nonregression/pipelines/test_run_pipelines_pet.py
+++ b/test/nonregression/pipelines/test_run_pipelines_pet.py
@@ -7,6 +7,7 @@ different functions available in Clinica
 
 import warnings
 from os import fspath
+from pathlib import Path
 from test.nonregression.testing_tools import *
 
 import pytest

--- a/test/nonregression/pipelines/test_run_pipelines_stats.py
+++ b/test/nonregression/pipelines/test_run_pipelines_stats.py
@@ -7,6 +7,7 @@ different functions available in Clinica
 
 import warnings
 from os import fspath
+from pathlib import Path
 from test.nonregression.testing_tools import *
 
 import pytest


### PR DESCRIPTION
This PR fixes a regression introduced in #694 by importing `Path` into the non-regression modules.