### PR TITLE
[ENH] Make `clinica run` subcommands registration dynamic

### DIFF
--- a/clinica/pipelines/cli.py
+++ b/clinica/pipelines/cli.py
@@ -1,87 +1,46 @@
+import os
+from pathlib import Path
+
 import click
 
-from clinica.pydra.t1_linear import t1_linear_cli as pydra_t1_linear_cli
-from clinica.pydra.t1_volume.create_dartel import cli as pydra_t1vol_cd_cli
-from clinica.pydra.t1_volume.tissue_segmentation import cli as pydra_t1vol_ts_cli
-
-from .deeplearning_prepare_data import (
-    deeplearning_prepare_data_cli as deeplearning_prepare_data_cli,
-)
-from .dwi_connectome import dwi_connectome_cli
-from .dwi_dti import dwi_dti_cli
-from .dwi_preprocessing_using_fmap import dwi_preprocessing_using_phasediff_fmap_cli
-from .dwi_preprocessing_using_t1 import dwi_preprocessing_using_t1_cli
-from .machine_learning import classification_cli
-from .machine_learning_spatial_svm import spatial_svm_cli
-from .pet_linear import pet_linear_cli
-from .pet_surface import pet_surface_cli, pet_surface_longitudinal_cli
-from .pet_volume import pet_volume_cli
-from .statistics_surface import statistics_surface_cli
-from .statistics_volume import statistics_volume_cli
-from .statistics_volume_correction import statistics_volume_correction_cli
-from .t1_freesurfer import t1_freesurfer_cli
-from .t1_freesurfer_longitudinal import (
-    t1_freesurfer_longitudinal_cli,
-    t1_freesurfer_longitudinal_correction_cli,
-    t1_freesurfer_template_cli,
-)
-from .t1_linear import flair_linear_cli, t1_linear_cli
-from .t1_volume import t1_volume_cli
-from .t1_volume_create_dartel import t1_volume_create_dartel_cli
-from .t1_volume_dartel2mni import t1_volume_dartel2mni_cli
-from .t1_volume_existing_template import t1_volume_existing_template_cli
-from .t1_volume_parcellation import t1_volume_parcellation_cli
-from .t1_volume_register_dartel import t1_volume_register_dartel_cli
-from .t1_volume_tissue_segmentation import t1_volume_tissue_segmentation_cli
+nipype_pipelines_folder = Path(os.path.dirname(__file__))
+pydra_pipelines_folder = Path(os.path.dirname(__file__)).parent / "pydra"
+pipeline_folders = [
+    nipype_pipelines_folder,
+    pydra_pipelines_folder,
+]
 
 
-class RegistrationOrderGroup(click.Group):
-    """CLI group which lists commands by order or registration."""
+class PipelineCommands(click.MultiCommand):
+    """CLI MultiCommand for executing pipelines."""
 
     def list_commands(self, ctx):
-        return self.commands.keys()
+        ns = {}
+        rv = []
+        for folder in pipeline_folders:
+            for filename in folder.glob("**/*_cli.py"):
+                with open(filename, "r") as fn:
+                    code = compile(fn.read(), filename, "exec")
+                    eval(code, ns, ns)
+                rv.append(ns["pipeline_name"])
+        rv.sort()
+        return rv
+
+    def get_command(self, ctx, name):
+        ns = {}
+        for folder in pipeline_folders:
+            for filename in folder.glob("**/*_cli.py"):
+                with open(filename, "r") as fn:
+                    code = compile(fn.read(), filename, "exec")
+                    eval(code, ns, ns)
+                if ns["pipeline_name"] == name:
+                    return ns["cli"]
 
 
-@click.group(cls=RegistrationOrderGroup, name="run")
+@click.command(cls=PipelineCommands, name="run")
 def cli() -> None:
     """Run pipelines on BIDS and CAPS datasets."""
     pass
