### PR TITLE
[TEST, DOC] Add tests and docstrings to functions from `filemanip.py`

### DIFF
--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -184,11 +184,17 @@ def save_participants_sessions(
         raise e
 
 
-def _raise_non_bids_or_caps_compliant_filename(filename: str) -> None:
-    raise ValueError(
-        f"Input filename {filename} is not in a BIDS or CAPS compliant format."
-        " It does not contain the subject and session information."
-    )
+def _check_bids_or_caps_compliance(filename: str, sep: str):
+    import re
+
+    m = re.search(sep.join([r"(sub-[a-zA-Z0-9]+)", r"(ses-[a-zA-Z0-9]+)"]), filename)
+    if not m:
+        raise ValueError(
+            f"Input filename {filename} is not in a BIDS or CAPS compliant format."
+            " It does not contain the subject and session information."
+        )
+
+    return m
 
 
 def get_subject_id(bids_or_caps_file: str) -> str:
@@ -223,12 +229,8 @@ def get_subject_id(bids_or_caps_file: str) -> str:
     --------
     extract_image_ids
     """
-    import re
-
-    m = re.search(r"(sub-[a-zA-Z0-9]+)/(ses-[a-zA-Z0-9]+)", bids_or_caps_file)
-    if not m:
-        _raise_non_bids_or_caps_compliant_filename(bids_or_caps_file)
-    subject_id = m.group(1) + "_" + m.group(2)
+    match = _check_bids_or_caps_compliance(bids_or_caps_file, sep="/")
+    subject_id = match.group(1) + "_" + match.group(2)
 
     return subject_id
 
@@ -293,14 +295,10 @@ def extract_image_ids(bids_or_caps_files: List[str]) -> List[str]:
     --------
     get_subject_id
     """
-    import re
-
     id_bids_or_caps_files = []
     for f in bids_or_caps_files:
-        m = re.search(r"(sub-[a-zA-Z0-9]+)_(ses-[a-zA-Z0-9]+)", f)
-        if not m:
-            _raise_non_bids_or_caps_compliant_filename(f)
-        id_bids_or_caps_files.append(m.group())
+        match = _check_bids_or_caps_compliance(f, sep="_")
+        id_bids_or_caps_files.append(match.group())
 
     return id_bids_or_caps_files
 

--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -402,21 +402,19 @@ def read_participant_tsv(tsv_file: str) -> Tuple[List[str], List[str]]:
     >>> read_participant_tsv("participant.tsv")
     (["sub-01", "sub-01", "sub-02"], ["ses-M000", "ses-M006", "ses-M000"])
     """
-    from pathlib import Path
-
     import pandas as pd
 
     from clinica.utils.exceptions import ClinicaException
 
-    tsv_file = Path(tsv_file)
-    if not tsv_file.is_file():
+    try:
+        df = pd.read_csv(tsv_file, sep="\t")
+    except FileNotFoundError:
         raise ClinicaException(
             "The TSV file you gave is not a file.\nError explanations:\n"
             f"\t- Clinica expected the following path to be a file: {tsv_file}\n"
             "\t- If you gave relative path, did you run Clinica on the good folder?"
         )
 
-    df = pd.read_csv(tsv_file, sep="\t")
     for column in ("participant_id", "session_id"):
         if column not in list(df.columns.values):
             raise ClinicaException(

--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -1,3 +1,7 @@
+import re
+from typing import List
+
+
 def zip_nii(in_file: str, same_dir: bool = False):
     import gzip
     import shutil
@@ -80,25 +84,73 @@ def save_participants_sessions(participant_ids, session_ids, out_folder, out_fil
         raise e
 
 
+def _raise_non_bids_or_caps_compliant_filename(filename: str) -> None:
+    raise ValueError(
+        f"Input filename {filename} is not in a BIDS or CAPS compliant format."
+        " It does not contain the subject and session information."
+    )
+
+
 def get_subject_id(bids_or_caps_file: str) -> str:
-    """Extract "sub-<participant_id>_ses-<session_label>" from BIDS or CAPS file."""
-    import re
+    """Extract the subject ID from a BIDS or CAPS file path.
 
+    The subject ID is defined as
+
+        sub-<participant_id>_ses-<session_label>
+
+    In other words, it is the concatenation of the subject and session labels,
+    separated by "_".
+
+    Parameters
+    ----------
+    bids_or_caps_file: str
+        Path to a file from a BIDS or CAPS folder.
+
+    Returns
+    -------
+    subject_id: str
+        The subject ID corresponding to the given file.
+
+    Examples
+    --------
+    >>> get_subject_id("sub-01/ses-M000/pet/sub-01_ses-M000_trc-18FAV45_pet.nii.gz")
+    'sub-01_ses-M000'
+    >>> get_subject_id("sub-01_ses-M000_trc-18FAV45_pet.nii.gz")
+    Traceback (most recent call last):
+    ValueError: Input filename sub-01_ses-M000_trc-18FAV45_pet.nii.gz is not in a BIDS or CAPS compliant format. It does not contain the subject and session information.
+
+    See also
+    --------
+    extract_image_ids
+    """
     m = re.search(r"(sub-[a-zA-Z0-9]+)/(ses-[a-zA-Z0-9]+)", bids_or_caps_file)
-
     if not m:
-        raise ValueError(
-            f"Input filename {bids_or_caps_file} is not in a BIDS or CAPS compliant format."
-            " It does not contain the subject and session information."
-        )
-
+        _raise_non_bids_or_caps_compliant_filename(bids_or_caps_file)
     subject_id = m.group(1) + "_" + m.group(2)
 
     return subject_id
 
 
-def get_filename_no_ext(filename):
-    """Get filename without extension [".nii.gz", ".tar.gz", ".niml.dset"]."""
+def get_filename_no_ext(filename: str) -> str:
+    """Get the filename without the extension.
+
+    Parameters
+    ----------
+    filename: str
+        The full filename from which to extract the extension out.
+
+    Returns
+    -------
+    filename_no_ext: str
+        The filename with extension removed.
+
+    Examples
+    --------
+    >>> get_filename_no_ext("foo.nii.gz")
+    'foo'
+    >>> get_filename_no_ext("sub-01/ses-M000/sub-01_ses-M000.tar.gz")
+    'sub-01_ses-M000'
+    """
     from nipype.utils.filemanip import split_filename
 
     _, filename_no_ext, _ = split_filename(filename)
@@ -106,14 +158,46 @@ def get_filename_no_ext(filename):
     return filename_no_ext
 
 
-def extract_image_ids(bids_or_caps_files):
-    """Extract image IDs (e.g. ['sub-CLNC01_ses-M00', 'sub-CLNC01_ses-M18']  from `bids_or_caps_files`."""
-    import re
+def extract_image_ids(bids_or_caps_files: List[str]) -> List[str]:
+    """Extract the image IDs from a list of BIDS or CAPS files.
 
-    id_bids_or_caps_files = [
-        re.search(r"(sub-[a-zA-Z0-9]+)_(ses-[a-zA-Z0-9]+)", file).group()
-        for file in bids_or_caps_files
-    ]
+    .. warning::
+        The image ID is the same as the subject ID from function
+        `get_subject_id()` but is extracted from the filename rather
+        than from the path. (See examples section).
+
+    Parameters
+    ----------
+    bids_or_caps_files: List[str]
+        List of file names from which to extract the image IDs.
+
+    Returns
+    -------
+    id_bids_or_caps_files: List[str]
+        List of extracted image IDs.
+
+    Examples
+    --------
+    >>> extract_image_ids(["sub-01/ses-M000/pet/sub-01_ses-M000_trc-18FAV45_pet.nii.gz"])
+    ['sub-01_ses-M000']
+
+    Beware, the image IDs is extracted from the filename and not from the folder names
+    as it is the case for `get_subject_id()`:
+
+    >>> extract_image_ids(["foo/bar/baz/sub-foo/ses-bar/foooo/sub-01_ses-M000_foo.json"])
+    ['sub-01_ses-M000']
+
+    See also
+    --------
+    get_subject_id
+    """
+    id_bids_or_caps_files = []
+    for f in bids_or_caps_files:
+        m = re.search(r"(sub-[a-zA-Z0-9]+)_(ses-[a-zA-Z0-9]+)", f)
+        if not m:
+            _raise_non_bids_or_caps_compliant_filename(f)
+        id_bids_or_caps_files.append(m.group())
+
     return id_bids_or_caps_files
 
 
@@ -199,7 +283,7 @@ def extract_metadata_from_json(json_file, list_keys):
         raise EnvironmentError(
             f"[Error] Clinica could not open the following JSON file: {json_file}"
         )
-    except KeyError as e:
+    except KeyError:
         now = datetime.datetime.now().strftime("%H:%M:%S")
         error_message = f"[{now}] Error: Clinica could not find the e key in the following JSON file: {json_file}"
         raise ClinicaException(error_message)

--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -444,17 +444,16 @@ def extract_metadata_from_json(json_file: str, list_keys: List[str]) -> List[str
         List of values extracted from the JSON file and corresponding to the keys.
     """
     import json
-    from pathlib import Path
 
     from clinica.utils.exceptions import ClinicaException
 
-    json_file = Path(json_file)
-    if not json_file.exists():
+    try:
+        with open(json_file, "r") as file:
+            data = json.load(file)
+    except FileNotFoundError:
         raise FileNotFoundError(
             f"Clinica could not open the following JSON file: {json_file}"
         )
-    with open(json_file, "r") as file:
-        data = json.load(file)
     list_values = []
     missing_keys = []
     for key in list_keys:

--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -256,9 +256,9 @@ def get_filename_no_ext(filename: str) -> str:
     'sub-01_ses-M000'
     """
     from pathlib import PurePath
-    
+
     stem = PurePath(filename).stem
-    while('.' in stem):
+    while "." in stem:
         stem = PurePath(stem).stem
 
     return stem

--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -168,7 +168,7 @@ def save_participants_sessions(
         )
 
     out_folder = Path(out_folder)
-    os.makedirs(out_folder, exist_ok=True)
+    out_folder.mkdir(parents=True, exist_ok=True)
     tsv_file = out_folder / out_file
 
     data = pd.DataFrame(
@@ -255,11 +255,13 @@ def get_filename_no_ext(filename: str) -> str:
     >>> get_filename_no_ext("sub-01/ses-M000/sub-01_ses-M000.tar.gz")
     'sub-01_ses-M000'
     """
-    from nipype.utils.filemanip import split_filename
+    from pathlib import PurePath
+    
+    stem = PurePath(filename).stem
+    while('.' in stem):
+        stem = PurePath(stem).stem
 
-    _, filename_no_ext, _ = split_filename(filename)
-
-    return filename_no_ext
+    return stem
 
 
 def extract_image_ids(bids_or_caps_files: List[str]) -> List[str]:

--- a/test/unittests/utils/test_filemanip.py
+++ b/test/unittests/utils/test_filemanip.py
@@ -1,0 +1,85 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "foo",
+        "sub-01.json",
+        "ses-M000.nii.gz",
+        "sub-01_ses-M000.json",
+        "sub-01_ses-M000_trc-18FAV45_pet.nii.gz",
+    ],
+)
+def test_get_subject_id_error(filename):
+    from clinica.utils.filemanip import get_subject_id
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            f"Input filename {filename} is not in a BIDS or CAPS compliant format. "
+            "It does not contain the subject and session information."
+        ),
+    ):
+        get_subject_id(filename)
+
+
+@pytest.mark.parametrize(
+    "filename,expected",
+    [
+        (
+            "sub-01/ses-M000/pet/sub-01_ses-M000_trc-18FAV45_pet.nii.gz",
+            "sub-01_ses-M000",
+        ),
+        (
+            "foo/bar/baz/sub-foo/ses-bar/foooo/sub-01_ses-M000_foo.json",
+            "sub-foo_ses-bar",
+        ),
+    ],
+)
+def test_get_subject_id(filename, expected):
+    from clinica.utils.filemanip import get_subject_id
+
+    assert get_subject_id(filename) == expected
+
+
+@pytest.mark.parametrize(
+    "filename,expected",
+    [
+        ("foo.nii.gz", "foo"),
+        ("sub-01/ses-M000/sub-01_ses-M000.tar.gz", "sub-01_ses-M000"),
+        ("foo/bar/baz/foo-bar_baz.niml.dset", "foo-bar_baz"),
+    ],
+)
+def test_get_filename_no_ext(filename, expected):
+    from clinica.utils.filemanip import get_filename_no_ext
+
+    assert get_filename_no_ext(filename) == expected
+
+
+def test_extract_image_ids_error():
+    from clinica.utils.filemanip import extract_image_ids
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Input filename foo.bar is not in a BIDS or CAPS compliant format. "
+            "It does not contain the subject and session information."
+        ),
+    ):
+        extract_image_ids(["foo.bar"])
+
+
+def test_extract_image_ids():
+    from clinica.utils.filemanip import extract_image_ids
+
+    assert (
+        extract_image_ids(
+            [
+                "sub-01/ses-M000/pet/sub-01_ses-M000_trc-18FAV45_pet.nii.gz",
+                "foo/bar/baz/sub-foo/ses-bar/foooo/sub-01_ses-M000_foo.json",
+                "sub-01_ses-M000.tar.gz",
+            ]
+        )
+        == ["sub-01_ses-M000"] * 3
+    )

