### PR TITLE
[REF TEST] Refactor `converter_utils`

### DIFF
--- a/clinica/iotools/converter_utils.py
+++ b/clinica/iotools/converter_utils.py
@@ -304,7 +304,7 @@ def compute_table(mod_dict: dict) -> str:
     table : str
         The summary table as a string.
     """
-    diagnoses = sorted(list(set().union(*mod_dict.values())))
+    diagnoses = sorted(set().union(*mod_dict.values()))
     table = "\t" + "\t| ".join(diagnoses)
     table += "\n" + "-" * 8 * (len(diagnoses) + 2) + "\n"
     for mod_key, mod_value in mod_dict.items():

--- a/clinica/iotools/converter_utils.py
+++ b/clinica/iotools/converter_utils.py
@@ -125,7 +125,7 @@ def write_statistics(
     mmt : MissingModsTracker
         Instance of MissingModsTracker.
     """
-    with open(summary_file, "r") as fp:
+    with open(summary_file, "w") as fp:
         fp.write(compute_statistics(num_subjs, ses_aval, mmt))
 
 

--- a/clinica/iotools/converter_utils.py
+++ b/clinica/iotools/converter_utils.py
@@ -1,4 +1,75 @@
-from typing import List
+from os import PathLike
+from typing import List, Optional
+
+
+class MissingModsTracker:
+    """Class used for tracking the number of missing modalities in a database.
+
+    Attributes
+    ----------
+    missing : dict
+        Dictionary of missing modalities.
+
+    ses : list of str
+        Sessions for which the tracker has information.
+    """
+
+    _default_modalities_tracked = ["dwi", "func", "fieldmap", "flair", "t1w"]
+
+    def __init__(self, sessions: List[str], mod_list: Optional[List[str]] = None):
+        modalities = mod_list or self._default_modalities_tracked
+        if "session" not in modalities:
+            modalities.insert(0, "session")
+        self.missing = {s: {mod: 0 for mod in modalities} for s in sessions}
+
+    @property
+    def ses(self):
+        return list(self.missing.keys())
+
+    def add_missing_mod(self, session: str, modality: str) -> None:
+        """Increase the number of missing files for the input modality.
+
+        Parameters
+        ----------
+        session : str
+            Name of the session for which to add a modality.
+
+        modality : str
+            The missing modality to add.
+        """
+        if session not in self.missing:
+            raise ValueError(
+                f"Session {session} was not provided to the MissingModsTracker constructor."
+            )
+        if modality not in self.missing[session]:
+            raise ValueError(
+                f"Modality {modality} is not tracked by this instance of MissingModsTracker."
+            )
+        self.missing[session][modality] += 1
+
+    def increase_missing_ses(self, session: str) -> None:
+        """Increase the session number.
+
+        Parameters
+        ----------
+        session : str
+            Name of the session.
+        """
+        if session not in self.missing:
+            raise ValueError(
+                f"Session {session} was not provided to the MissingModsTracker constructor."
+            )
+        self.missing[session]["session"] += 1
+
+    def get_missing_list(self) -> dict:
+        """Return the dictionary of missing modalities.
+
+        Returns
+        -------
+        dict :
+             The dictionary containing the list of missing files.
+        """
+        return self.missing
 
 
 def sort_session_list(session_list: List[str]) -> List[str]:
@@ -30,41 +101,79 @@ def sort_session_list(session_list: List[str]) -> List[str]:
     return [f"ses-M{session[0]}" for session in session_idx]
 
 
