### PR TITLE
[FIX] Expose `fwhm` to `t1_volume_template_tpm_in_mni`

### DIFF
--- a/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
+++ b/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
@@ -117,7 +117,10 @@ class StatisticsVolume(cpe.Pipeline):
         elif self.parameters["orig_input_data_volume"] == "t1-volume":
             self.parameters["measure_label"] = "graymatter"
             information_dict = t1_volume_template_tpm_in_mni(
-                self.parameters["group_label_dartel"], 1, True
+                group_label=self.parameters["group_label_dartel"],
+                tissue_number=1,
+                modulation=True,
+                fwhm=self.parameters["full_width_at_half_maximum"],
             )
 
         elif self.parameters["orig_input_data_volume"] == "custom-pipeline":

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_cli.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_cli.py
@@ -13,6 +13,13 @@ pipeline_name = "t1-volume-parcellation"
 @cli_param.argument.caps_directory
 @cli_param.argument.group_label
 @cli_param.option_group.common_pipelines_options
+@cli_param.option_group.option(
+    "-fwhm",
+    "--full_width_at_half_maximum",
+    default=8,
+    show_default=True,
+    help="Full Width at Half Maximum (FWHM) of the smoothing used in your input files.",
+)
 @cli_param.option.subjects_sessions_tsv
 @cli_param.option.working_directory
 @cli_param.option.n_procs
@@ -22,6 +29,7 @@ def cli(
     caps_directory: str,
     group_label: str,
     subjects_sessions_tsv: Optional[str] = None,
+    full_width_at_half_maximum: int = 8,
     working_directory: Optional[str] = None,
     n_procs: Optional[int] = None,
     modulate: bool = True,
@@ -38,7 +46,11 @@ def cli(
 
     from .t1_volume_parcellation_pipeline import T1VolumeParcellation
 
-    parameters = {"group_label": group_label, "modulate": modulate}
+    parameters = {
+        "group_label": group_label,
+        "modulate": modulate,
+        "full_width_at_half_maximum": full_width_at_half_maximum,
+    }
 
     pipeline = T1VolumeParcellation(
         caps_directory=caps_directory,

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_cli.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_cli.py
@@ -13,13 +13,6 @@ pipeline_name = "t1-volume-parcellation"
 @cli_param.argument.caps_directory
 @cli_param.argument.group_label
 @cli_param.option_group.common_pipelines_options
-@cli_param.option_group.option(
-    "-fwhm",
-    "--full_width_at_half_maximum",
-    default=8,
-    show_default=True,
-    help="Full Width at Half Maximum (FWHM) of the smoothing used in your input files.",
-)
 @cli_param.option.subjects_sessions_tsv
 @cli_param.option.working_directory
 @cli_param.option.n_procs
@@ -29,7 +22,6 @@ def cli(
     caps_directory: str,
     group_label: str,
     subjects_sessions_tsv: Optional[str] = None,
-    full_width_at_half_maximum: int = 8,
     working_directory: Optional[str] = None,
     n_procs: Optional[int] = None,
     modulate: bool = True,
@@ -49,7 +41,6 @@ def cli(
     parameters = {
         "group_label": group_label,
         "modulate": modulate,
-        "full_width_at_half_maximum": full_width_at_half_maximum,
     }
 
     pipeline = T1VolumeParcellation(

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
@@ -19,7 +19,6 @@ class T1VolumeParcellation(cpe.Pipeline):
         self.parameters.setdefault("group_label", None)
         check_group_label(self.parameters["group_label"])
 
-        self.parameters.setdefault("full_width_at_half_maximum", 8)
         self.parameters.setdefault("atlases", T1_VOLUME_ATLASES)
         self.parameters.setdefault("modulate", True)
 
@@ -75,7 +74,6 @@ class T1VolumeParcellation(cpe.Pipeline):
                     group_label=self.parameters["group_label"],
                     tissue_number=1,
                     modulation=self.parameters["modulate"],
-                    fwhm=self.parameters["full_width_at_half_maximum"],
                 ),
             )
         except ClinicaException as e:

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
@@ -19,6 +19,7 @@ class T1VolumeParcellation(cpe.Pipeline):
         self.parameters.setdefault("group_label", None)
         check_group_label(self.parameters["group_label"])
 
+        self.parameters.setdefault("full_width_at_half_maximum", 8)
         self.parameters.setdefault("atlases", T1_VOLUME_ATLASES)
         self.parameters.setdefault("modulate", True)
 
@@ -74,6 +75,7 @@ class T1VolumeParcellation(cpe.Pipeline):
                     group_label=self.parameters["group_label"],
                     tissue_number=1,
                     modulation=self.parameters["modulate"],
+                    fwhm=self.parameters["full_width_at_half_maximum"],
                 ),
             )
         except ClinicaException as e:

--- a/clinica/utils/input_files.py
+++ b/clinica/utils/input_files.py
@@ -401,24 +401,49 @@ def t1_volume_native_tpm_in_mni(tissue_number, modulation):
     }
 
 
-def t1_volume_template_tpm_in_mni(group_label, tissue_number, modulation):
+def t1_volume_template_tpm_in_mni(group_label, tissue_number, modulation, fwhm=None):
+    """Build the dictionary required by clinica_file_reader to get the tissue
+    probability maps based on group template in MNI space.
+
+    Parameters
+    ----------
+    group_label : str
+        Label used for the group of interest.
+
+    tissue_number : int
+        An integer defining the tissue of interest.
+
+    modulation : {"on", "off"}
+        Whether modulation is on or off.
+
+    fwhm : int, optional
+        The smoothing kernel in millimeters.
+
+    Returns
+    -------
+    dict :
+        Information dict to be passed to clinica_file_reader.
+    """
     import os
 
     from .spm import INDEX_TISSUE_MAP
 
     pattern_modulation = "on" if modulation else "off"
     description_modulation = "with" if modulation else "without"
+    fwhm_key_value = f"_fwhm-{fwhm}mm" if fwhm else ""
+    fwhm_description = f"with {fwhm}mm smoothing" if fwhm else "with no smoothing"
+
     return {
         "pattern": os.path.join(
             "t1",
             "spm",
             "dartel",
             f"group-{group_label}",
-            f"*_T1w_segm-{INDEX_TISSUE_MAP[tissue_number]}_space-Ixi549Space_modulated-{pattern_modulation}_probability.nii*",
+            f"*_T1w_segm-{INDEX_TISSUE_MAP[tissue_number]}_space-Ixi549Space_modulated-{pattern_modulation}{fwhm_key_value}_probability.nii*",
         ),
         "description": (
             f"Tissue probability map {INDEX_TISSUE_MAP[tissue_number]} based "
-            f"on {group_label} template in MNI space (Ixi549) {description_modulation} modulation."
+            f"on {group_label} template in MNI space (Ixi549) {description_modulation} modulation and {fwhm_description}."
         ),
         "needed_pipeline": "t1-volume",
     }


### PR DESCRIPTION
Fixes #830 

This PR proposes a possible fix for #830 by adding a new `fwhm` argument to `t1_volume_template_tpm_in_mni` in order to query files obtained with smoothing, similar to what is done for pet.

@AudreyDuran I still need to test it but feel free to take a look and check if this patch fixes your problem.