--- a/test/unittests/utils/test_filemanip.py
+++ b/test/unittests/utils/test_filemanip.py
@@ -10,12 +10,12 @@ def test_zip_nii(tmp_path):
     from clinica.utils.filemanip import zip_nii
 
     assert zip_nii(None) is None
-    assert zip_nii(tmp_path / "foo.gz", same_dir=True) == tmp_path / "foo.gz"
+    assert zip_nii(tmp_path / "foo.gz", same_dir=True) == str(tmp_path / "foo.gz")
     assert not (tmp_path / "foo.gz").exists()
     with pytest.raises(FileNotFoundError):
         zip_nii(tmp_path / "foo.nii")
     (tmp_path / "foo.nii").touch()
-    assert zip_nii(tmp_path / "foo.nii", same_dir=True) == tmp_path / "foo.nii.gz"
+    assert zip_nii(tmp_path / "foo.nii", same_dir=True) == str(tmp_path / "foo.nii.gz")
     for ext in ("", ".gz"):
         assert (tmp_path / f"foo.nii{ext}").exists()
 
@@ -24,7 +24,7 @@ def test_unzip_nii(tmp_path):
     from clinica.utils.filemanip import unzip_nii
 
     assert unzip_nii(None) is None
-    assert unzip_nii(tmp_path / "foo.nii") == tmp_path / "foo.nii"
+    assert unzip_nii(tmp_path / "foo.nii") == str(tmp_path / "foo.nii")
     assert not (tmp_path / "foo.nii").exists()
 
 