-def print_statistics(summary_file, num_subjs, ses_aval, mmt):
+def write_statistics(
+    summary_file: PathLike, num_subjs: int, ses_aval: List[str], mmt: MissingModsTracker
+) -> None:
     """Write statistics file.
 
-    Print to a given input file statistics about missing files and modalities
-    in a dataset.  This method takes in input a MissingModsTracker object (mmt)
+    Write to a given input file statistics about missing files and modalities in a dataset.
+    This method takes in input a MissingModsTracker object (mmt)
     that contains the number of missing modalities for each session and the
     number of missing sessions for each subject.
 
-    Args:
-        summary_file: path of the output file where write.
-        num_subjs: number of subjects.
-        ses_aval: list of sessions available.
-        mmt: object MissingModsTracker
+    Parameters
+    ----------
+    summary_file : PathLike
+        Path of the output file where statistics should be written.
+
+    num_subjs : int
+        Number of subjects.
+
+    ses_aval : list of str
+        List of sessions available.
+
+    mmt : MissingModsTracker
+        Instance of MissingModsTracker.
+    """
+    with open(summary_file, "r") as fp:
+        fp.write(compute_statistics(num_subjs, ses_aval, mmt))
+
+
+def compute_statistics(
+    num_subjs: int, ses_aval: List[str], mmt: MissingModsTracker
+) -> str:
+    """Compute statistics and return them as a string for printing/writing.
+
+    Statistics are about missing files and modalities in a dataset.
+    This method takes in input a MissingModsTracker object (mmt)
+    that contains the number of missing modalities for each session and the
+    number of missing sessions for each subject.
+
+    Parameters
+    ----------
+    num_subjs : int
+        Number of subjects.
+
+    ses_aval : list of str
+        List of sessions available.
+
+    mmt : MissingModsTracker
+        Instance of MissingModsTracker.
+
+    Returns
+    -------
+    summary : str
+        The statistics formatted as a summary string.
     """
     missing_list = mmt.get_missing_list()
     ses_aval = sort_session_list(ses_aval)
-    summary_file.write("**********************************************\n")
-    summary_file.write(f"Number of subjects converted: {num_subjs}\n")
-    summary_file.write(f"Sessions available: {ses_aval}\n")
-
-    ses_aval = sort_session_list(ses_aval)
-
+    ses_founds = {ses: num_subjs - missing_list[ses]["session"] for ses in ses_aval}
+    summary = "\n".join(
+        [
+            "*" * 46,
+            f"Number of subjects converted: {num_subjs}",
+            f"Sessions available: {ses_aval}\n",
+            "\n".join(
+                [
+                    f"Number of sessions {ses} found: {ses_found} ({ses_found * 100 / num_subjs}%)\n"
+                    for ses, ses_found in ses_founds.items()
+                ]
+            ),
+            "*" * 46 + "\n\n" + "Number of missing modalities for each session:\n",
+        ]
+    )
     for ses in ses_aval:
-        ses_miss = missing_list[ses]["session"]
-        ses_found = num_subjs - ses_miss
-        perc_ses_found = ses_found * 100 / num_subjs
-        summary_file.write(
-            f"Number of sessions {ses} found: {ses_found} ({perc_ses_found}%)\n"
-        )
-
-    summary_file.write("**********************************************\n\n")
-    summary_file.write("Number of missing modalities for each session:\n")
-
-    for ses in ses_aval:
-        summary_file.write("\n" + ses + "\n")
+        summary += "\n" + ses + "\n"
         for mod in missing_list[ses]:
             if mod != "session":
                 num_miss_mod = missing_list[ses][mod]
@@ -76,149 +185,131 @@ def print_statistics(summary_file, num_subjs, ses_aval, mmt):
                     ),
                     2,
                 )
-                summary_file.write(f"{mod}: {num_miss_mod} ({percentage_missing}%) \n")
+                summary += f"{mod}: {num_miss_mod} ({percentage_missing}%) \n"
+
+    return summary
 
 
-def print_longitudinal_analysis(
-    summary_file, bids_dir, out_dir, ses_aval, out_file_name
-):
-    """Print to a given input file statistics about the present modalities and diagnoses in a dataset for each session.
+def write_longitudinal_analysis(
+    summary_file: PathLike,
+    bids_dir: PathLike,
+    out_dir: PathLike,
+    ses_aval: List[str],
+    out_file_name: str,
+) -> None:
+    """Write to a given input file statistics about the present modalities and diagnoses in a dataset for each session.
 
