### PR TITLE
[CI, TEST] Run SPM instantiation tests in same process

### DIFF
--- a/test/instantiation/test_instantiate_all_pipelines.py
+++ b/test/instantiation/test_instantiate_all_pipelines.py
@@ -4,21 +4,16 @@ import warnings
 from os import fspath
 from pathlib import Path
 
-# Small unit tests for all pipelines
-##
-# test if instantiation and building of workflows is working
-
+import pytest
 
 warnings.filterwarnings("ignore")
 
 
-def test_instantiate_T1FreeSurferCrossSectional(cmdopt):
-
+def test_instantiate_t1_freesurfer_cross_sectional(cmdopt):
     from clinica.pipelines.t1_freesurfer.t1_freesurfer_pipeline import T1FreeSurfer
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "T1FreeSurfer"
-
     parameters = {
         "recon_all_args": "-qcache",
         "skip_question": True,
@@ -32,15 +27,24 @@ def test_instantiate_T1FreeSurferCrossSectional(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_T1VolumeTissueSegmentation(cmdopt):
+def test_instantiate_spm_based_pipelines(cmdopt):
+    """Run the instantiation tests for all pipelines using SPM.
+    This avoids issues when running tests in parallel.
+    """
+    input_dir = Path(cmdopt["input"])
+    run_tissue_segmentation(input_dir)
+    run_create_dartel(input_dir)
+    run_dartel_to_mni(input_dir)
+    run_register_dartel(input_dir)
+    run_pet_volume(input_dir)
 
+
+def run_tissue_segmentation(input_dir: Path) -> None:
     from clinica.pipelines.t1_volume_tissue_segmentation.t1_volume_tissue_segmentation_pipeline import (
         T1VolumeTissueSegmentation,
     )
 
-    input_dir = Path(cmdopt["input"])
     root = input_dir / "T1VolumeTissueSegmentation"
-
     parameters = {"skip_question": True}
     pipeline = T1VolumeTissueSegmentation(
         bids_directory=fspath(root / "in" / "bids"),
@@ -51,15 +55,12 @@ def test_instantiate_T1VolumeTissueSegmentation(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_T1VolumeCreateDartel(cmdopt):
-
+def run_create_dartel(input_dir: Path) -> None:
     from clinica.pipelines.t1_volume_create_dartel.t1_volume_create_dartel_pipeline import (
         T1VolumeCreateDartel,
     )
 
-    input_dir = Path(cmdopt["input"])
     root = input_dir / "T1VolumeCreateDartel"
-
     parameters = {"group_label": "UnitTest"}
     pipeline = T1VolumeCreateDartel(
         bids_directory=fspath(root / "in" / "bids"),
@@ -70,15 +71,12 @@ def test_instantiate_T1VolumeCreateDartel(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_T1VolumeDartel2MNI(cmdopt):
-
+def run_dartel_to_mni(input_dir: Path) -> None:
     from clinica.pipelines.t1_volume_dartel2mni.t1_volume_dartel2mni_pipeline import (
         T1VolumeDartel2MNI,
     )
 
-    input_dir = Path(cmdopt["input"])
     root = input_dir / "T1VolumeDartel2MNI"
-
     parameters = {"group_label": "UnitTest"}
     pipeline = T1VolumeDartel2MNI(
         bids_directory=fspath(root / "in" / "bids"),
@@ -89,15 +87,12 @@ def test_instantiate_T1VolumeDartel2MNI(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_T1VolumeRegisterDartel(cmdopt):
-
+def run_register_dartel(input_dir: Path) -> None:
     from clinica.pipelines.t1_volume_register_dartel.t1_volume_register_dartel_pipeline import (
         T1VolumeRegisterDartel,
     )
 
-    input_dir = Path(cmdopt["input"])
     root = input_dir / "T1VolumeRegisterDartel"
-
     parameters = {"group_label": "UnitTest"}
     pipeline = T1VolumeRegisterDartel(
         bids_directory=fspath(root / "in" / "bids"),
@@ -108,15 +103,13 @@ def test_instantiate_T1VolumeRegisterDartel(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_T1VolumeParcellation(cmdopt):
-
+def test_instantiate_t1_volume_parcellation(cmdopt):
     from clinica.pipelines.t1_volume_parcellation.t1_volume_parcellation_pipeline import (
         T1VolumeParcellation,
     )
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "T1VolumeParcellation"
-
     parameters = {"group_label": "UnitTest"}
     pipeline = T1VolumeParcellation(
         caps_directory=fspath(root / "in" / "caps"),
@@ -126,15 +119,13 @@ def test_instantiate_T1VolumeParcellation(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_DWIPreprocessingUsingT1(cmdopt):
-
+def test_instantiate_dwi_preprocessing_using_t1(cmdopt):
     from clinica.pipelines.dwi_preprocessing_using_t1.dwi_preprocessing_using_t1_pipeline import (
         DwiPreprocessingUsingT1,
     )
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "DWIPreprocessingUsingT1"
-
     parameters = {
         "initrand": False,
         "low_bval": 5,
@@ -150,15 +141,13 @@ def test_instantiate_DWIPreprocessingUsingT1(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_DWIPreprocessingUsingPhaseDiffFieldmap(cmdopt):
-
+def test_instantiate_dwi_preprocessing_using_phase_diff_field_map(cmdopt):
     from clinica.pipelines.dwi_preprocessing_using_fmap.dwi_preprocessing_using_phasediff_fmap_pipeline import (
         DwiPreprocessingUsingPhaseDiffFMap,
     )
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "DWIPreprocessingUsingPhaseDiffFieldmap"
-
     parameters = {
         "initrand": False,
         "low_bval": 5,
@@ -173,13 +162,11 @@ def test_instantiate_DWIPreprocessingUsingPhaseDiffFieldmap(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_DWIDTI(cmdopt):
-
+def test_instantiate_dwi_dti(cmdopt):
     from clinica.pipelines.dwi_dti.dwi_dti_pipeline import DwiDti
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "DWIDTI"
-
     pipeline = DwiDti(
         caps_directory=fspath(root / "in" / "caps"),
         tsv_file=fspath(root / "in" / "subjects.tsv"),
@@ -187,13 +174,11 @@ def test_instantiate_DWIDTI(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_DWIConnectome(cmdopt):
-
+def test_instantiate_dwi_connectome(cmdopt):
     from clinica.pipelines.dwi_connectome.dwi_connectome_pipeline import DwiConnectome
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "DWIConnectome"
-
     parameters = {"n_tracks": 1000}
     pipeline = DwiConnectome(
         caps_directory=fspath(root / "in" / "caps"),
@@ -203,14 +188,11 @@ def test_instantiate_DWIConnectome(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_PETVolume(cmdopt):
-
+def run_pet_volume(input_dir: Path) -> None:
     from clinica.pipelines.pet_volume.pet_volume_pipeline import PETVolume
     from clinica.utils.pet import Tracer
 
-    input_dir = Path(cmdopt["input"])
     root = input_dir / "PETVolume"
-
     parameters = {
         "group_label": "UnitTest",
         "acq_label": Tracer.FDG,
@@ -226,14 +208,12 @@ def test_instantiate_PETVolume(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_PETLinear(cmdopt):
-
+def test_instantiate_pet_linear(cmdopt):
     from clinica.pipelines.pet_linear.pet_linear_pipeline import PETLinear
     from clinica.utils.pet import Tracer
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "PETLinear"
-
     parameters = {
         "acq_label": Tracer.FDG,
         "suvr_reference_region": "cerebellumPons2",
@@ -245,25 +225,21 @@ def test_instantiate_PETLinear(cmdopt):
         tsv_file=fspath(root / "in" / "subjects.tsv"),
         parameters=parameters,
     )
-    pipeline.build
+    pipeline.build()
 
 
-def test_instantiate_StatisticsSurface(cmdopt):
-
+def test_instantiate_statistics_surface(cmdopt):
     from clinica.pipelines.statistics_surface.statistics_surface_pipeline import (
         StatisticsSurface,
     )
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "StatisticsSurface"
-
     parameters = {
-        # Clinica compulsory parameters
         "group_label": "UnitTest",
         "orig_input_data": "t1-freesurfer",
         "glm_type": "group_comparison",
         "contrast": "group",
-        # Optional parameters
         "covariates": "age sex",
     }
     pipeline = StatisticsSurface(
@@ -271,18 +247,15 @@ def test_instantiate_StatisticsSurface(cmdopt):
         tsv_file=fspath(root / "in" / "subjects.tsv"),
         parameters=parameters,
     )
-
     pipeline.build()
 
 
-def test_instantiate_PETSurfaceCrossSectional(cmdopt):
-
+def test_instantiate_pet_surface_cross_sectional(cmdopt):
     from clinica.pipelines.pet_surface.pet_surface_pipeline import PetSurface
     from clinica.utils.pet import Tracer
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "PETSurface"
-
     parameters = {
         "acq_label": Tracer.FDG,
         "suvr_reference_region": "pons",
@@ -299,29 +272,29 @@ def test_instantiate_PETSurfaceCrossSectional(cmdopt):
     pipeline.build()
 
 
-# def test_instantiate_PETSurfaceLongitudinal():
-#     from os.path import dirname, join, abspath
-#     from clinica.pipelines.pet_surface.pet_surface_pipeline import PetSurface
-#     from clinica.utils.pet import Tracer
-#
-#     root = dirname(abspath(join(abspath(__file__), pardir)))
-#     root = join(root, 'data', 'PETSurfaceLongitudinal')
-#     parameters = {
-#         'acq_label': Tracer.FDG,
-#         'suvr_reference_region': 'pons',
-#         'pvc_psf_tsv': join(root, 'in', 'subjects.tsv'),
-#         'longitudinal': True
-#     }
-#     pipeline = PetSurface(
-#         bids_directory=join(root, 'in', 'bids'),
-#         caps_directory=join(root, 'in', 'caps'),
-#         tsv_file=join(root, 'in', 'subjects.tsv'),
-#         parameters=parameters,
-#     )
-#     pipeline.build()
+@pytest.mark.skip(reason="Currently broken. Needs to be fixed...")
+def test_instantiate_pet_surface_longitudinal(cmdopt):
+    from clinica.pipelines.pet_surface.pet_surface_pipeline import PetSurface
+    from clinica.utils.pet import Tracer
+
+    input_dir = Path(cmdopt["input"])
+    root = input_dir / "PETSurfaceLongitudinal"
+    parameters = {
+        "acq_label": Tracer.FDG,
+        "suvr_reference_region": "pons",
+        "pvc_psf_tsv": fspath(root / "in" / "subjects.tsv"),
+        "longitudinal": True,
+    }
+    pipeline = PetSurface(
+        bids_directory=fspath(root / "in" / "bids"),
+        caps_directory=fspath(root / "in" / "caps"),
+        tsv_file=fspath(root / "in" / "subjects.tsv"),
+        parameters=parameters,
+    )
+    pipeline.build()
 
 
-def test_instantiate_WorlflowsML(cmdopt):
+def test_instantiate_workflows_ml(cmdopt):
     from os.path import exists
 
     from clinica.pipelines.machine_learning.input import (
@@ -333,7 +306,6 @@ def test_instantiate_WorlflowsML(cmdopt):
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "WorkflowsML"
-
     caps_dir = fspath(root / "in" / "caps")
     tsv = fspath(root / "in" / "subjects.tsv")
     diagnoses_tsv = fspath(root / "in" / "diagnosis.tsv")
@@ -342,7 +314,6 @@ def test_instantiate_WorlflowsML(cmdopt):
     atlases = ["AAL2", "Neuromorphometrics", "AICHA", "LPBA40", "Hammers"]
     possible_fwhm = [0, 5, 10, 15, 20, 25]
     tracer = Tracer.FDG
-
     voxel_input = [
         CAPSVoxelBasedInput(
             {
@@ -359,7 +330,6 @@ def test_instantiate_WorlflowsML(cmdopt):
         )
         for im in image_type
     ]
-
     region_input = [
         CAPSRegionBasedInput(
             {
@@ -377,7 +347,6 @@ def test_instantiate_WorlflowsML(cmdopt):
         for im in image_type
         for at in atlases
     ]
-
     vertex_input = [
         CAPSVertexBasedInput(
             {
@@ -393,7 +362,6 @@ def test_instantiate_WorlflowsML(cmdopt):
         )
         for fwhm in possible_fwhm
     ]
-
     # Check that each file exists
     for inputs in voxel_input + region_input + vertex_input:
         for file in inputs.get_images():
@@ -406,15 +374,13 @@ def test_instantiate_WorlflowsML(cmdopt):
                 raise ValueError("An error occurred...")
 
 
-def test_instantiate_SpatialSVM(cmdopt):
-
+def test_instantiate_spatial_svm(cmdopt):
     from clinica.pipelines.machine_learning_spatial_svm.spatial_svm_pipeline import (
         SpatialSVM,
     )
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "SpatialSVM"
-
     parameters = {"group_label": "ADNIbl", "orig_input_data": "t1-volume"}
     pipeline = SpatialSVM(
         caps_directory=fspath(root / "in" / "caps"),
@@ -424,15 +390,13 @@ def test_instantiate_SpatialSVM(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_T1FreeSurferTemplate(cmdopt):
-
+def test_instantiate_t1_freesurfer_template(cmdopt):
     from clinica.pipelines.t1_freesurfer_longitudinal.t1_freesurfer_template_pipeline import (
         T1FreeSurferTemplate,
     )
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "T1FreeSurferTemplate"
-
     pipeline = T1FreeSurferTemplate(
         caps_directory=fspath(root / "in" / "caps"),
         tsv_file=fspath(root / "in" / "subjects.tsv"),
@@ -440,15 +404,13 @@ def test_instantiate_T1FreeSurferTemplate(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_T1FreeSurferLongitudinalCorrection(cmdopt):
-
+def test_instantiate_t1_freesurfer_longitudinal_correction(cmdopt):
     from clinica.pipelines.t1_freesurfer_longitudinal.t1_freesurfer_longitudinal_correction_pipeline import (
         T1FreeSurferLongitudinalCorrection,
     )
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "T1FreeSurferLongitudinalCorrection"
-
     pipeline = T1FreeSurferLongitudinalCorrection(
         caps_directory=fspath(root / "in" / "caps"),
         tsv_file=fspath(root / "in" / "subjects.tsv"),
@@ -456,26 +418,23 @@ def test_instantiate_T1FreeSurferLongitudinalCorrection(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_T1Linear(cmdopt):
-
+def test_instantiate_t1_linear(cmdopt):
     from clinica.pipelines.t1_linear.anat_linear_pipeline import AnatLinear
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "T1Linear"
-
     parameters = {"uncropped_image": False}
-
     pipeline = AnatLinear(
         bids_directory=fspath(root / "in" / "bids"),
         caps_directory=fspath(root / "in" / "caps"),
         tsv_file=fspath(root / "in" / "subjects.tsv"),
         name="t1-linear",
+        parameters=parameters,
     )
     pipeline.build()
 
 
-def test_instantiate_StatisticsVolume(cmdopt):
-
+def test_instantiate_statistics_volume(cmdopt):
     from clinica.pipelines.statistics_volume.statistics_volume_pipeline import (
         StatisticsVolume,
     )
@@ -483,19 +442,14 @@ def test_instantiate_StatisticsVolume(cmdopt):
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "StatisticsVolume"
-
-    # Instantiate pipeline and run()
     parameters = {
-        # Clinica compulsory parameters
         "group_label": "UnitTest",
         "orig_input_data_volume": "pet-volume",
         "contrast": "group",
-        # Optional arguments for inputs from pet-volume pipeline
         "acq_label": Tracer.FDG,
         "use_pvc_data": False,
         "suvr_reference_region": "pons",
     }
-
     pipeline = StatisticsVolume(
         caps_directory=fspath(root / "in" / "caps"),
         tsv_file=fspath(root / "in" / "group-UnitTest_covariates.tsv"),
@@ -504,16 +458,13 @@ def test_instantiate_StatisticsVolume(cmdopt):
     pipeline.build()
 
 
-def test_instantiate_StatisticsVolumeCorrection(cmdopt):
-
+def test_instantiate_statistics_volume_correction(cmdopt):
     from clinica.pipelines.statistics_volume_correction.statistics_volume_correction_pipeline import (
         StatisticsVolumeCorrection,
     )
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "StatisticsVolumeCorrection"
-
-    # Instantiate pipeline and run()
     parameters = {
         "t_map": "group-UnitTest_AD-lt-CN_measure-fdg_fwhm-8_TStatistics.nii",
         "height_threshold": 3.2422,


### PR DESCRIPTION
Closes #859 

Alternative possible solution for the intermittent errors we currently have in instantiation tests. The error happens when running tests in parallel, for pipelines relying on SPM.

After investigation, I'm still unsure why this happens and why it seems to happen more frequently on `clinica-ubuntu-3`... I tried with SPM standalone and without and I get the same results.

In #859, I was proposing to run the instantiation tests in a single process to avoid these failures.
This PR proposes instead to keep the parallelism at the pytest session level, but group the tests using SPM in a single test function. 
It also proposes to clean the names of the test functions (remove all capital letters which are not PEP8 compliant), and explicitly skip a test which was commented (I don't know why, so the skip reason I've put isn't super informative...).