### PR TITLE
build: Install nipype up to version 1.8.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1913,7 +1913,7 @@ docs = ["mkdocs", "mkdocs-material", "pymdown-extensions"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "f224cae376fdd5d7b8aedfb22191c8eab9040ddd3b3d9f92ba2e50b7a4dae1dd"
+content-hash = "39c900a47ef18196559bde08390be07b15f4adc243511c550fed802d8aa1722e"
 
 [metadata.files]
 abagen = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 nibabel = "^2.3.3"
-nipype = "^1.7.1"
+nipype = ">=1.7.1,<1.8.3"
 argcomplete = "^1.9.4"
 pandas = "^1.4"
 jinja2 = "^3"


### PR DESCRIPTION
Version 1.8.3 introduced a regression to the DWI bias correction interface.

See https://github.com/nipy/nipype/pull/3523