-    Args:
-        summary_file: path of the output file where write.
-        bids_dir: path to the BIDS directory
-        out_dir: output_dir of the check-missing-modality pipeline.
-        ses_aval: list of sessions available.
-        out_file_name: string that replace the default prefix ('missing_mods_') in the name of all the output files
+    Parameters
+    ----------
+    summary_file : PathLike
+        Path to the file where statistics should be written.
+
+    bids_dir : PathLike
+        Path to the BIDS directory.
+
+    out_dir : PathLike
+        Path to the output directory of the check-missing-modality pipeline.
+
+    ses_aval : list of str
+        List of sessions available.
+
+    out_file_name : str
+        String that replaces the default prefix ('missing_mods_') in
+        the name of all the output files.
     """
-    from os import path
+    with open(summary_file, "w") as fp:
+        fp.write(
+            compute_longitudinal_analysis(bids_dir, out_dir, ses_aval, out_file_name)
+        )
+
+
+def compute_longitudinal_analysis(
+    bids_dir: PathLike,
+    out_dir: PathLike,
+    ses_aval: List[str],
+    out_file_name: str,
+) -> str:
+    """Compute statistics about the present modalities and diagnoses in a dataset for each session.
+
+    Parameters
+    ----------
+    bids_dir : PathLike
+        Path to the BIDS directory.
+
+    out_dir : PathLike
+        Path to the output directory of the check-missing-modality pipeline.
+
+    ses_aval : list of str
+        List of sessions available.
+
+    out_file_name : str
+        String that replaces the default prefix ('missing_mods_') in
+        the name of all the output files.
+
+    Returns
+    -------
+    summary : str
+        The summary analysis as a string.
+    """
+    from collections import Counter
+    from pathlib import Path
 
     import pandas as pd
 
+    out_dir = Path(out_dir)
+    bids_dir = Path(bids_dir)
     ses_aval = sort_session_list(ses_aval)
-    summary_file.write("**********************************************\n\n")
-    summary_file.write("Number of present diagnoses and modalities for each session:\n")
-
+    summary = "\n\n".join(
+        ["*" * 46, f"Number of present diagnoses and modalities for each session:\n"]
+    )
     for ses in ses_aval:
         ses_df = pd.read_csv(
-            path.join(out_dir, out_file_name + ses + ".tsv"), sep="\t"
+            out_dir / (out_file_name + ses + ".tsv"), sep="\t"
         ).set_index("participant_id")
         mods_avail = ses_df.columns.values
         mod_dict = dict()
         for mod in mods_avail:
-            diagnosis_dict = dict()
+            diagnosis_counter = Counter()
             subjects_avail = ses_df[ses_df[mod] == 1].index.values
             for subject in subjects_avail:
-                subj_tsv_path = path.join(bids_dir, subject, f"{subject}_sessions.tsv")
+                subj_tsv_path = bids_dir / subject / f"{subject}_sessions.tsv"
                 subj_df = pd.read_csv(subj_tsv_path, sep="\t").set_index("session_id")
+                diagnosis = "missing"
                 if (
                     ses in subj_df.index.values
                     and "diagnosis" in subj_df.columns.values
                 ):
                     diagnosis = subj_df.loc[ses, "diagnosis"]
-                    if isinstance(diagnosis, str):
-                        increment_dict(diagnosis_dict, diagnosis)
-                    else:
-                        increment_dict(diagnosis_dict, "n/a")
-                else:
-                    increment_dict(diagnosis_dict, "missing")
-
-            mod_dict[mod] = diagnosis_dict
-
-        summary_file.write(f"{ses}\n")
-        print_table(summary_file, mod_dict)
-        summary_file.write("\n\n")
+                    diagnosis = diagnosis if isinstance(diagnosis, str) else "n/a"
+                diagnosis_counter.update([diagnosis])
+            mod_dict[mod] = dict(diagnosis_counter)
+        summary += f"{ses}\n{compute_table(mod_dict)}\n\n"
+    return summary
 
 
-def increment_dict(dictionary, key):
-    if key not in dictionary:
-        dictionary[key] = 1
-    else:
-        dictionary[key] += 1
+def compute_table(mod_dict: dict) -> str:
+    """Builds a table, encoded as a string, describing the
+    modalities in the given dictionary.
 
