### PR TITLE
MNT: Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig <editorconfig.org>
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.tsv]
+indent_style = tab
+
+[*.y{,a}ml]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Helps mantaining a consistent codestyle (at least the basics) for most IDEs.

Since I know we all use different IDEs in the team, this should help reduce inconsistencies. All IDEs support most, if not all EditorConfig [properties](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties) these days. Properties are collected and overriden top-down.