### PR TITLE
[CI] Automate publishing to PyPI on new releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,22 @@
+name: publish
+
+on:
+  # Trigger this workflow when a release is created.
+  release:
+    types:
+      - created
+
+permissions:
+  # Allow checkout of the project.
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: snok/install-poetry@v1
+      - name: Publish to PyPI
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: make publish

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,6 @@ help: Makefile
 	@echo "Commands:"
 	@sed -n 's/^##//p' $<
 
-## build			: Build the package.
-.PHONY: build
-build:
-	@$(POETRY) build
-
 .PHONY: check.lock
 check.lock:
 	@$(POETRY) lock --check
@@ -21,9 +16,13 @@ check.lock:
 clean.doc:
 	@$(RM) -rf site
 
-.PHONY: config.testpypi
-config.testpypi:
-	@$(POETRY) config repositories.testpypi https://test.pypi.org/legacy
+.PHONY: config.pypi
+config.pypi:
+ifdef PYPI_TOKEN
+	@$(POETRY) config pypi-token.pypi "${PYPI_TOKEN}"
+else
+	$(error "Missing API token for PyPI repository")
+endif
 
 ## doc			: Build the documentation.
 .PHONY: doc
@@ -83,17 +82,13 @@ lint.isort:
 lock:
 	@$(POETRY) lock --no-update
 
-## publish		: Publish the package to pypi.
+## publish		: Publish the package to PyPI.
 .PHONY: publish
 publish: publish.pypi
 
 .PHONY: publish.pypi
-publish.pypi: build
-	@$(POETRY) publish
-
-.PHONY: publish.testpypi
-publish.testpypi: build config.testpypi
-	@$(POETRY) publish --repository testpypi
+publish.pypi: config.pypi
+	@$(POETRY) publish --build
 
 .PHONY: test
 test: install


### PR DESCRIPTION
This PR updates the Makefile targets to enable publishing to PyPI if a valid API token is passed throught the `PYPI_TOKEN` envvar. It also adds a new workflow dedicated to publishing, which is triggered when a GitHub release is successfully drafted. It requires a repository secret to be set with the name `PYPI_TOKEN`, which can be done subsequently after this PR is merged.