### PR TITLE
[UKB-To-BIDS] Add error if the data is not found or filtered

### DIFF
--- a/clinica/iotools/converters/ukb_to_bids/ukb_utils.py
+++ b/clinica/iotools/converters/ukb_to_bids/ukb_utils.py
@@ -54,9 +54,13 @@ def find_clinical_data(
 
 
 def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
+    import sys
     from pathlib import Path
 
+    import click
     import pandas as pd
+
+    from clinica.utils.stream import cprint
 
     source_path_series_nifti = pd.Series(
         find_imaging_data(imaging_data_directory), name="source_path"
@@ -94,6 +98,13 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
     )
     dataframe = dataframe[filename.isin(file_mod_list)]
     filename = filename[filename.isin(file_mod_list)]
+    if dataframe.empty:
+        cprint(
+            f"Dataset not found, or not handled by Clinica. Please check your data.",
+            lvl="warning",
+        )
+        click.echo("Clinica will now exit...")
+        sys.exit()
     split_zipfile = dataframe["source_zipfile"].str.split("_", expand=True)
     split_zipfile = split_zipfile.rename(
         {0: "source_id", 1: "modality_num", 2: "source_sessions_number"}, axis="columns"

--- a/clinica/iotools/converters/ukb_to_bids/ukb_utils.py
+++ b/clinica/iotools/converters/ukb_to_bids/ukb_utils.py
@@ -58,8 +58,6 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
 
     import pandas as pd
 
-    from clinica.utils.stream import cprint
-
     source_path_series_nifti = pd.Series(
         find_imaging_data(imaging_data_directory), name="source_path"
     )
@@ -98,7 +96,7 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
     filename = filename[filename.isin(file_mod_list)]
     if dataframe.empty:
         raise ValueError(
-            f"Dataset not found, or not handled by Clinica. Please check your data."
+            f"No imaging data were found in the provided folder: {imaging_data_directory}, or they are not handled by Clinica. Please check your data."
         )
     split_zipfile = dataframe["source_zipfile"].str.split("_", expand=True)
     split_zipfile = split_zipfile.rename(

--- a/clinica/iotools/converters/ukb_to_bids/ukb_utils.py
+++ b/clinica/iotools/converters/ukb_to_bids/ukb_utils.py
@@ -54,10 +54,8 @@ def find_clinical_data(
 
 
 def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
-    import sys
     from pathlib import Path
 
-    import click
     import pandas as pd
 
     from clinica.utils.stream import cprint
@@ -99,12 +97,9 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
     dataframe = dataframe[filename.isin(file_mod_list)]
     filename = filename[filename.isin(file_mod_list)]
     if dataframe.empty:
-        cprint(
-            f"Dataset not found, or not handled by Clinica. Please check your data.",
-            lvl="warning",
+        raise ValueError(
+            f"Dataset not found, or not handled by Clinica. Please check your data."
         )
-        click.echo("Clinica will now exit...")
-        sys.exit()
     split_zipfile = dataframe["source_zipfile"].str.split("_", expand=True)
     split_zipfile = split_zipfile.rename(
         {0: "source_id", 1: "modality_num", 2: "source_sessions_number"}, axis="columns"

--- a/clinica/iotools/converters/ukb_to_bids/ukb_utils.py
+++ b/clinica/iotools/converters/ukb_to_bids/ukb_utils.py
@@ -96,7 +96,8 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
     filename = filename[filename.isin(file_mod_list)]
     if dataframe.empty:
         raise ValueError(
-            f"No imaging data were found in the provided folder: {imaging_data_directory}, or they are not handled by Clinica. Please check your data."
+            f"No imaging data were found in the provided folder: {imaging_data_directory}, "
+            "or they are not handled by Clinica. Please check your data."
         )
     split_zipfile = dataframe["source_zipfile"].str.split("_", expand=True)
     split_zipfile = split_zipfile.rename(

--- a/test/unittests/iotools/converters/ukb_to_bids/test_ukb_to_bids_utils.py
+++ b/test/unittests/iotools/converters/ukb_to_bids/test_ukb_to_bids_utils.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import pytest
+
+
+def test_read_imaging_data(tmp_path):
+    import shutil
+
+    from clinica.iotools.converters.ukb_to_bids.ukb_utils import read_imaging_data
+
+    path_to_zip = tmp_path / Path("alt")
+    shutil.make_archive(path_to_zip, "zip", tmp_path)
+    with pytest.raises(
+        ValueError,
+        match=f"No imaging data were found in the provided folder: {path_to_zip}, or they are not handled by Clinica. Please check your data.",
+    ):
+        read_imaging_data(path_to_zip)

--- a/test/unittests/iotools/converters/ukb_to_bids/test_ukb_to_bids_utils.py
+++ b/test/unittests/iotools/converters/ukb_to_bids/test_ukb_to_bids_utils.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 
 
@@ -8,10 +6,11 @@ def test_read_imaging_data(tmp_path):
 
     from clinica.iotools.converters.ukb_to_bids.ukb_utils import read_imaging_data
 
-    path_to_zip = tmp_path / Path("alt")
+    path_to_zip = tmp_path / "alt"
     shutil.make_archive(path_to_zip, "zip", tmp_path)
     with pytest.raises(
         ValueError,
-        match=f"No imaging data were found in the provided folder: {path_to_zip}, or they are not handled by Clinica. Please check your data.",
+        match=f"No imaging data were found in the provided folder: {path_to_zip}, "
+        "or they are not handled by Clinica. Please check your data.",
     ):
         read_imaging_data(path_to_zip)


### PR DESCRIPTION
Currently, ukb-to-bids converter errors in not so user friendly way if the imaging data is not found or if it is filtered (since we do not convert all of the modalities).

Closes #783.