### PR TITLE
[CI] Fix poetry not found on MacOS machines

### DIFF
--- a/.jenkins/nonregression_fast.Jenkinsfile
+++ b/.jenkins/nonregression_fast.Jenkinsfile
@@ -259,6 +259,8 @@ pipeline {
           environment {
 	    CONDA_ENV = "$WORKSPACE/env"
             CONDA_HOME = "$HOME/miniconda3"
+            PATH = "$HOME/.local/bin:$PATH"
+            POETRY="poetry"
           }
           stages {
             stage('Build environment') {
@@ -269,6 +271,13 @@ pipeline {
                   make env.conda
                   conda activate $CONDA_ENV
                   conda info
+                  if ! command -v $POETRY &> /dev/null
+                  then
+                    echo "$POETRY could not be found"
+                    exit
+                  else
+                    echo "$($POETRY --version) installed at : $(which $POETRY)"
+                  fi
                 '''
               }
             }

--- a/.jenkins/nonregression_slow.Jenkinsfile
+++ b/.jenkins/nonregression_slow.Jenkinsfile
@@ -259,6 +259,8 @@ pipeline {
           environment {
 	    CONDA_ENV = "$WORKSPACE/env"
             CONDA_HOME = "$HOME/miniconda3"
+            PATH = "$HOME/.local/bin:$PATH"
+            POETRY="poetry"
           }
           stages {
             stage('Build environment') {
@@ -269,6 +271,13 @@ pipeline {
                   make env.conda
                   conda activate $CONDA_ENV
                   conda info
+                  if ! command -v $POETRY &> /dev/null
+                  then
+                    echo "$POETRY could not be found"
+                    exit
+                  else
+                    echo "$($POETRY --version) installed at : $(which $POETRY)"
+                  fi
                 '''
               }
             }


### PR DESCRIPTION
This PR fixes the `poetry not found` errors we are currently getting when running non regression tests on Mac OS machines. We already fixed this a couple weeks ago on Linux machines but because the Jenkins files are full of copy pasted stuffs, we missed the Mac OS configs. I believe this is another example of why using shared libs as proposed by @ghisvail would save us time (see PR #841).