+    Parameters
+    ----------
+    mod_dict : dict
+        Dictionary of modalities for which to compute the table.
 
-def print_table(summary_file, double_dict):
-
-    # Find all keys at the second level of the dictionary
-    diagnoses = set()
-    mods = double_dict.keys()
-    for mod in mods:
-        diagnoses = diagnoses | set(double_dict[mod].keys())
-
-    diagnoses = list(diagnoses)
-    diagnoses.sort()
-
-    summary_file.write("\t")
-    for diag in diagnoses:
-        summary_file.write(f"\t| {diag}")
-    summary_file.write("\n" + "-" * 8 * (len(diagnoses) + 2) + "\n")
-
-    for mod in double_dict.keys():
-        summary_file.write(f"{mod}")
-        if len(mod) < 8:
-            summary_file.write("\t")
-        for diag in diagnoses:
-            if diag not in double_dict[mod]:
-                summary_file.write("\t| 0")
-            else:
-                summary_file.write(f"\t| {double_dict[mod][diag]}")
-        summary_file.write("\n")
-
-
-def has_one_index(index_list):
-    if len(index_list) == 1:
-        return index_list[0]
-    if len(index_list) == 0:
-        return -1
-    if len(index_list) > 1:
-        raise ValueError("Multiple indexes found")
-
-
-class MissingModsTracker:
-    """Class used for tracking the number of missing modalities in a database."""
-
-    def __init__(self, ses, mod_list=None):
-        self.missing = {}
-        self.ses = ses
-        if mod_list:
-            for s in ses:
-                self.missing.update({s: {"session": 0}})
-                for mod in mod_list:
-                    self.missing[s].update({mod: 0})
-        else:
-            for s in ses:
-                self.missing.update(
-                    {
-                        s: {
-                            "session": 0,
-                            "dwi": 0,
-                            "func": 0,
-                            "fieldmap": 0,
-                            "flair": 0,
-                            "t1w": 0,
-                        }
-                    }
-                )
-
-    def add_missing_mod(self, ses, mod):
-        """Increase the number of missing files for the input modality.
-
-        Args:
-            ses: name of the session
-            mod: modality missing
-        """
-        self.missing[ses][mod] += 1
-
-    def increase_missing_ses(self, ses):
-        self.missing[ses]["session"] += 1
-
-    def get_missing_list(self):
-        """Return the hash map mods_missing.
-
-        Returns:
-             The hash map containing the list of missing files.
-        """
-        return self.missing
+    Returns
+    -------
+    table : str
+        The summary table as a string.
+    """
+    diagnoses = sorted(list(set().union(*mod_dict.values())))
+    table = "\t" + "\t| ".join(diagnoses)
+    table += "\n" + "-" * 8 * (len(diagnoses) + 2) + "\n"
+    for mod_key, mod_value in mod_dict.items():
+        table += f"{mod_key}"
+        if len(mod_key) < 8:
+            table += "\t"
+        table += "\t| ".join([str(mod_value.get(d, "0")) for d in diagnoses]) + "\n"
+    return table
 
 
 def viscode_to_session(viscode: str) -> str:

--- a/clinica/iotools/converter_utils.py
+++ b/clinica/iotools/converter_utils.py
@@ -102,7 +102,10 @@ def sort_session_list(session_list: List[str]) -> List[str]:
 
 
 def write_statistics(
-    summary_file: PathLike, num_subjs: int, ses_aval: List[str], mmt: MissingModsTracker
+    summary_file: PathLike,
+    num_subjs: int,
+    ses_avail: List[str],
+    mmt: MissingModsTracker,
 ) -> None:
     """Write statistics file.
 
