### PR TITLE
Allow setting a custom logging directory via an envvar

### DIFF
--- a/clinica/cmdline.py
+++ b/clinica/cmdline.py
@@ -60,7 +60,10 @@ def setup_logging(verbose: bool = False) -> None:
     nipype.config.enable_debug_mode()
     nipype.config.update_config(
         {
-            "logging": {"log_directory": os.getcwd(), "log_to_file": True},
+            "logging": {
+                "log_directory": os.getenv("CLINICA_LOGGING_DIR", os.getcwd()),
+                "log_to_file": True,
+            },
             "execution": {"check_version": False},
         },
     )

--- a/docs/InteractingWithClinica.md
+++ b/docs/InteractingWithClinica.md
@@ -70,10 +70,8 @@ clinica run modality-pipeline bids_directory caps_directory -tsv my_participants
 "modality" is a prefix that corresponds to the data modality (e.g. T1, DWI, fMRI, PET) or to the category of processing (machine learning, statistics...).
 If you execute `clinica run --help`, you can see the list of `modality-pipeline` available: they correspond to the different pipelines displayed on the [main page of the documentation](..).
 
-<!-- ### clinica visualize
-
 !!! note
-    We are currently rewriting this section. We will update this section ASAP. -->
+    Clinica run logs are written in the current working directory by default. A different directory may be specified by setting the `CLINICA_LOGGING_DIR` environment variable.
 
 ### `clinica convert`
 


### PR DESCRIPTION
Defaults to current working directory, unless CLINICA_LOGGING_DIR is set. This is a stop gap solution for #771 until a proper config structure for customising Clinica is designed.

Closes #771 
Closes #772 