### PR TITLE
[CI] Add `poetry` to `PATH` and add user friendly checks

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
             CONDA_ENV = "$WORKSPACE/env"
             CONDA_HOME = "$HOME/miniconda"
             PATH = "$HOME/.local/bin:$PATH"
+            POETRY = "poetry"
           }
           stages {
             stage('Build environment') {
@@ -26,6 +27,13 @@ pipeline {
                   make env.conda
                   conda activate "${CONDA_ENV}"
                   conda info
+                  if ! command -v $POETRY &> /dev/null
+                  then
+                    echo "$POETRY could not be found"
+                    exit
+                  else
+                    echo "$($POETRY --version) installed at : $(which $POETRY)"
+                  fi
                 '''
               }
             }

--- a/.jenkins/Jenkinsfile_nonregression
+++ b/.jenkins/Jenkinsfile_nonregression
@@ -17,6 +17,8 @@ pipeline {
           environment {
             CONDA_ENV = "$WORKSPACE/env"
             CONDA_HOME = "$HOME/miniconda"
+            PATH = "$HOME/.local/bin:$PATH"
+            POETRY="poetry"
           }
           stages {
             stage('Build environment') {
@@ -27,6 +29,13 @@ pipeline {
                   make env.conda
                   conda activate $CONDA_ENV
                   conda info
+                  if ! command -v $POETRY &> /dev/null
+                  then
+                    echo "$POETRY could not be found"
+                    exit
+                  else
+                    echo "$($POETRY --version) installed at : $(which $POETRY)"
+                  fi
                 '''
               }
             }
@@ -230,7 +239,7 @@ pipeline {
                   sh 'rm -rf ${WORK_DIR}'
                 }
               }
-            } 
+            }
           }
           post {
             always {
@@ -269,7 +278,7 @@ pipeline {
                 '''
               }
             }
-            /* 
+            /*
             stage("PET:nonreg") {
                environment {
                  WORK_DIR = "/Volumes/data/working_dir_mac/PET"
@@ -339,7 +348,7 @@ pipeline {
                   sh 'rm -rf ${WORK_DIR}/*'
                 }
               }
-            } 
+            }
             stage('ML:nonreg') {
               environment {
                 WORK_DIR = "/Volumes/data/working_dir_mac/ML"


### PR DESCRIPTION
I think the current failures we have with non regression tests are due to the fact that the PATH isn't set correctly. Thus `poetry` is unknown. This PR proposes to fix this and add checks and user friendly displays for `poetry`.