--- a/test/unittests/utils/test_filemanip.py
+++ b/test/unittests/utils/test_filemanip.py
@@ -83,3 +83,27 @@ def test_extract_image_ids():
         )
         == ["sub-01_ses-M000"] * 3
     )
+
+
+def test_extract_subjects_sessions_from_filename():
+    from clinica.utils.filemanip import extract_subjects_sessions_from_filename
+
+    assert (
+        extract_subjects_sessions_from_filename(
+            [
+                "sub-01/ses-M000/pet/sub-01_ses-M000_trc-18FAV45_pet.nii.gz",
+                "foo/bar/baz/sub-foo/ses-bar/foooo/sub-01_ses-M000_foo.json",
+                "sub-01_ses-M000.tar.gz",
+            ]
+        )
+    ) == (["sub-01", "sub-01", "sub-01"], ["ses-M000", "ses-M000", "ses-M000"])
+
+
+def test_extract_crash_files_from_log_file_error():
+    from clinica.utils.filemanip import extract_crash_files_from_log_file
+
+    with pytest.raises(
+        ValueError,
+        match="extract_crash_files_from_log_file",
+    ):
+        extract_crash_files_from_log_file("foo.log")


### PR DESCRIPTION
This PR proposes to improve the `clinica.utils.filemanip` module by:

- Adding type hints when possible
- Adding docstrings following the Numpydoc's conventions
- Refactoring some code
- Adding unit tests for all functions

Also, the function `unzip_nii` was implemented in a very different way from `zip_nii` and was offering a different API. This PR also proposes to change this and have the same implementation and API for both functions.