### PR TITLE
Increase time limit to 60 hrs

### DIFF
--- a/.jenkins/Jenkinsfile_nonregression
+++ b/.jenkins/Jenkinsfile_nonregression
@@ -1,9 +1,9 @@
 pipeline {
   triggers {
-      cron('H 21 * * 5')
+      cron('H 20 * * 5')
     }
   options {
-    timeout(time: 48, unit: 'HOURS')
+    timeout(time: 60, unit: 'HOURS')
     disableConcurrentBuilds(abortPrevious: true)
   }
   agent none


### PR DESCRIPTION
The time limit needs to be increased as DWI Tests fail on time out currently.