### PR TITLE
FIX: FutureWarning in pandas.concat

### DIFF
--- a/clinica/iotools/converters/ukb_to_bids/ukb_utils.py
+++ b/clinica/iotools/converters/ukb_to_bids/ukb_utils.py
@@ -86,7 +86,7 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
     dataframe_dicom = pd.DataFrame.from_records(
         source_path_series_dicom, columns=["source_zipfile", "source_filename"]
     )
-    dataframe = pd.concat([dataframe_nifti, dataframe_dicom], 0)
+    dataframe = pd.concat([dataframe_nifti, dataframe_dicom])
     filename = (
         dataframe["source_filename"]
         .apply(lambda x: Path(str(x)).name)


### PR DESCRIPTION
Fix warning `FutureWarning: In a future version of pandas all arguments of concat except for the argument 'objs' will be keyword-only.` reported in CI with the latest version of `pandas`. The `axis` parameter will become keyword-only and we are using the default value anyway. Better just remove it.