### PR TITLE
[TEST] Add non regression test for B0 flirt pipeline

### DIFF
--- a/test/nonregression/pipelines/test_run_pipelines_dwi.py
+++ b/test/nonregression/pipelines/test_run_pipelines_dwi.py
@@ -16,6 +16,26 @@ import pytest
 warnings.filterwarnings("ignore")
 
 
+@pytest.mark.fast
+def test_dwi_b0_flirt(cmdopt, tmp_path):
+    from clinica.pipelines.dwi_preprocessing_using_t1.dwi_preprocessing_using_t1_workflows import (
+        b0_flirt_pipeline,
+    )
+ 
+    base_dir = Path(cmdopt["input"])
+    input_dir, tmp_dir, ref_dir = configure_paths(base_dir, tmp_path, "DWIB0Flirt")
+    b0_flirt = b0_flirt_pipeline(num_b0s=11)
+    b0_flirt.inputs.inputnode.in_file = str(input_dir / "sub-01_ses-M000_dwi_b0.nii.gz")
+    (tmp_path / "tmp").mkdir()
+    b0_flirt.base_dir = str(tmp_path / "tmp")
+    b0_flirt.run()
+
+    out_file = fspath(tmp_path / "tmp" / "b0_coregistration" / "concat_ref_moving" / "merged_files.nii.gz")
+    ref_file = fspath(ref_dir / "merged_files.nii.gz")
+
+    assert similarity_measure(out_file, ref_file, 0.99)
+
+
 @pytest.mark.slow
 def test_dwi_preprocessing_using_t1(cmdopt, tmp_path):
     base_dir = Path(cmdopt["input"])

--- a/test/nonregression/pipelines/test_run_pipelines_dwi.py
+++ b/test/nonregression/pipelines/test_run_pipelines_dwi.py
@@ -21,7 +21,7 @@ def test_dwi_b0_flirt(cmdopt, tmp_path):
     from clinica.pipelines.dwi_preprocessing_using_t1.dwi_preprocessing_using_t1_workflows import (
         b0_flirt_pipeline,
     )
- 
+
     base_dir = Path(cmdopt["input"])
     input_dir, tmp_dir, ref_dir = configure_paths(base_dir, tmp_path, "DWIB0Flirt")
     b0_flirt = b0_flirt_pipeline(num_b0s=11)
@@ -30,7 +30,13 @@ def test_dwi_b0_flirt(cmdopt, tmp_path):
     b0_flirt.base_dir = str(tmp_path / "tmp")
     b0_flirt.run()
 
-    out_file = fspath(tmp_path / "tmp" / "b0_coregistration" / "concat_ref_moving" / "merged_files.nii.gz")
+    out_file = fspath(
+        tmp_path
+        / "tmp"
+        / "b0_coregistration"
+        / "concat_ref_moving"
+        / "merged_files.nii.gz"
+    )
     ref_file = fspath(ref_dir / "merged_files.nii.gz")
 
     assert similarity_measure(out_file, ref_file, 0.99)


### PR DESCRIPTION
This PR proposes to add non regression tests specific to the `b0_flirt` pipeline which relies on FSL to perform rigid registration of the B0 dataset onto the first DWI volume.
The pipeline is defined here:

https://github.com/aramis-lab/clinica/blob/0566ca64de22e5c9ec522cdb0268c1c04538c2c7/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py#L334-L338

and used in the `DWIPreprocessingUsingT1` pipeline:

https://github.com/aramis-lab/clinica/blob/5733d8c1c5817fa8dcff5b4ce38b4c06802f20b6/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_utils.py#L284-L287

The test is relatively fast and runs in a few minutes (usually 3 to 4 minutes).

This PR is linked to the data PR: https://github.com/aramis-lab/clinica_data_ci/pull/24