### PR TITLE
[ENH] Delete duplicated function `write_to_tsv`

### DIFF
--- a/clinica/iotools/converters/habs_to_bids/habs_to_bids.py
+++ b/clinica/iotools/converters/habs_to_bids/habs_to_bids.py
@@ -170,11 +170,6 @@ def parse_imaging_data(paths: List[Tuple[str, str]]) -> Optional[DataFrame]:
     return dataframe
 
 
-def write_to_tsv(dataframe: DataFrame, buffer: TextIOBase) -> None:
-    """Save the input dataframe to a BIDS-compliant TSV format."""
-    dataframe.to_csv(buffer, sep="\t", na_rep="n/a", date_format="%Y-%m-%d")
-
-
 def install_nifti(zipfile: str, filename: str, bids_path: str) -> None:
     """Install a NIfTI file from a source archive to the target BIDS path."""
     import fsspec
@@ -195,6 +190,7 @@ def write_bids(
     from pandas import notna
 
     from clinica.iotools.bids_dataset_description import BIDSDatasetDescription
+    from clinica.iotools.bids_utils import write_to_tsv
 
     participants = (
         clinical_data["Demographics"]

--- a/clinica/iotools/converters/nifd_to_bids/nifd_utils.py
+++ b/clinica/iotools/converters/nifd_to_bids/nifd_utils.py
@@ -286,11 +286,6 @@ def dataset_to_bids(
     return subjects, sessions, scans
 
 
-def write_to_tsv(dataframe: DataFrame, buffer: Union[PathLike, BinaryIO]) -> None:
-    # Save dataframe as a BIDS-compliant TSV file.
-    dataframe.to_csv(buffer, sep="\t", na_rep="n/a", date_format="%Y-%m-%d")
-
-
 def convert_dicom(sourcedata_dir: PathLike, bids_filename: PathLike) -> None:
     from pathlib import PurePath
 
@@ -339,6 +334,7 @@ def write_bids(
     from fsspec.implementations.local import LocalFileSystem
 
     from clinica.iotools.bids_dataset_description import BIDSDatasetDescription
+    from clinica.iotools.bids_utils import write_to_tsv
 
     to = PurePath(to)
     fs = LocalFileSystem(auto_mkdir=True)

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -260,11 +260,6 @@ def dataset_to_bids(
     return df_participants, df_session, df_scan
 
 
-def write_to_tsv(dataframe: DataFrame, buffer: Union[PathLike, BinaryIO]) -> None:
-    # Save dataframe as a BIDS-compliant TSV file.
-    dataframe.to_csv(buffer, sep="\t", na_rep="n/a", date_format="%Y-%m-%d")
-
-
 def install_bids(sourcedata_dir: PathLike, bids_filename: PathLike) -> None:
     from pathlib import Path
 
@@ -306,6 +301,7 @@ def write_bids(
     from fsspec.implementations.local import LocalFileSystem
 
     from clinica.iotools.bids_dataset_description import BIDSDatasetDescription
+    from clinica.iotools.bids_utils import write_to_tsv
 
     to = Path(to)
     fs = LocalFileSystem(auto_mkdir=True)


### PR DESCRIPTION
Atm, each converter defines its own copy of the function `write_to_tsv`:

https://github.com/aramis-lab/clinica/blob/83d6d9958b3b3e2ffe82e5fedf09cd70b3109a44/clinica/iotools/converters/habs_to_bids/habs_to_bids.py#L173-L175

https://github.com/aramis-lab/clinica/blob/444e4a4e711d6a373fae07412fa378da1e356572/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py#L263-L265

https://github.com/aramis-lab/clinica/blob/83d6d9958b3b3e2ffe82e5fedf09cd70b3109a44/clinica/iotools/converters/nifd_to_bids/nifd_utils.py#L289-L291

This PR proposes to delete these duplicated functions and import the implementation of the `bids_utils` module:

https://github.com/aramis-lab/clinica/blob/83d6d9958b3b3e2ffe82e5fedf09cd70b3109a44/clinica/iotools/bids_utils.py#L780-L782