### PR TITLE
[CI] Fix modules on macOS machines

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -217,25 +217,21 @@ pipeline {
               steps {
                 sh 'echo "Agent name is ${NODE_NAME}"'
                 sh '''
-                  echo $PATH
 		  source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   make env.conda
                   conda activate "${CONDA_ENV}"
                   conda info
-		 echo $PATH
                 '''
               }
             }
             stage('Install Clinica') {
               steps {
                 sh '''
-		  echo $PATH
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate "${CONDA_ENV}"
                   make install
                   clinica --help
                   conda list
-		  echo $PATH
                 '''
               }
             }
@@ -246,10 +242,8 @@ pipeline {
               }
               steps {
                 sh '''
-		  echo $PATH
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate "${CONDA_ENV}"
-		  echo $PATH
                   source "$(brew --prefix)/opt/modules/init/bash"
                   module load clinica.all
                   cd test

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -210,7 +210,7 @@ pipeline {
           environment {
             CONDA_ENV = "$WORKSPACE/env"
             CONDA_HOME = "$HOME/miniconda3"
-            PATH = "$HOME/.local/bin:$PATH"
+            PATH = "$HOME/.local/bin:/usr/local/bin:$PATH"
           }
           stages {
             stage('Build environment') {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -244,7 +244,7 @@ pipeline {
                 sh '''
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate "${CONDA_ENV}"
-                  source "${BREW_PREFIX}/opt/modules/init/bash"
+                  source "$(brew --prefix)/opt/modules/init/bash"
                   module load clinica.all
                   cd test
                   poetry run pytest \
@@ -275,7 +275,7 @@ pipeline {
                 sh '''
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate "${CONDA_ENV}"
-                  source "${BREW_PREFIX}/opt/modules/init/bash"
+                  source "$(brew --prefix)/opt/modules/init/bash"
                   module load clinica.all
                   cd test
                   poetry run pytest \
@@ -310,7 +310,7 @@ pipeline {
                 sh '''
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate "${CONDA_ENV}"
-                  source "${BREW_PREFIX}/opt/modules/init/bash"
+                  source "$(brew --prefix)/opt/modules/init/bash"
                   module load clinica.all
                   cd test
                   poetry run pytest \

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -217,21 +217,25 @@ pipeline {
               steps {
                 sh 'echo "Agent name is ${NODE_NAME}"'
                 sh '''
-                  source "${CONDA_HOME}/etc/profile.d/conda.sh"
+                  echo $PATH
+		  source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   make env.conda
                   conda activate "${CONDA_ENV}"
                   conda info
+		 echo $PATH
                 '''
               }
             }
             stage('Install Clinica') {
               steps {
                 sh '''
+		  echo $PATH
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate "${CONDA_ENV}"
                   make install
                   clinica --help
                   conda list
+		  echo $PATH
                 '''
               }
             }
@@ -242,8 +246,10 @@ pipeline {
               }
               steps {
                 sh '''
+		  echo $PATH
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate "${CONDA_ENV}"
+		  echo $PATH
                   source "$(brew --prefix)/opt/modules/init/bash"
                   module load clinica.all
                   cd test

--- a/.jenkins/nonregression_fast.Jenkinsfile
+++ b/.jenkins/nonregression_fast.Jenkinsfile
@@ -338,7 +338,7 @@ pipeline {
                 sh '''
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate $CONDA_ENV
-                  source "${BREW_PREFIX}/opt/modules/init/bash"
+                  source "$(brew --prefix)/opt/modules/init/bash"
                   mkdir -p $WORK_DIR
                   module load clinica.all
                   cd test
@@ -374,7 +374,7 @@ pipeline {
                 sh '''
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate $CONDA_ENV
-                  source "${BREW_PREFIX}/opt/modules/init/bash"
+                  source "$(brew --prefix)/opt/modules/init/bash"
                   mkdir -p $WORK_DIR
                   module load clinica.all
                   cd test
@@ -410,7 +410,7 @@ pipeline {
                 sh '''
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate $CONDA_ENV
-                  source "${BREW_PREFIX}/opt/modules/init/bash"
+                  source "$(brew --prefix)/opt/modules/init/bash"
                   mkdir -p $WORK_DIR
                   module load clinica.all
                   cd test
@@ -446,7 +446,7 @@ pipeline {
                 sh '''
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate $CONDA_ENV
-                  source "${BREW_PREFIX}/opt/modules/init/bash"
+                  source "$(brew --prefix)/opt/modules/init/bash"
                   mkdir -p $WORK_DIR
                   module load clinica.all
                   cd test

--- a/.jenkins/nonregression_fast.Jenkinsfile
+++ b/.jenkins/nonregression_fast.Jenkinsfile
@@ -259,7 +259,7 @@ pipeline {
           environment {
 	    CONDA_ENV = "$WORKSPACE/env"
             CONDA_HOME = "$HOME/miniconda3"
-            PATH = "$HOME/.local/bin:$PATH"
+            PATH = "$HOME/.local/bin:/usr/local/bin:$PATH"
             POETRY="poetry"
           }
           stages {

--- a/.jenkins/nonregression_fast.Jenkinsfile
+++ b/.jenkins/nonregression_fast.Jenkinsfile
@@ -302,7 +302,7 @@ pipeline {
                  sh '''
                    source "${CONDA_HOME}/etc/profile.d/conda.sh"
                    conda activate $CONDA_ENV
-                   source /usr/local/opt/modules/init/bash
+                   source "$(brew --prefix)/opt/modules/init/bash"
                    mkdir -p $WORK_DIR
                    module load clinica.all
                    cd test

--- a/.jenkins/nonregression_slow.Jenkinsfile
+++ b/.jenkins/nonregression_slow.Jenkinsfile
@@ -338,7 +338,7 @@ pipeline {
                 sh '''
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate $CONDA_ENV
-                  source "${BREW_PREFIX}/opt/modules/init/bash"
+                  source "$(brew --prefix)/opt/modules/init/bash"
                   mkdir -p $WORK_DIR
                   module load clinica.all
                   cd test
@@ -374,7 +374,7 @@ pipeline {
                 sh '''
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate $CONDA_ENV
-                  source "${BREW_PREFIX}/opt/modules/init/bash"
+                  source "$(brew --prefix)/opt/modules/init/bash"
                   mkdir -p $WORK_DIR
                   module load clinica.all
                   cd test
@@ -410,7 +410,7 @@ pipeline {
                 sh '''
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate $CONDA_ENV
-                  source "${BREW_PREFIX}/opt/modules/init/bash"
+                  source "$(brew --prefix)/opt/modules/init/bash"
                   mkdir -p $WORK_DIR
                   module load clinica.all
                   cd test
@@ -446,7 +446,7 @@ pipeline {
                 sh '''
                   source "${CONDA_HOME}/etc/profile.d/conda.sh"
                   conda activate $CONDA_ENV
-                  source "${BREW_PREFIX}/opt/modules/init/bash"
+                  source "$(brew --prefix)/opt/modules/init/bash"
                   mkdir -p $WORK_DIR
                   module load clinica.all
                   cd test

--- a/.jenkins/nonregression_slow.Jenkinsfile
+++ b/.jenkins/nonregression_slow.Jenkinsfile
@@ -259,7 +259,7 @@ pipeline {
           environment {
 	    CONDA_ENV = "$WORKSPACE/env"
             CONDA_HOME = "$HOME/miniconda3"
-            PATH = "$HOME/.local/bin:$PATH"
+            PATH = "$HOME/.local/bin:/usr/local/bin:$PATH"
             POETRY="poetry"
           }
           stages {

--- a/.jenkins/nonregression_slow.Jenkinsfile
+++ b/.jenkins/nonregression_slow.Jenkinsfile
@@ -302,7 +302,7 @@ pipeline {
                  sh '''
                    source "${CONDA_HOME}/etc/profile.d/conda.sh"
                    conda activate $CONDA_ENV
-                   source /usr/local/opt/modules/init/bash
+                   source "$(brew --prefix)/opt/modules/init/bash"
                    mkdir -p $WORK_DIR
                    module load clinica.all
                    cd test


### PR DESCRIPTION
Fix the current issue we have with non regression test pipelines running on MACOS machines.
The pipelines fail at the node `PETnonreg` because the associated script attempts to source a non-existing file which probably comes from a copy-paste from the same node defined for Linux machines. 
Once again, a good reason to move to shared libs (see #841).
