### PR TITLE
Restrict GH permissions to minimum necessary

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [dev]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,11 +4,15 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v6
         with:
           stale-issue-message: 'This issue is considered stale because it has not received further activity for the last 14 days. You may remove the `inactive` label or add a comment, otherwise it will be closed after the next 14 days.'
           stale-issue-label: 'inactive'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [dev]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test on ${{ matrix.os }} with Python ${{ matrix.python-version }}


### PR DESCRIPTION
As part of the recommended [security hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions) guidelines for GH workflows.

Whenever a checkout occurs:

```yaml
permissions:
  contents: read
```

Stale workflow may edit issues and PRs, so need:

```yaml
permissions:
  issues: write
  pull-requests: write
```