### PR TITLE
Correct number of digits on session

### DIFF
--- a/clinica/iotools/converter_utils.py
+++ b/clinica/iotools/converter_utils.py
@@ -4,6 +4,8 @@ def sort_session_list(session_list):
     session_id_list = []
     for session in session_idx:
         if session < 10:
+            session_id_list.append(f"ses-M00{session}")
+        elif session < 100 and session >= 10:
             session_id_list.append(f"ses-M0{session}")
         else:
             session_id_list.append(f"ses-M{session}")


### PR DESCRIPTION
The number of digits used by create-merge-tsv for the session number is currently two (ex: ses-M06), whereas Clinica's BIDS take three digits for the session number (ex: ses-M006). This difference makes it crash.