### PR TITLE
[CI] Upload package when a release is published

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,10 +1,10 @@
 name: publish
 
 on:
-  # Trigger this workflow when a release is created.
+  # Trigger this workflow when a release is published.
   release:
     types:
-      - created
+      - published
 
 permissions:
   # Allow checkout of the project.


### PR DESCRIPTION
A release can be drafted but not published. This setting ensures upload happens only when the release is published.