-
-
-# Standard pipelines.
-cli.add_command(t1_freesurfer_cli.cli)
-cli.add_command(t1_volume_cli.cli)
-cli.add_command(t1_freesurfer_longitudinal_cli.cli)
-cli.add_command(t1_linear_cli.cli)
-cli.add_command(flair_linear_cli.cli)
-cli.add_command(dwi_preprocessing_using_phasediff_fmap_cli.cli)
-cli.add_command(dwi_preprocessing_using_t1_cli.cli)
-cli.add_command(dwi_dti_cli.cli)
-cli.add_command(dwi_connectome_cli.cli)
-cli.add_command(pet_linear_cli.cli)
-cli.add_command(pet_volume_cli.cli)
-cli.add_command(pet_surface_cli.cli)
-cli.add_command(pet_surface_longitudinal_cli.cli)
-cli.add_command(spatial_svm_cli.cli)
-cli.add_command(classification_cli.cli)
-cli.add_command(statistics_surface_cli.cli)
-cli.add_command(statistics_volume_cli.cli)
-cli.add_command(statistics_volume_correction_cli.cli)
-cli.add_command(t1_volume_existing_template_cli.cli)
-cli.add_command(t1_volume_tissue_segmentation_cli.cli)
-cli.add_command(t1_volume_create_dartel_cli.cli)
-cli.add_command(t1_volume_register_dartel_cli.cli)
-cli.add_command(t1_volume_dartel2mni_cli.cli)
-cli.add_command(t1_volume_parcellation_cli.cli)
-cli.add_command(t1_freesurfer_template_cli.cli)
-cli.add_command(t1_freesurfer_longitudinal_correction_cli.cli)
-cli.add_command(deeplearning_prepare_data_cli.cli)
-
-# Pydra pipelines
-
-cli.add_command(pydra_t1_linear_cli.cli)
-cli.add_command(pydra_t1vol_ts_cli.cli)
-cli.add_command(pydra_t1vol_cd_cli.cli)
 
 
 if __name__ == "__main__":

--- a/clinica/pipelines/deeplearning_prepare_data/deeplearning_prepare_data_cli.py
+++ b/clinica/pipelines/deeplearning_prepare_data/deeplearning_prepare_data_cli.py
@@ -1,8 +1,10 @@
 import click
 
+pipeline_name = "deeplearning-prepare-data"
+
 
 @click.command(
-    "deeplearning-prepare-data",
+    name=pipeline_name,
     deprecated=True,
     context_settings={
         "allow_extra_args": True,

--- a/clinica/pydra/t1_volume/create_dartel/cli.py
+++ b/clinica/pydra/t1_volume/create_dartel/cli.py
@@ -10,7 +10,7 @@ from clinica.pipelines import cli_param
 pipeline_name = "pydra-create-dartel"
 
 
-@click.command(name=pipeline_name)
+@click.command(name=pipeline_name, hidden=True)
 @cli_param.argument.bids_directory
 @cli_param.argument.caps_directory
 @cli_param.argument.group_label


### PR DESCRIPTION
**General description**

This PR proposes to change the way subcommands are registered for `clinica run` and is a first step towards having a `clinica_pipeline` decorator which would require, among other things, a dynamic registration of subcommands.

**The current way**

To add a pipeline command, you need to manually edit the file `clinica/pipelines/cli.py` to import and add the the new subcommand there.

This isn't very dynamic and can be easily forgotten when implementing a new subcommand.
For example, it seems like `clinica run compute-atlas` isn't registered although it is defined here:

https://github.com/aramis-lab/clinica/blob/3386bff1bd2898bec569ff79ab7fb3f0c19800dc/clinica/pipelines/t1_freesurfer_atlas/t1_freesurfer_atlas_cli.py#L7-L19

```
$ clinica run compute-atlas
Usage: clinica run [OPTIONS] COMMAND [ARGS]...
Try 'clinica run -h' for help.

Error: No such command 'compute-atlas'.
```

**The proposed way**

This PR defines folders to look for subcommands: `clinica/pipelines` and `clinica/pydra` for now, and looks for python files defining subcommand (ending with `_cli.py` and defining `pipeline_name`).

This removes the need for manually editing `clinica/pipelines/cli.py`. To add a new subcommand, you just need to create a new folder and define the python CLI file inside.