### PR TITLE
[REF] Refactor `rename_into_caps` DWI utilities

### DIFF
--- a/clinica/pipelines/dwi_dti/dwi_dti_pipeline.py
+++ b/clinica/pipelines/dwi_dti/dwi_dti_pipeline.py
@@ -217,9 +217,9 @@ class DwiDti(cpe.Pipeline):
         from nipype.interfaces.mrtrix.preprocess import DWI2Tensor
 
         from clinica.utils.check_dependency import check_environment_variable
+        from clinica.utils.dwi import extract_bids_identifier_from_filename
 
         from .dwi_dti_utils import (
-            extract_bids_identifier_from_caps_filename,
             get_ants_transforms,
             get_caps_filenames,
             print_begin_pipeline,
@@ -233,7 +233,7 @@ class DwiDti(cpe.Pipeline):
             interface=nutil.Function(
                 input_names=["caps_dwi_filename"],
                 output_names=["bids_identifier"],
-                function=extract_bids_identifier_from_caps_filename,
+                function=extract_bids_identifier_from_filename,
             ),
             name="0-Get_BIDS_Identifier",
         )

--- a/clinica/pipelines/dwi_dti/dwi_dti_utils.py
+++ b/clinica/pipelines/dwi_dti/dwi_dti_utils.py
@@ -49,21 +49,6 @@ def statistics_on_atlases(in_registered_map, name_map, prefix_file=None):
     return atlas_statistics_list
 
 
-def extract_bids_identifier_from_caps_filename(caps_dwi_filename: str) -> str:
-    """Extract BIDS identifier from CAPS filename."""
-    import re
-
-    m = re.search(r"(sub-[a-zA-Z0-9]+)_(ses-[a-zA-Z0-9]+).*_dwi", caps_dwi_filename)
-
-    if not m:
-        raise ValueError(
-            f"Input filename {caps_dwi_filename} is not in a CAPS compliant format."
-        )
-    bids_identifier = m.group(0)
-
-    return bids_identifier
-
-
 def get_caps_filenames(caps_dwi_filename: str):
     """Prepare some filenames with CAPS naming convention."""
     import re
@@ -91,77 +76,43 @@ def get_caps_filenames(caps_dwi_filename: str):
 
 
 def rename_into_caps(
-    in_caps_dwi,
-    in_norm_fa,
-    in_norm_md,
-    in_norm_ad,
-    in_norm_rd,
-    in_b_spline_transform,
-    in_affine_matrix,
-):
+    in_caps_dwi: str,
+    in_norm_fa: str,
+    in_norm_md: str,
+    in_norm_ad: str,
+    in_norm_rd: str,
+    in_b_spline_transform: str,
+    in_affine_matrix: str,
+) -> tuple:
     """Rename different outputs of the pipelines into CAPS format.
 
-    Returns:
+    Parameters
+    ----------
+    in_caps_dwi : str
+    in_norm_fa : str
+    in_norm_md : str
+    in_norm_ad : str
+    in_norm_rd : str
+    in_b_spline_transform : str
+    in_affine_matrix : str
+
+    Returns
+    -------
+    tuple :
         The different outputs with CAPS naming convention
     """
-    from nipype.interfaces.utility import Rename
+    from clinica.utils.dwi import rename_files
 
