### PR TITLE
Fix create_scan_dict's row_to_extract conditions

### DIFF
--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -418,7 +418,7 @@ def create_scans_dict(
                             filter(
                                 None, file_to_read[name_column_ses].str.split("ses-")
                             )
-                        )[0]
+                        )[0][0]
                         == ses_dict[bids_id][
                             list(filter(None, session_name.split("ses-")))[0]
                         ]


### PR DESCRIPTION
Currently the conditions for a row to be be extracted from the csv's are wrong, since the condition is always false and therefore no metadata are ever extracted.