### PR TITLE
Use cache feature of actions/setup-python@v4

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,25 +1,22 @@
-name: 'Lint codebase'
+name: Lint
+
 on:
-  pull_request:
-    branches:
-      - dev
   push:
-    branches:
-      - dev
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: snok/install-poetry@v1
         with:
-          python-version: '3.8'
-      - name: Install environment
-        run: |
-          python -m ensurepip
-          python -m pip install poetry
-          make env
-      - name: Lint code with black
-        run: make lint.black
-      - name: Lint code with isort
-        run: make lint.isort
+          version: '1.1.15'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: poetry
+      - name: Lint code
+        run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,42 +1,28 @@
-name: 'Test'
+name: Test
 
 on:
   push:
-    branches:
-      - "dev"
+    branches: [dev]
   pull_request:
-    branches:
-      - '*'
-
-defaults:
-  run:
-    shell: bash
+    branches: [dev]
 
 jobs:
   test:
+    name: Test on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
-    name: Test on ${{ matrix.os }} with Python ${{ matrix.python-version }}
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.8', '3.9', '3.10']
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        id: setup-python
-        with:
-          python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v3
       - uses: snok/install-poetry@v1
         with:
           version: '1.1.15'
-          virtualenvs-in-project: true
-      - uses: actions/cache@v2
-        id: cache-venv
+      - uses: actions/setup-python@v4
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-      - name: 'Install Clinica'
-        run: make install
-      - name: 'Run unit tests'
+          python-version: ${{ matrix.python-version }}
+          cache: poetry
+      - name: Run unit tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -43,15 +43,15 @@ env.doc:
 
 ## format			: Format the codebase.
 .PHONY: format
-format: format.black format.isort
+format: install format.black format.isort
 
 .PHONY: format.black
-format.black: env.dev
+format.black:
 	$(info Formatting code with black)
 	@$(POETRY) run black --quiet $(PACKAGES)
 
 .PHONY: format.isort
-format.isort: env.dev
+format.isort:
 	$(info Formatting code with isort)
 	@$(POETRY) run isort --quiet $(PACKAGES)
 
@@ -62,15 +62,15 @@ install:
 
 ## lint			: Lint the codebase.
 .PHONY: lint
-lint: lint.black lint.isort
+lint: install lint.black lint.isort
 
 .PHONY: lint.black
-lint.black: env.dev
+lint.black:
 	$(info Linting code with black)
 	@$(POETRY) run black --check --diff $(PACKAGES)
 
 .PHONY: lint.isort
-lint.isort: env.dev
+lint.isort:
 	$(info Linting code with isort)
 	@$(POETRY) run isort --check --diff $(PACKAGES)
 
@@ -87,5 +87,5 @@ publish.testpypi: build config.testpypi
 	@$(POETRY) publish --repository testpypi
 
 .PHONY: test
-test:
+test: install
 	@$(POETRY) run python -m pytest -v test/unittests


### PR DESCRIPTION
Recent versions of [actions/setup-python](https://github.com/actions/setup-python/releases/tag/v3.1.0) now support caching `poetry` dependencies.

This PR makes use of this new caching feature which enables further simplification of our CI scripts and make targets and removal of our custom cache management step.