-    from clinica.pipelines.dwi_dti.dwi_dti_utils import (
-        extract_bids_identifier_from_caps_filename,
-    )
-
-    bids_identifier = extract_bids_identifier_from_caps_filename(in_caps_dwi)
-
-    # CAPS normalized FA
-    rename_fa = Rename()
-    rename_fa.inputs.in_file = in_norm_fa
-    rename_fa.inputs.format_string = (
-        f"{bids_identifier}_space-MNI152Lin_res-1x1x1_FA.nii.gz"
-    )
-    out_caps_fa = rename_fa.run()
-    # CAPS normalized MD
-    rename_md = Rename()
-    rename_md.inputs.in_file = in_norm_md
-    rename_md.inputs.format_string = (
-        f"{bids_identifier}_space-MNI152Lin_res-1x1x1_MD.nii.gz"
-    )
-    out_caps_md = rename_md.run()
-    # CAPS normalized AD
-    rename_ad = Rename()
-    rename_ad.inputs.in_file = in_norm_ad
-    rename_ad.inputs.format_string = (
-        f"{bids_identifier}_space-MNI152Lin_res-1x1x1_AD.nii.gz"
-    )
-    out_caps_ad = rename_ad.run()
-    # CAPS normalized RD
-    rename_rd = Rename()
-    rename_rd.inputs.in_file = in_norm_rd
-    rename_rd.inputs.format_string = (
-        f"{bids_identifier}_space-MNI152Lin_res-1x1x1_RD.nii.gz"
-    )
-    out_caps_rd = rename_rd.run()
-    # CAPS B-spline transform
-    rename_b_spline = Rename()
-    rename_b_spline.inputs.in_file = in_b_spline_transform
-    rename_b_spline.inputs.format_string = (
-        f"{bids_identifier}_space-MNI152Lin_res-1x1x1_deformation.nii.gz"
-    )
-    out_caps_b_spline_transform = rename_b_spline.run()
-    # CAPS Affine matrix
-    rename_affine = Rename()
-    rename_affine.inputs.in_file = in_affine_matrix
-    rename_affine.inputs.format_string = (
-        f"{bids_identifier}_space-MNI152Lin_res-1x1x1_affine.mat"
-    )
-    out_caps_affine_matrix = rename_affine.run()
-
-    return (
-        out_caps_fa.outputs.out_file,
-        out_caps_md.outputs.out_file,
-        out_caps_ad.outputs.out_file,
-        out_caps_rd.outputs.out_file,
-        out_caps_b_spline_transform.outputs.out_file,
-        out_caps_affine_matrix.outputs.out_file,
+    return rename_files(
+        in_caps_dwi,
+        {
+            in_norm_fa: "_space-MNI152Lin_res-1x1x1_FA.nii.gz",
+            in_norm_md: "_space-MNI152Lin_res-1x1x1_MD.nii.gz",
+            in_norm_ad: "_space-MNI152Lin_res-1x1x1_AD.nii.gz",
+            in_norm_rd: "_space-MNI152Lin_res-1x1x1_RD.nii.gz",
+            in_b_spline_transform: "_space-MNI152Lin_res-1x1x1_deformation.nii.gz",
+            in_affine_matrix: "_space-MNI152Lin_res-1x1x1_affine.mat",
+        },
     )
 
 

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_utils.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_utils.py
@@ -1,109 +1,59 @@
 def rename_into_caps(
-    in_bids_dwi,
-    fname_dwi,
-    fname_bval,
-    fname_bvec,
-    fname_brainmask,
-    fname_magnitude,
-    fname_fmap,
-    fname_smoothed_fmap,
-):
+    in_bids_dwi: str,
+    fname_dwi: str,
+    fname_bval: str,
+    fname_bvec: str,
+    fname_brainmask: str,
+    fname_magnitude: str,
+    fname_fmap: str,
+    fname_smoothed_fmap: str,
+) -> tuple:
     """Rename the outputs of the pipelines into CAPS.
 
-    Args:
-        in_bids_dwi (str): Input BIDS DWI to extract the <source_file>
-        fname_dwi (str): Preprocessed DWI file.
-        fname_bval (str): Preprocessed bval.
-        fname_bvec (str): Preprocessed bvec.
-        fname_brainmask (str): B0 mask.
-        fname_smoothed_fmap (str): Smoothed (calibrated) fmap on b0 space.
-        fname_fmap (str): Calibrated fmap on b0 space.
-        fname_magnitude (str): Magnitude image on b0 space.
+    Parameters
+    ----------
+    in_bids_dwi : str
+        Path to input BIDS DWI to extract the <source_file>
 
-    Returns:
-        Tuple[str, str, str, str, str, str, str]: The different outputs in CAPS format.
+    fname_dwi : str
+        Name of preprocessed DWI file.
+
+    fname_bval : str
+        Name of preprocessed bval file.
+
+    fname_bvec : str
+        Name of preprocessed bvec file.
+
+    fname_brainmask : str
+        Name of B0 mask file.
+
+    fname_smoothed_fmap : str
+        Name of smoothed (calibrated) fmap file on b0 space.
+
+    fname_fmap : str
+        Name of calibrated fmap file on b0 space.
+
+    fname_magnitude : str
+        Name of magnitude image file on b0 space.
+
+    Returns
+    -------
+    Tuple[str, str, str, str, str, str, str] :
+        The different outputs in CAPS format.
     """
