### PR TITLE
[FIX] Fix `_zip_unzip_nii` with iterable inputs

### DIFF
--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -5,6 +5,7 @@ def _zip_unzip_nii(in_file: str, same_dir: bool, compress: bool):
     import gzip
     import operator
     import shutil
+    from collections.abc import Iterable
     from os import getcwd
     from os.path import abspath, join
     from pathlib import Path
@@ -15,7 +16,7 @@ def _zip_unzip_nii(in_file: str, same_dir: bool, compress: bool):
     if (in_file is None) or isinstance(in_file, _Undefined):
         return None
 
-    if isinstance(in_file, list):
+    if isinstance(in_file, Iterable):
         return [_zip_unzip_nii(f, same_dir, compress) for f in in_file]
 
     in_file = Path(in_file)


### PR DESCRIPTION
Fixes #835 

@zhaonann This should fix the issue you currently have. It comes from the fact that Nipype is calling `zip_nii` and/or `unzip_nii` with tuples for `in_file` while the code expects lists.