### PR TITLE
Add name to T1Linear test

### DIFF
--- a/test/nonregression/pipelines/test_run_pipelines_anat.py
+++ b/test/nonregression/pipelines/test_run_pipelines_anat.py
@@ -480,6 +480,7 @@ def run_T1Linear(
         tsv_file=fspath(input_dir / "subjects.tsv"),
         base_dir=fspath(working_dir),
         parameters=parameters,
+        name="t1-linear"
     )
     pipeline.run(plugin="MultiProc", plugin_args={"n_procs": 4}, bypass_check=True)
 

--- a/test/nonregression/pipelines/test_run_pipelines_anat.py
+++ b/test/nonregression/pipelines/test_run_pipelines_anat.py
@@ -480,7 +480,7 @@ def run_T1Linear(
         tsv_file=fspath(input_dir / "subjects.tsv"),
         base_dir=fspath(working_dir),
         parameters=parameters,
-        name="t1-linear"
+        name="t1-linear",
     )
     pipeline.run(plugin="MultiProc", plugin_args={"n_procs": 4}, bypass_check=True)
 


### PR DESCRIPTION
Fixes the T1Linear non-regression test by specifying a name to the pipeline and avoiding the default. The name became mandatory after introducing Flair Linear.