### PR TITLE
FIX: Only list first-level non-hidden directories

### DIFF
--- a/clinica/iotools/converters/aibl_to_bids/aibl_utils.py
+++ b/clinica/iotools/converters/aibl_to_bids/aibl_utils.py
@@ -1,22 +1,30 @@
 """Utils to convert AIBL dataset in BIDS."""
 from functools import partial
-from typing import Sequence
+from typing import List, Sequence
 
 import pandas as pd
 
 
-def listdir_nohidden(path):
+def listdir_nohidden(path: str) -> List[str]:
     """List all the subdirectories of path except the hidden folders.
 
-    Args:
-        path (str): path whose subdirectories are needed
+    Parameters
+    ----------
+    path: str
+        Path to list subdirectories from.
 
-    Returns:
-        List(str): list of all the subdirectories of path
+    Returns
+    -------
+    list of str:
+        Subdirectories found within path.
     """
-    from os import listdir
+    from pathlib import Path
 
-    return [result for result in listdir(path) if not result.startswith(".")]
+    return [
+        str(p.name)
+        for p in Path(path).iterdir()
+        if p.is_dir() and not p.name.startswith(".")
+    ]
 
 
 def find_t1_in_paths(

--- a/test/unittests/iotools/converters/aibl_to_bids/test_aibl_utils.py
+++ b/test/unittests/iotools/converters/aibl_to_bids/test_aibl_utils.py
@@ -1,0 +1,15 @@
+from clinica.iotools.converters.aibl_to_bids import aibl_utils
+
+
+def test_listdir_nohidden():
+    from pathlib import Path
+    from tempfile import TemporaryDirectory
+
+    with TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir)
+        (path / "file").touch()
+        (path / ".hidden_file").touch()
+        (path / "dir").mkdir()
+        (path / ".hidden_dir").mkdir()
+        result = aibl_utils.listdir_nohidden(str(path))
+        assert result == ["dir"]


### PR DESCRIPTION
Found when trying to reproduce #786 with a local AIBL dataset containing a collection and associated XML metadata.

Without this fix, the converter fails with the following error:

```
ValueError: invalid literal for int() with base 10: 'AIBL_1262_PET-CTAC_SUM_S236830_I453888.xml'
```

Resulting from the fact that the `listdir_nohidden` utility function will return first-level directories **and files**, unlike what its name and docstring suggest 🤦 

There is a lot of horrible code in this converter so I went for the immediate fix, which is to replace the implementation with one based on `pathlib` and use `Path.is_dir` to filter first-level files from what's being returned. I also took this opportunity to update the docstring and add tests.