### PR TITLE
Fix vox_to_world_space_method_1

### DIFF
--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -1258,7 +1258,7 @@ def vox_to_world_space_method_1(
     import numpy as np
 
     return np.array(coordinates_vol) * np.array(
-        header["pixdim"][1], header["pixdim"][2], header["pixdim"][3]
+        [header["pixdim"][1], header["pixdim"][2], header["pixdim"][3]]
     )
 
 


### PR DESCRIPTION
As pointed out in #743, `t1-volume` doesn't work with data from `OASIS-3`. It seems that the function `vox_to_world_space_method_1()` was missing some brackets (which are present in vox_to_world_space_method_2 and 3).

Closes #743.