### PR TITLE
Enh remove split from engine

### DIFF
--- a/clinica/pydra/engine.py
+++ b/clinica/pydra/engine.py
@@ -44,9 +44,9 @@ def build_input_workflow(pipeline: Workflow, core_workflow: Workflow) -> str:
          the functional workflow
 
     Returns
-    ------
-    str
-        the field to split on.
+    -------
+    Workflow
+        The pipeline with the input workflow.
     """
 
     field = ""
@@ -68,7 +68,7 @@ def build_input_workflow(pipeline: Workflow, core_workflow: Workflow) -> str:
         read_data = getattr(input_workflow.lzout, field)
         setattr(core_workflow.inputs, field, read_data)
 
-    return field
+    return pipeline
 
 
 def add_input_task(input_workflow: Workflow, query_bids: dict) -> Workflow:
@@ -119,7 +119,7 @@ def build_output_workflow(
     Returns
     -------
     Workflow
-        The output workflow.
+        The pipeline with the output workflow.
     """
 
     output_attrs = []

--- a/clinica/pydra/engine.py
+++ b/clinica/pydra/engine.py
@@ -23,10 +23,10 @@ def clinica_io(func):
             input_dir=input_dir,
         )
 
-        split_key = build_input_workflow(pipeline, core_workflow)
+        build_input_workflow(pipeline, core_workflow)
 
         # TODO: define condition on split if multiple fields
-        pipeline.add(core_workflow.split(split_key))
+        pipeline.add(core_workflow)
 
         build_output_workflow(pipeline, core_workflow, output_dir)
 

--- a/clinica/pydra/t1_linear/t1_linear.py
+++ b/clinica/pydra/t1_linear/t1_linear.py
@@ -64,7 +64,7 @@ def download_ref_template() -> PurePath:
 
 
 @clinica_io
-def build_core_workflow(name: str = "core") -> Workflow:
+def build_core_workflow(name: str = "core", parameters={}) -> Workflow:
     """Core workflow for the T1 linear pipeline.
 
     Parameters
@@ -90,7 +90,7 @@ def build_core_workflow(name: str = "core") -> Workflow:
             name="n4_bias_field_correction",
             interface=n4_bias_field_correction,
             input_image=wf.lzin.T1w,
-        ).split('input_image')
+        ).split("input_image")
     )
 
     wf.add(

--- a/clinica/pydra/t1_linear/t1_linear.py
+++ b/clinica/pydra/t1_linear/t1_linear.py
@@ -90,7 +90,7 @@ def build_core_workflow(name: str = "core") -> Workflow:
             name="n4_bias_field_correction",
             interface=n4_bias_field_correction,
             input_image=wf.lzin.T1w,
-        )
+        ).split('input_image')
     )
 
     wf.add(

--- a/clinica/pydra/t1_linear/t1_linear_cli.py
+++ b/clinica/pydra/t1_linear/t1_linear_cli.py
@@ -20,6 +20,7 @@ def cli(
         name="t1-linear-pydra",
         input_dir=bids_directory,
         output_dir=caps_directory,
+        parameters={},
     )
     pydra_utils.run(t1_linear_pipeline)
 

--- a/clinica/pydra/t1_volume/tissue_segmentation/pipeline.py
+++ b/clinica/pydra/t1_volume/tissue_segmentation/pipeline.py
@@ -39,6 +39,8 @@ def t1volume_tissue_segmentation(
         input_spec=["T1w"],
     )
 
+    workflow.split("T1w")
+
     workflow.add(
         task_volume_location_in_world_coordinate_system(
             name="check_location_world",

--- a/test/unittests/pydra/test_engine.py
+++ b/test/unittests/pydra/test_engine.py
@@ -52,11 +52,11 @@ def test_build_input_workflow(pipeline: Workflow, core_workflow: Workflow):
 
     assert len(pipeline.nodes) == 0
 
-    _ = build_input_workflow(pipeline, core_workflow)
+    decorated_pipeline = build_input_workflow(pipeline, core_workflow)
 
-    assert len(pipeline.nodes) == 1
+    assert len(decorated_pipeline.nodes) == 1
 
-    assert "input_workflow" in [x.name for x in pipeline.nodes]
+    assert "input_workflow" in [x.name for x in decorated_pipeline.nodes]
 
     return
 


### PR DESCRIPTION
After discussion with @NicolasGensollen, it seems easier to handle the splits and combines directly inside the core workflows instead of the readers. This PR proposes to update the engine to reflect this proposal.