### PR TITLE
DOC: Improve getting started section of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,24 +92,39 @@ Alzheimer's disease using
 > Full instructions for installation and additional information can be found in
 the [user documentation](https://aramislab.paris.inria.fr/clinica/docs/public/latest/).
 
-Clinica currently supports macOS and Linux.
-It can be installed by typing the following command:
+### Using pipx (recommended)
 
-```sh
+Clinica can be easily installed and updated using [pipx](https://pypa.github.io/pipx/).
+
+```console
+pipx install clinica
+```
+
+### Using pip
+
+```console
 pip install clinica
 ```
 
-To avoid conflicts with other versions of the dependency packages installed by pip, it is strongly recommended to create a virtual environment before the installation.
-For example, use [Conda](https://docs.conda.io/en/latest/miniconda.html), to create a virtual
-environment and activate it before installing clinica (you can also use
-`virtualenv`):
+### Using Conda
 
-```sh
-conda create --name clinicaEnv python=3.8
-conda activate clinicaEnv
+Clinica relies on multiple third-party tools to perform processing.
+
+An environment file is provided in this repository
+to facilitate their installation in a [Conda](https://docs.conda.io/en/latest/miniconda.html) environment:
+
+```console
+git clone https://github.com/aramis-lab/clinica && cd clinica
+conda env create
+conda activate clinica
 ```
 
+After activation, use `pip` to install Clinica.
+
+### Additional dependencies (required)
+
 Depending on the pipeline that you want to use, you need to install pipeline-specific interfaces.
+Some of which uses a different runtime or use incompatible licensing terms, which prevent their distribution alongside Clinica.
 Not all the dependencies are necessary to run Clinica.
 Please refer to this [page](https://aramislab.paris.inria.fr/clinica/docs/public/latest/Third-party/)
 to determine which third-party libraries you need to install.

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,9 @@
-name: clinica_env
+name: clinica
 channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.10
   - dcm2niix
   - petpvc
-  - convert3d  
+  - convert3d


### PR DESCRIPTION
- Promote pipx as the recommended method for install
- Promote conda as means to install Clinica plus dependencies
- Explain why all third-party dependencies cannot be distributed
- Use Python 3.10 for the conda environment (now the default version)