### PR TITLE
[CI] Update cron nonregression tests fast

### DIFF
--- a/.jenkins/nonregression_fast.Jenkinsfile
+++ b/.jenkins/nonregression_fast.Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
   triggers {
-      cron('0 16 * * *')
+      cron('0 18 * * *')
     }
   options {
     timeout(time: 6, unit: 'HOURS')


### PR DESCRIPTION
I realized I missed a configuration on Jenkins and the daily pipeline wasn't triggered.
This PR just changes the time from 4pm et 6pm such that we get another shot at it today.