-    import os
+    from clinica.utils.dwi import rename_files
 
-    from nipype.interfaces.utility import Rename
-    from nipype.utils.filemanip import split_filename
-
-    # Extract <source_file> in format sub-CLNC01_ses-M000_[acq-label]_dwi
-    _, source_file_dwi, _ = split_filename(in_bids_dwi)
-
-    # Extract base path from fname:
-    base_dir_dwi, _, _ = split_filename(fname_dwi)
-    base_dir_bval, _, _ = split_filename(fname_bval)
-    base_dir_bvec, _, _ = split_filename(fname_bvec)
-    base_dir_brainmask, _, _ = split_filename(fname_brainmask)
-    base_dir_smoothed_fmap, _, _ = split_filename(fname_smoothed_fmap)
-    base_dir_calibrated_fmap, _, _ = split_filename(fname_fmap)
-    base_dir_magnitude, _, _ = split_filename(fname_magnitude)
-
-    # Rename into CAPS DWI:
-    rename_dwi = Rename()
-    rename_dwi.inputs.in_file = fname_dwi
-    rename_dwi.inputs.format_string = os.path.join(
-        base_dir_dwi, f"{source_file_dwi}_space-b0_preproc.nii.gz"
-    )
-    out_caps_dwi = rename_dwi.run()
-
-    # Rename into CAPS bval:
-    rename_bval = Rename()
-    rename_bval.inputs.in_file = fname_bval
-    rename_bval.inputs.format_string = os.path.join(
-        base_dir_bval, f"{source_file_dwi}_space-b0_preproc.bval"
-    )
-    out_caps_bval = rename_bval.run()
-
-    # Rename into CAPS bvec:
-    rename_bvec = Rename()
-    rename_bvec.inputs.in_file = fname_bvec
-    rename_bvec.inputs.format_string = os.path.join(
-        base_dir_bvec, f"{source_file_dwi}_space-b0_preproc.bvec"
-    )
-    out_caps_bvec = rename_bvec.run()
-
-    # Rename into CAPS brainmask:
-    rename_brainmask = Rename()
-    rename_brainmask.inputs.in_file = fname_brainmask
-    rename_brainmask.inputs.format_string = os.path.join(
-        base_dir_brainmask, f"{source_file_dwi}_space-b0_brainmask.nii.gz"
-    )
-    out_caps_brainmask = rename_brainmask.run()
-
-    # Rename into CAPS magnitude:
-    rename_magnitude = Rename()
-    rename_magnitude.inputs.in_file = fname_magnitude
-    rename_magnitude.inputs.format_string = os.path.join(
-        base_dir_magnitude, f"{source_file_dwi}_space-b0_magnitude1.nii.gz"
-    )
-    out_caps_magnitude = rename_magnitude.run()
-
-    # Rename into CAPS fmap:
-    rename_calibrated_fmap = Rename()
-    rename_calibrated_fmap.inputs.in_file = fname_fmap
-    rename_calibrated_fmap.inputs.format_string = os.path.join(
-        base_dir_calibrated_fmap, f"{source_file_dwi}_space-b0_fmap.nii.gz"
-    )
-    out_caps_fmap = rename_calibrated_fmap.run()
-
-    # Rename into CAPS smoothed fmap:
-    rename_smoothed_fmap = Rename()
-    rename_smoothed_fmap.inputs.in_file = fname_smoothed_fmap
-    rename_smoothed_fmap.inputs.format_string = os.path.join(
-        base_dir_smoothed_fmap, f"{source_file_dwi}_space-b0_fwhm-4_fmap.nii.gz"
-    )
-    out_caps_smoothed_fmap = rename_smoothed_fmap.run()
-
-    return (
-        out_caps_dwi.outputs.out_file,
-        out_caps_bval.outputs.out_file,
-        out_caps_bvec.outputs.out_file,
-        out_caps_brainmask.outputs.out_file,
-        out_caps_magnitude.outputs.out_file,
-        out_caps_fmap.outputs.out_file,
-        out_caps_smoothed_fmap.outputs.out_file,
+    return rename_files(
+        in_bids_dwi,
+        {
+            fname_dwi: "_space-b0_preproc.nii.gz",
+            fname_bval: "_space-b0_preproc.bval",
+            fname_bvec: "_space-b0_preproc.bval",
+            fname_brainmask: "_space-b0_brainmask.nii.gz",
+            fname_magnitude: "_space-b0_magnitude1.nii.gz",
+            fname_fmap: "_space-b0_fmap.nii.gz",
+            fname_smoothed_fmap: "_space-b0_fwhm-4_fmap.nii.gz",
+        },
     )
 
 

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_utils.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_utils.py
@@ -1,68 +1,44 @@
-def rename_into_caps(in_bids_dwi, fname_dwi, fname_bval, fname_bvec, fname_brainmask):
+def rename_into_caps(
+    in_bids_dwi: str,
+    fname_dwi: str,
+    fname_bval: str,
+    fname_bvec: str,
+    fname_brainmask: str,
+):
     """Rename the outputs of the pipelines into CAPS.
 
+    Parameters
+    ----------
+    in_bids_dwi : str
+        Path to input BIDS DWI to extract the <source_file>
 
-    Args:
-        in_bids_dwi (str): Input BIDS DWI to extract the <source_file>
-        fname_dwi (str): Preprocessed DWI file.
-        fname_bval (str): Preprocessed bval.
-        fname_bvec (str): Preprocessed bvec.
-        fname_brainmask (str): B0 mask.
+    fname_dwi : str
+        Name of preprocessed DWI file.
 
-    Returns:
-        Tuple[str, str, str, str]: The different outputs in CAPS format.
+    fname_bval : str
+        Name of preprocessed bval file.
+
+    fname_bvec : str
+        Name of preprocessed bvec file.
+
+    fname_brainmask : str
+        Name of B0 mask file.
+
+    Returns
+    -------
+    Tuple[str, str, str, str]
+        The different outputs in CAPS format.
     """
-    import os
+    from clinica.utils.dwi import rename_files
 
-    from nipype.interfaces.utility import Rename
-    from nipype.utils.filemanip import split_filename
-
-    # Extract <source_file> in format sub-CLNC01_ses-M000[_acq-label]_dwi
-    _, source_file_dwi, _ = split_filename(in_bids_dwi)
-
-    # Extract base path from fname:
-    base_dir_dwi, _, _ = split_filename(fname_dwi)
-    base_dir_bval, _, _ = split_filename(fname_bval)
-    base_dir_bvec, _, _ = split_filename(fname_bvec)
-    base_dir_brainmask, _, _ = split_filename(fname_brainmask)
-
-    # Rename into CAPS DWI:
-    rename_dwi = Rename()
-    rename_dwi.inputs.in_file = fname_dwi
-    rename_dwi.inputs.format_string = os.path.join(
-        base_dir_dwi, f"{source_file_dwi}_space-T1w_preproc.nii.gz"
-    )
-    out_caps_dwi = rename_dwi.run()
-
-    # Rename into CAPS bval:
-    rename_bval = Rename()
-    rename_bval.inputs.in_file = fname_bval
-    rename_bval.inputs.format_string = os.path.join(
-        base_dir_bval, f"{source_file_dwi}_space-T1w_preproc.bval"
-    )
-    out_caps_bval = rename_bval.run()
-
-    # Rename into CAPS bvec:
-    rename_bvec = Rename()
-    rename_bvec.inputs.in_file = fname_bvec
-    rename_bvec.inputs.format_string = os.path.join(
-        base_dir_bvec, f"{source_file_dwi}_space-T1w_preproc.bvec"
-    )
-    out_caps_bvec = rename_bvec.run()
-
-    # Rename into CAPS DWI:
-    rename_brainmask = Rename()
-    rename_brainmask.inputs.in_file = fname_brainmask
-    rename_brainmask.inputs.format_string = os.path.join(
-        base_dir_brainmask, f"{source_file_dwi}_space-T1w_brainmask.nii.gz"
-    )
-    out_caps_brainmask = rename_brainmask.run()
-
-    return (
-        out_caps_dwi.outputs.out_file,
-        out_caps_bval.outputs.out_file,
-        out_caps_bvec.outputs.out_file,
-        out_caps_brainmask.outputs.out_file,
+    return rename_files(
+        in_bids_dwi,
+        {
+            fname_dwi: "_space-T1w_preproc.nii.gz",
+            fname_bval: "_space-T1w_preproc.bval",
+            fname_bvec: "_space-T1w_preproc.bval",
+            fname_brainmask: "_space-T1w_brainmask.nii.gz",
+        },
     )
 
 

--- a/clinica/utils/dwi.py
+++ b/clinica/utils/dwi.py
@@ -401,9 +401,14 @@ def extract_bids_identifier_from_filename(dwi_filename: str) -> str:
 def rename_files(in_caps_dwi: str, mapping: dict) -> tuple:
     """Rename files provided.
 
+    The new files are symbolic links to old files.
+    For this reason, the old files still exists after renaming.
+
     Parameters
     ----------
     in_caps_dwi : str
+        A DWI file from the CAPS folder.
+        This is used only to extract the BIDS identifier.
 
     mapping : dict
         Mapping between original file names and suffixes for

--- a/clinica/utils/dwi.py
+++ b/clinica/utils/dwi.py
@@ -363,3 +363,69 @@ def bids_dir_to_fsl_dir(bids_dir):
         )
 
     return fsl_dir.replace("i", "x").replace("j", "y").replace("k", "z")
+
+
+def extract_bids_identifier_from_filename(dwi_filename: str) -> str:
+    """Extract BIDS identifier from CAPS filename.
+
+    Parameters
+    ----------
+    dwi_filename : str
+        DWI file name for which to extract the bids identifier.
+
+    Returns
+    -------
+    str :
+        The corresponding BIDS identifier.
+
+    Examples
+    --------
+    >>> extract_bids_identifier_from_filename("sub-01_ses-M000_dwi_space-b0_preproc.bval")
+    'sub-01_ses-M000_dwi'
+    >>> extract_bids_identifier_from_filename("sub-01_ses-M000_dwi.bvec")
+    'sub-01_ses-M000_dwi'
+    >>> extract_bids_identifier_from_filename("foo/bar/sub-01_ses-M000_dwi_baz.foo.bar")
+    'sub-01_ses-M000_dwi'
+    """
+    import re
+
+    m = re.search(r"(sub-[a-zA-Z0-9]+)_(ses-[a-zA-Z0-9]+).*_dwi", dwi_filename)
+    if not m:
+        raise ValueError(
+            f"Could not extract the BIDS identifier from the DWI input filename {dwi_filename}."
+        )
+
+    return m.group(0)
+
+
+def rename_files(in_caps_dwi: str, mapping: dict) -> tuple:
+    """Rename files provided.
+
+    Parameters
+    ----------
+    in_caps_dwi : str
+
+    mapping : dict
+        Mapping between original file names and suffixes for
+        new file names.
+
+    Returns
+    -------
+    tuple :
+        New file names.
+    """
+    import os
+
+    from nipype.interfaces.utility import Rename
+    from nipype.utils.filemanip import split_filename
+
+    bids_id = extract_bids_identifier_from_filename(in_caps_dwi)
+    renamed_files = []
+    for original_file, suffix in mapping.items():
+        base_dir, _, _ = split_filename(original_file)
+        rename = Rename()
+        rename.inputs.in_file = original_file
+        rename.inputs.format_string = os.path.join(base_dir, f"{bids_id}{suffix}")
+        renamed_files.append(rename.run().outputs.out_file)
+
+    return tuple(renamed_files)

--- a/test/unittests/utils/test_dwi.py
+++ b/test/unittests/utils/test_dwi.py
@@ -1,0 +1,55 @@
+import pytest
+
+
+def test_rename_files_errors(tmp_path):
+    from clinica.utils.dwi import rename_files
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Could not extract the BIDS identifier "
+            "from the DWI input filename foo.txt"
+        ),
+    ):
+        rename_files("foo.txt", {})
+    (tmp_path / "foo/bar").mkdir(parents=True)
+    with pytest.raises(
+        Exception,
+        match=(
+            "The 'in_file' trait of a RenameInputSpec instance must be a "
+            "pathlike object or string representing an existing file"
+        ),
+    ):
+        rename_files(
+            "sub-01_ses-M000_dwi_space-b0_preproc.bval",
+            {
+                str(tmp_path / "foo/bar/baz.nii.gz"): "_space-b0_preproc.nii.gz",
+            },
+        )
+
+
+def test_rename_files(tmp_path):
+    from clinica.utils.dwi import rename_files
+
+    assert rename_files("sub-01_ses-M000_dwi_space-b0_preproc.bval", {}) == ()
+    (tmp_path / "foo/bar").mkdir(parents=True)
+    (tmp_path / "foo/bar/baz.nii.gz").touch()
+    (tmp_path / "foo/bar/sub-02_ses-M666_dwi_foo.nii.gz").touch()
+    assert rename_files(
+        "sub-01_ses-M000_dwi_space-b0_preproc.bval",
+        {
+            str(tmp_path / "foo/bar/baz.nii.gz"): "_space-b0_preproc.nii.gz",
+            str(
+                tmp_path / "foo/bar/sub-02_ses-M666_dwi_foo.nii.gz"
+            ): "_space-b0_fwhm-4_fmap.nii.gz",
+        },
+    ) == (
+        str(tmp_path / "foo/bar/sub-01_ses-M000_dwi_space-b0_preproc.nii.gz"),
+        str(tmp_path / "foo/bar/sub-01_ses-M000_dwi_space-b0_fwhm-4_fmap.nii.gz"),
+    )
+    assert (tmp_path / "foo/bar/sub-01_ses-M000_dwi_space-b0_preproc.nii.gz").exists()
+    assert (
+        tmp_path / "foo/bar/sub-01_ses-M000_dwi_space-b0_fwhm-4_fmap.nii.gz"
+    ).exists()
+    assert (tmp_path / "foo/bar/baz.nii.gz").exists()
+    assert (tmp_path / "foo/bar/sub-02_ses-M666_dwi_foo.nii.gz").exists()


### PR DESCRIPTION
The `DWIDTI`, `DWIPreprocessingUsingT1`, and `DWIPreprocesingUsingPhasediff` pipelines all have a function `rename_into_caps` which instantiates iteratively as many `Rename` nodes as files to rename.

This PR proposes to do some refactoring such that:

- A loop is used to avoid code duplication
- The logic is moved to a common `rename_files` function in the `utils.dwi` module
- The function `extract_bids_identifier_from_caps_filename` is moved from `dwi_dti_utils` to `utils.dwi` since it is common to all DWI pipelines (could be made even more generic but let's do it gradually...). 
- It is renamed to `extract_bids_identifier_from_filename` because I don't see what is specific to CAPS structure in its logic.
- Type hints and documentation are added
- Unit tests for `rename_files` are added