@@ -119,18 +122,18 @@ def write_statistics(
     num_subjs : int
         Number of subjects.
 
-    ses_aval : list of str
+    ses_avail : list of str
         List of sessions available.
 
     mmt : MissingModsTracker
         Instance of MissingModsTracker.
     """
     with open(summary_file, "w") as fp:
-        fp.write(compute_statistics(num_subjs, ses_aval, mmt))
+        fp.write(compute_statistics(num_subjs, ses_avail, mmt))
 
 
 def compute_statistics(
-    num_subjs: int, ses_aval: List[str], mmt: MissingModsTracker
+    num_subjs: int, ses_avail: List[str], mmt: MissingModsTracker
 ) -> str:
     """Compute statistics and return them as a string for printing/writing.
 
@@ -144,7 +147,7 @@ def compute_statistics(
     num_subjs : int
         Number of subjects.
 
-    ses_aval : list of str
+    ses_avail : list of str
         List of sessions available.
 
     mmt : MissingModsTracker
@@ -156,13 +159,13 @@ def compute_statistics(
         The statistics formatted as a summary string.
     """
     missing_list = mmt.get_missing_list()
-    ses_aval = sort_session_list(ses_aval)
-    ses_founds = {ses: num_subjs - missing_list[ses]["session"] for ses in ses_aval}
+    ses_avail = sort_session_list(ses_avail)
+    ses_founds = {ses: num_subjs - missing_list[ses]["session"] for ses in ses_avail}
     summary = "\n".join(
         [
             "*" * 46,
             f"Number of subjects converted: {num_subjs}",
-            f"Sessions available: {ses_aval}\n",
+            f"Sessions available: {ses_avail}\n",
             "\n".join(
                 [
                     f"Number of sessions {ses} found: {ses_found} ({ses_found * 100 / num_subjs}%)\n"
@@ -172,7 +175,7 @@ def compute_statistics(
             "*" * 46 + "\n\n" + "Number of missing modalities for each session:\n",
         ]
     )
-    for ses in ses_aval:
+    for ses in ses_avail:
         summary += "\n" + ses + "\n"
         for mod in missing_list[ses]:
             if mod != "session":
@@ -194,7 +197,7 @@ def write_longitudinal_analysis(
     summary_file: PathLike,
     bids_dir: PathLike,
     out_dir: PathLike,
-    ses_aval: List[str],
+    ses_avail: List[str],
     out_file_name: str,
 ) -> None:
     """Write to a given input file statistics about the present modalities and diagnoses in a dataset for each session.
@@ -210,7 +213,7 @@ def write_longitudinal_analysis(
     out_dir : PathLike
         Path to the output directory of the check-missing-modality pipeline.
 
-    ses_aval : list of str
+    ses_avail : list of str
         List of sessions available.
 
     out_file_name : str
@@ -219,14 +222,14 @@ def write_longitudinal_analysis(
     """
     with open(summary_file, "w") as fp:
         fp.write(
-            compute_longitudinal_analysis(bids_dir, out_dir, ses_aval, out_file_name)
+            compute_longitudinal_analysis(bids_dir, out_dir, ses_avail, out_file_name)
         )
 
 
 def compute_longitudinal_analysis(
     bids_dir: PathLike,
     out_dir: PathLike,
-    ses_aval: List[str],
+    ses_avail: List[str],
     out_file_name: str,
 ) -> str:
     """Compute statistics about the present modalities and diagnoses in a dataset for each session.
@@ -239,7 +242,7 @@ def compute_longitudinal_analysis(
     out_dir : PathLike
         Path to the output directory of the check-missing-modality pipeline.
 
-    ses_aval : list of str
+    ses_avail : list of str
         List of sessions available.
 
     out_file_name : str
@@ -258,11 +261,11 @@ def compute_longitudinal_analysis(
 
     out_dir = Path(out_dir)
     bids_dir = Path(bids_dir)
-    ses_aval = sort_session_list(ses_aval)
+    ses_avail = sort_session_list(ses_avail)
     summary = "\n\n".join(
         ["*" * 46, f"Number of present diagnoses and modalities for each session:\n"]
     )
-    for ses in ses_aval:
+    for ses in ses_avail:
         ses_df = pd.read_csv(
             out_dir / (out_file_name + ses + ".tsv"), sep="\t"
         ).set_index("participant_id")

--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -684,7 +684,7 @@ def compute_missing_mods(
         missing_mods_df = pd.DataFrame(columns=cols_dataframe)
 
     write_statistics(
-        out_dir / out_file_name / "summary.txt",
+        out_dir / (out_file_name + "summary.txt"),
         len(subjects_paths_lists),
         sessions_found,
         mmt,

--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -524,27 +524,39 @@ def compute_missing_processing(bids_dir, caps_dir, out_file):
     output_df.to_csv(out_file, sep="\t", index=False)
 
 
-def compute_missing_mods(bids_dir, out_dir, output_prefix=""):
+def compute_missing_mods(
+    bids_dir: PathLike, out_dir: PathLike, output_prefix: str = ""
+) -> None:
     """Compute the list of missing modalities for each subject in a BIDS compliant dataset.
 
-    Args:
-        bids_dir: path to the BIDS directory
-        out_dir: path to the output folder
-        output_prefix: string that replace the default prefix ('missing_mods_') in the name of all the output files
-    created
+    Parameters
+    ----------
+    bids_dir : PathLike
+        Path to the BIDS directory.
+
+    out_dir : PathLike
+        Path to the output folder.
+
+    output_prefix : str, optional
+        String that replaces the default prefix ('missing_mods_')
+        in the name of all the created output files.
+        Default = "".
     """
     import os
     from glob import glob
     from os import path
+    from pathlib import Path
 
     import pandas as pd
 
     from ..converter_utils import (
         MissingModsTracker,
-        print_longitudinal_analysis,
-        print_statistics,
+        write_longitudinal_analysis,
+        write_statistics,
     )
 
+    out_dir = Path(out_dir)
+    bids_dir = Path(bids_dir)
     os.makedirs(out_dir, exist_ok=True)
 
     # Find all the modalities and sessions available for the input dataset
@@ -557,13 +569,8 @@ def compute_missing_mods(bids_dir, out_dir, output_prefix=""):
     cols_dataframe.insert(0, "participant_id")
     mmt = MissingModsTracker(sessions_found, mods_avail)
 
-    if output_prefix == "":
-        out_file_name = "missing_mods_"
-    else:
-        out_file_name = output_prefix + "_"
+    out_file_name = "missing_mods_" if output_prefix == "" else output_prefix + "_"
 
-    summary_file = open(path.join(out_dir, out_file_name + "summary.txt"), "w")
-    analysis_file = open(path.join(out_dir, "analysis.txt"), "w")
     missing_mods_df = pd.DataFrame(columns=cols_dataframe)
     row_to_append_df = pd.DataFrame(columns=cols_dataframe)
     subjects_paths_lists = glob(path.join(bids_dir, "*sub-*"))
@@ -676,9 +683,14 @@ def compute_missing_mods(bids_dir, out_dir, output_prefix=""):
         )
         missing_mods_df = pd.DataFrame(columns=cols_dataframe)
 
-    print_statistics(summary_file, len(subjects_paths_lists), sessions_found, mmt)
-    print_longitudinal_analysis(
-        analysis_file, bids_dir, out_dir, sessions_found, out_file_name
+    write_statistics(
+        out_dir / out_file_name / "summary.txt",
+        len(subjects_paths_lists),
+        sessions_found,
+        mmt,
+    )
+    write_longitudinal_analysis(
+        out_dir / "analysis.txt", bids_dir, out_dir, sessions_found, out_file_name
     )
 
 

--- a/test/unittests/iotools/test_converter_utils.py
+++ b/test/unittests/iotools/test_converter_utils.py
@@ -44,3 +44,156 @@ def test_viscode_to_session(input, expected):
     from clinica.iotools.converter_utils import viscode_to_session
 
     assert viscode_to_session(input) == expected
+
+
+@pytest.mark.parametrize(
+    "sessions,modalities,expected",
+    [
+        ([], None, {}),
+        (
+            ["ses-M000", "ses-M006"],
+            None,
+            {
+                k: {
+                    "session": 0,
+                    "dwi": 0,
+                    "func": 0,
+                    "fieldmap": 0,
+                    "flair": 0,
+                    "t1w": 0,
+                }
+                for k in ["ses-M000", "ses-M006"]
+            },
+        ),
+        ([], ["fmri"], {}),
+        (
+            ["ses-M000", "ses-M006"],
+            ["fmri", "dwi"],
+            {k: {"session": 0, "dwi": 0, "fmri": 0} for k in ["ses-M000", "ses-M006"]},
+        ),
+    ],
+)
+def test_missing_mods_tracker_instantiation(sessions, modalities, expected):
+    from clinica.iotools.converter_utils import MissingModsTracker
+
+    tracker = MissingModsTracker(sessions, modalities)
+    assert tracker.missing == expected
+    assert tracker.ses == sessions
+    assert tracker.get_missing_list() == expected
+
+
+def test_missing_mods_tracker_add_errors():
+    from clinica.iotools.converter_utils import MissingModsTracker
+
+    tracker = MissingModsTracker(["ses-M000", "ses-M006"], ["fmri", "dwi"])
+
+    with pytest.raises(
+        ValueError,
+        match="Session foo was not provided to the MissingModsTracker constructor.",
+    ):
+        tracker.add_missing_mod("foo", "fmri")
+        tracker.increase_missing_ses("foo")
+
+    with pytest.raises(
+        ValueError,
+        match="Modality foo is not tracked by this instance of MissingModsTracker.",
+    ):
+        tracker.add_missing_mod("ses-M006", "foo")
+
+
+def test_missing_mods_tracker_add():
+    from clinica.iotools.converter_utils import MissingModsTracker
+
+    tracker = MissingModsTracker(["ses-M000", "ses-M006"], ["fmri", "dwi"])
+    tracker.increase_missing_ses("ses-M000")
+    assert tracker.missing["ses-M000"]["session"] == 1
+    assert tracker.missing["ses-M006"]["session"] == 0
+    tracker.add_missing_mod("ses-M006", "dwi")
+    assert tracker.missing["ses-M006"]["dwi"] == 1
+    assert tracker.missing["ses-M000"]["dwi"] == 0
+    tracker.add_missing_mod("ses-M000", "dwi")
+    assert tracker.missing["ses-M006"]["dwi"] == 1
+    assert tracker.missing["ses-M000"]["dwi"] == 1
+
+
+def test_compute_statistics():
+    from clinica.iotools.converter_utils import MissingModsTracker, compute_statistics
+
+    tracker = MissingModsTracker(["ses-M000", "ses-M006"], ["fmri", "dwi"])
+    tracker.increase_missing_ses("ses-M000")
+    tracker.add_missing_mod("ses-M006", "dwi")
+    assert compute_statistics(2, ["ses-M000", "ses-M006"], tracker) == (
+        "**********************************************\n"
+        "Number of subjects converted: 2\n"
+        "Sessions available: ['ses-M000', 'ses-M006']\n\n"
+        "Number of sessions ses-M000 found: 1 (50.0%)\n\n"
+        "Number of sessions ses-M006 found: 2 (100.0%)\n\n"
+        "**********************************************\n\n"
+        "Number of missing modalities for each session:\n\n"
+        "ses-M000\nfmri: 0 (0.0%) \ndwi: 0 (0.0%) \n\n"
+        "ses-M006\nfmri: 0 (0.0%) \ndwi: 1 (50.0%) \n"
+    )
+
+
+def test_compute_table():
+    from clinica.iotools.converter_utils import compute_table
+
+    mods = {
+        "foo": {
+            "missing": 42,
+            "n/a": 16,
+            "bar": 23,
+        },
+        "bar": {
+            "missing": 0,
+            "baz": 7,
+        },
+    }
+    assert compute_table(mods) == (
+        "\tbar\t| baz\t| missing\t| n/a\n------------------------------------------------\n"
+        "foo\t23\t| 0\t| 42\t| 16\nbar\t0\t| 7\t| 0\t| 0\n"
+    )
+
+
+def test_compute_longitudinal_analysis(tmp_path):
+    import pandas as pd
+
+    from clinica.iotools.converter_utils import compute_longitudinal_analysis
+
+    sessions = ["ses-M000", "ses-M006"]
+    for subject in ("sub-01", "sub-03"):
+        (tmp_path / "bids" / subject).mkdir(parents=True)
+    for ses in sessions:
+        df = pd.DataFrame(
+            [["sub-01", 1, 0, 1], ["sub-03", 0, 1, 1]],
+            columns=["participant_id", "foo", "bar", "baz"],
+        )
+        df.to_csv(tmp_path / f"missing_mods_{ses}.tsv", sep="\t", index=False)
+    df = pd.DataFrame(
+        [
+            ["ses-M000", 18, "foooo", "CN", "ADNI"],
+            ["ses-M006", 19, "foooo", "AD", "ADNI"],
+        ],
+        columns=["session_id", "age", "foobarbaz", "diagnosis", "study"],
+    )
+    df.to_csv(
+        tmp_path / "bids" / "sub-01" / "sub-01_sessions.tsv", sep="\t", index=False
+    )
+    df = pd.DataFrame(
+        [["ses-M000", 66, "bar", 42, "ADNI"], ["ses-M012", 67, "baz", 69, "ADNI"]],
+        columns=["session_id", "age", "bar", "diagnosis", "study"],
+    )
+    df.to_csv(
+        tmp_path / "bids" / "sub-03" / "sub-03_sessions.tsv", sep="\t", index=False
+    )
+    assert compute_longitudinal_analysis(
+        tmp_path / "bids", tmp_path, sessions, "missing_mods_"
+    ) == (
+        "**********************************************\n\n"
+        "Number of present diagnoses and modalities "
+        "for each session:\nses-M000\n\tCN\t| n/a\n"
+        "--------------------------------\nfoo\t1\t| 0\nbar\t0\t| "
+        "1\nbaz\t1\t| 1\n\n\nses-M006\n\tAD\t| missing\n"
+        "--------------------------------\nfoo\t1\t| "
+        "0\nbar\t0\t| 1\nbaz\t1\t| 1\n\n\n"
+    )


### PR DESCRIPTION
This PR proposes to update the utilities defined in `clinica.iotools.converter_utils.py`:

- Add type hints to functions
- Update existing docstrings to follow Numpydoc conventions
- Add documentations
- Refactor the `MissingModsTracker` class
      - Simplify constructor
      - Add safety checks in associated methods
- Refactor `print_statistics`, `print_longitudinal_analysis`, and `print_table`
      - Decouples the summary string generation logic from the file writing.
      - Rename to `write_*` since they write to files and don't print
      - Pass `Path` objects instead of file handles which avoids forgetting to close them
- Remove `has_one_index` which was not used
- Remove `increment_dict` and use a `Counter` object instead
- Add unit tests