### PR TITLE
[CI] Clean typos in Jenkins files

### DIFF
--- a/.jenkins/nonregression_fast.Jenkinsfile
+++ b/.jenkins/nonregression_fast.Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
             CONDA_ENV = "$WORKSPACE/env"
             CONDA_HOME = "$HOME/miniconda"
             PATH = "$HOME/.local/bin:$PATH"
-            POETRY="poetry"
+            POETRY = "poetry"
           }
           stages {
             stage('Build environment') {
@@ -75,7 +75,7 @@ pipeline {
                     --disable-warnings \
                     --timeout=0 \
                     -n 4 \
-                    -m "not slow" \n
+                    -m "not slow" \
                     ./nonregression/pipelines/test_run_pipelines_pet.py
                 '''
                 }
@@ -153,7 +153,7 @@ pipeline {
                     --disable-warnings \
                     --timeout=0 \
                     -n 4 \
-                    -m "not slow" \n
+                    -m "not slow" \
                     ./nonregression/pipelines/test_run_pipelines_ml.py
                 '''
                 }
@@ -192,7 +192,7 @@ pipeline {
                     --disable-warnings \
                     --timeout=0 \
                     -n 4 \
-                    -m "not slow" \n
+                    -m "not slow" \
                     ./nonregression/pipelines/test_run_pipelines_anat.py
                 '''
                 }
@@ -231,7 +231,7 @@ pipeline {
                     --disable-warnings \
                     --timeout=0 \
                     -n 4 \
-                    -m "not slow" \n
+                    -m "not slow" \
                     ./nonregression/pipelines/test_run_pipelines_dwi.py
                 '''
                 }
@@ -260,7 +260,7 @@ pipeline {
 	    CONDA_ENV = "$WORKSPACE/env"
             CONDA_HOME = "$HOME/miniconda3"
             PATH = "$HOME/.local/bin:/usr/local/bin:/Users/ci-aramis-clinica/.brew/bin:$PATH"
-            POETRY="poetry"
+            POETRY = "poetry"
           }
           stages {
             stage('Build environment') {

--- a/.jenkins/nonregression_slow.Jenkinsfile
+++ b/.jenkins/nonregression_slow.Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
             CONDA_ENV = "$WORKSPACE/env"
             CONDA_HOME = "$HOME/miniconda"
             PATH = "$HOME/.local/bin:$PATH"
-            POETRY="poetry"
+            POETRY = "poetry"
           }
           stages {
             stage('Build environment') {
@@ -257,10 +257,10 @@ pipeline {
             label 'macos'
           }
           environment {
-	    CONDA_ENV = "$WORKSPACE/env"
+	        CONDA_ENV = "$WORKSPACE/env"
             CONDA_HOME = "$HOME/miniconda3"
             PATH = "$HOME/.local/bin:/usr/local/bin:/Users/ci-aramis-clinica/.brew/bin:$PATH"
-            POETRY="poetry"
+            POETRY = "poetry"
           }
           stages {
             stage('Build environment') {
@@ -471,7 +471,7 @@ pipeline {
                   sh 'rm -rf ${WORK_DIR}/*'
                 }
               }
-            } */
+            }
           }
           post {
             always {


### PR DESCRIPTION
When triggering the slow non regression tests, I get an immediate `unexpected char: 0xFFFF @ line 493, column 1` which means that the file couldn't be parsed successfully. I had a look but couldn't find any obvious syntax mismatch for the moment. This PR just fixes a few small typos I found while reading through.