### PR TITLE
[FIX] Fix wrong 4 digits session number in non regression test

### DIFF
--- a/test/nonregression/pipelines/test_run_pipelines_anat.py
+++ b/test/nonregression/pipelines/test_run_pipelines_anat.py
@@ -186,7 +186,7 @@ def run_T1VolumeTissueSegmentation(
         / "caps"
         / "subjects"
         / "sub-ADNI011S4105"
-        / "ses-M0000"
+        / "ses-M000"
         / "t1"
         / "spm"
         / "segmentation"


### PR DESCRIPTION
Fix bug introduced in #810 which is causing the anat non regression tests to fail atm.