### PR TITLE
[UKB2BIDS] Correct the file that is used for FLAIR

### DIFF
--- a/clinica/iotools/converters/ukb_to_bids/ukb_utils.py
+++ b/clinica/iotools/converters/ukb_to_bids/ukb_utils.py
@@ -69,7 +69,7 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
     # list of the files we want to build the bids for each modality
     file_mod_list = [
         "T1.nii.gz",
-        "T2_FLAIR.nii.gz",
+        "T2_FLAIR_orig_defaced.nii.gz",
         "AP.nii.gz",
         "PA.nii.gz",
         "rfMRI.dcm",
@@ -164,7 +164,7 @@ def complete_clinical(df_clinical: DataFrame) -> DataFrame:
     df_clinical = df_clinical.join(
         df_clinical.filename.map(
             {
-                "T2_FLAIR.nii.gz": {
+                "T2_FLAIR_orig_defaced.nii.gz": {
                     "datatype": "anat",
                     "modality": "FLAIR",
                     "suffix": "FLAIR",


### PR DESCRIPTION
The current implentation takes as input the `T2_FLAIR.nii.gz`. This image is registered on the T1 image and it is therefore not the one we wish to convert to BIDS, as it is not the rawest image, which would be `T2_FLAIR_orig_defaced.nii.gz`.