### PR TITLE
FIX: Test instantiation for all Pydra pipelines

### DIFF
--- a/clinica/pipelines/__init__.py
+++ b/clinica/pipelines/__init__.py
@@ -1,8 +1,4 @@
-from ..pydra import pet_volume  # noqa
-from ..pydra.t1_linear import t1_linear_cli as pydra_t1_linear_cli  # noqa
-from ..pydra.t1_volume.create_dartel import cli as pydra_t1vol_cd_cli  # noqa
-from ..pydra.t1_volume.register_dartel import cli as pydra_t1vol_rd_cli  # noqa
-from ..pydra.t1_volume.tissue_segmentation import cli as pydra_t1vol_ts_cli  # noqa
+from .. import pydra  # noqa
 from . import (
     deeplearning_prepare_data,
     dwi_connectome,

--- a/clinica/pipelines/__init__.py
+++ b/clinica/pipelines/__init__.py
@@ -1,4 +1,4 @@
-from ..pydra.pet_volume import pet_volume_cli as pydra_pet_volume_cli  # noqa
+from ..pydra import pet_volume  # noqa
 from ..pydra.t1_linear import t1_linear_cli as pydra_t1_linear_cli  # noqa
 from ..pydra.t1_volume.create_dartel import cli as pydra_t1vol_cd_cli  # noqa
 from ..pydra.t1_volume.register_dartel import cli as pydra_t1vol_rd_cli  # noqa

--- a/clinica/pydra/__init__.py
+++ b/clinica/pydra/__init__.py
@@ -1,5 +1,1 @@
-from . import (
-    pet_volume,
-    t1_linear,
-    t1_volume,
-)
+from . import pet_volume, t1_linear, t1_volume

--- a/clinica/pydra/__init__.py
+++ b/clinica/pydra/__init__.py
@@ -1,0 +1,5 @@
+from . import (
+    pet_volume,
+    t1_linear,
+    t1_volume,
+)

--- a/clinica/pydra/pet_volume/__init__.py
+++ b/clinica/pydra/pet_volume/__init__.py
@@ -1,0 +1,1 @@
+from . import pet_volume_cli

--- a/clinica/pydra/pet_volume/pet_volume_cli.py
+++ b/clinica/pydra/pet_volume/pet_volume_cli.py
@@ -19,7 +19,6 @@ pipeline_name = "pydra-pet-volume"
 @cli_param.argument.suvr_reference_region
 @cli_param.option_group.pipeline_specific_options
 @cli_param.option.pvc_psf_tsv
-@cli_param.option_group.common_pipelines_options
 @cli_param.option_group.advanced_pipeline_options
 @cli_param.option_group.option(
     "-mask",

--- a/clinica/pydra/t1_linear/__init__.py
+++ b/clinica/pydra/t1_linear/__init__.py
@@ -1,0 +1,1 @@
+from . import t1_linear_cli

--- a/clinica/pydra/t1_volume/__init__.py
+++ b/clinica/pydra/t1_volume/__init__.py
@@ -1,0 +1,5 @@
+from . import (
+    create_dartel,
+    register_dartel,
+    tissue_segmentation,
+)

--- a/clinica/pydra/t1_volume/__init__.py
+++ b/clinica/pydra/t1_volume/__init__.py
@@ -1,5 +1,1 @@
-from . import (
-    create_dartel,
-    register_dartel,
-    tissue_segmentation,
-)
+from . import create_dartel, register_dartel, tissue_segmentation

--- a/clinica/pydra/t1_volume/create_dartel/__init__.py
+++ b/clinica/pydra/t1_volume/create_dartel/__init__.py
@@ -1,0 +1,1 @@
+from . import cli

--- a/clinica/pydra/t1_volume/create_dartel/cli.py
+++ b/clinica/pydra/t1_volume/create_dartel/cli.py
@@ -8,7 +8,7 @@ import clinica.pydra.t1_volume.create_dartel.pipeline as pydra_create_dartel
 from clinica.pipelines import cli_param
 from clinica.pipelines.engine import clinica_pipeline
 
-pipeline_name = "pydra-create-dartel"
+pipeline_name = "pydra-t1-volume-create-dartel"
 
 
 @clinica_pipeline

--- a/clinica/pydra/t1_volume/register_dartel/__init__.py
+++ b/clinica/pydra/t1_volume/register_dartel/__init__.py
@@ -1,0 +1,1 @@
+from . import cli

--- a/clinica/pydra/t1_volume/tissue_segmentation/__init__.py
+++ b/clinica/pydra/t1_volume/tissue_segmentation/__init__.py
@@ -1,0 +1,1 @@
+from . import cli

--- a/clinica/pydra/t1_volume/tissue_segmentation/cli.py
+++ b/clinica/pydra/t1_volume/tissue_segmentation/cli.py
@@ -7,7 +7,7 @@ import clinica.pydra.t1_volume.tissue_segmentation.pipeline as pydra_t1vol
 from clinica.pipelines import cli_param
 from clinica.pipelines.engine import clinica_pipeline
 
-pipeline_name = "pydra-t1vol-ts"
+pipeline_name = "pydra-t1-volume-tissue-segmentation"
 
 
 @clinica_pipeline

--- a/test/instantiation/test_cli.py
+++ b/test/instantiation/test_cli.py
@@ -102,6 +102,10 @@ def test_second_lv_iotools(generate_cli_second_lv_iotools):
         "t1-freesurfer-template",
         "t1-freesurfer-longitudinal-correction",
         "pydra-pet-volume",
+        "pydra-t1-linear",
+        "pydra-create-dartel",
+        "pydra-t1-volume-register-dartel",
+        "pydra-t1vol-ts",
     ]
 )
 def generate_cli_second_lv_run(request):

--- a/test/instantiation/test_cli.py
+++ b/test/instantiation/test_cli.py
@@ -103,9 +103,9 @@ def test_second_lv_iotools(generate_cli_second_lv_iotools):
         "t1-freesurfer-longitudinal-correction",
         "pydra-pet-volume",
         "pydra-t1-linear",
-        "pydra-create-dartel",
+        "pydra-t1-volume-create-dartel",
         "pydra-t1-volume-register-dartel",
-        "pydra-t1vol-ts",
+        "pydra-t1-volume-tissue-segmentation",
     ]
 )
 def generate_cli_second_lv_run(request):

--- a/test/instantiation/test_cli.py
+++ b/test/instantiation/test_cli.py
@@ -101,6 +101,7 @@ def test_second_lv_iotools(generate_cli_second_lv_iotools):
         "t1-volume-parcellation",
         "t1-freesurfer-template",
         "t1-freesurfer-longitudinal-correction",
+        "pydra-pet-volume",
     ]
 )
 def generate_cli_second_lv_run(request):


### PR DESCRIPTION
Fixes the following warning:

`RuntimeWarning: The empty option group "Common pipelines options" was found (line 56) for "cli". The group will not be added.`

Also add  instantiation tests for all Pydra pipelines (they are hidden but they can still be tested).