### PR TITLE
CI: Improve publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,22 +1,27 @@
 name: publish
 
 on:
-  # Trigger this workflow when a release is published.
   release:
-    types:
-      - published
+    types: [ published ]
 
 permissions:
-  # Allow checkout of the project.
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: snok/install-poetry@v1
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Build distribution
+        run: pipx run build
       - name: Publish to PyPI
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: make publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,6 @@ clean.py:
 clean.test:
 	@$(RM) -r .pytest_cache/
 
-.PHONY: config.pypi
-config.pypi:
-ifdef PYPI_TOKEN
-	@$(POETRY) config pypi-token.pypi "${PYPI_TOKEN}"
-else
-	$(error "Missing API token for PyPI repository")
-endif
-
 ## doc			: Build the documentation.
 .PHONY: doc
 doc: clean.doc install.doc
@@ -97,14 +89,6 @@ lint.isort:
 .PHONY: lock
 lock:
 	@$(POETRY) lock --no-update
-
-## publish		: Publish the package to PyPI.
-.PHONY: publish
-publish: publish.pypi
-
-.PHONY: publish.pypi
-publish.pypi: config.pypi
-	@$(POETRY) publish --build
 
 .PHONY: spellcheck
 spellcheck: install.dev

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ lock:
 spellcheck: install.dev
 	@$(POETRY) run codespell
 
+## test 		: Run unit tests.
 .PHONY: test
 test: install
 	@$(POETRY) run python -m pytest -v test/unittests


### PR DESCRIPTION
Use the official [build](https://pypa-build.readthedocs.io/) and [publish GHA](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/) from the PyPA to release Clinica to PyPI.