### PR TITLE
[FIX] Fix non regression tests DWI

### DIFF
--- a/test/nonregression/pipelines/test_run_pipelines_dwi.py
+++ b/test/nonregression/pipelines/test_run_pipelines_dwi.py
@@ -53,7 +53,7 @@ def test_dwi_connectome(cmdopt, tmp_path):
     base_dir = Path(cmdopt["input"])
     working_dir = Path(cmdopt["wd"])
     input_dir, tmp_dir, ref_dir = configure_paths(base_dir, tmp_path, "DWIConnectome")
-    run_dwi_dti(input_dir, tmp_dir, ref_dir, working_dir)
+    run_dwi_connectome(input_dir, tmp_dir, ref_dir, working_dir)
 
 
 def run_dwi_preprocessing_using_t1(

--- a/test/nonregression/pipelines/test_run_pipelines_dwi.py
+++ b/test/nonregression/pipelines/test_run_pipelines_dwi.py
@@ -195,7 +195,7 @@ def run_dwi_dti(
             ref_dir
             / (
                 subject_id
-                + "_ses-M00_dwi_space-JHUDTI81_res-1x1x1_map-"
+                + "_ses-M000_dwi_space-JHUDTI81_res-1x1x1_map-"
                 + m
                 + "_statistics.tsv"
             )


### PR DESCRIPTION
Fix two small bugs in non regression tests for DWI:

- wrong test function called, bug introduced in #837 
- two digit session instead of three, bug introduced in #810 