### PR TITLE
[REF] Use `eddy_fsl_pipeline` in `DWIPreprocessingUsingPhasediff`

### DIFF
--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
@@ -320,7 +320,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
         )
 
         reference_b0 = compute_reference_b0(
-            low_bval=self.parameters["low_bval"],
+            b_value_threshold=self.parameters["low_bval"],
             use_cuda=self.parameters["use_cuda"],
             initrand=self.parameters["initrand"],
         )
@@ -360,7 +360,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
         # Step 3: Run FSL eddy
         # ====================
         eddy = eddy_fsl_pipeline(
-            low_bval=self.parameters["low_bval"],
+            b_value_threshold=self.parameters["low_bval"],
             use_cuda=self.parameters["use_cuda"],
             initrand=self.parameters["initrand"],
             image_id=True,
@@ -413,9 +413,9 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
                                               ("fmap_phasediff_json", "fmap_phasediff_json")]),
                 # Step 1: Computation of the reference b0 (i.e. average b0 but with EPI distortions)
                 # =======================================
-                (init_node, reference_b0, [("bval", "inputnode.b_values"),
-                                           ("bvec", "inputnode.b_vectors"),
-                                           ("dwi", "inputnode.dwi"),
+                (init_node, reference_b0, [("bval", "inputnode.b_values_filename"),
+                                           ("bvec", "inputnode.b_vectors_filename"),
+                                           ("dwi", "inputnode.dwi_filename"),
                                            ("total_readout_time", "inputnode.total_readout_time"),
                                            ("phase_encoding_direction", "inputnode.phase_encoding_direction"),
                                            ("image_id", "inputnode.image_id")]),
@@ -446,9 +446,9 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
 
                 # Step 3: Run FSL eddy
                 # ====================
-                (init_node, eddy, [("dwi", "inputnode.in_file"),
-                                   ("bval", "inputnode.in_bval"),
-                                   ("bvec", "inputnode.in_bvec"),
+                (init_node, eddy, [("dwi", "inputnode.dwi_filename"),
+                                   ("bval", "inputnode.b_values_filename"),
+                                   ("bvec", "inputnode.b_vectors_filename"),
                                    ("image_id", "inputnode.image_id")]),
                 (smoothing, eddy, [("out_file", "inputnode.field")]),
                 (reference_b0, eddy, [("outputnode.brainmask", "inputnode.in_mask")]),

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
@@ -363,6 +363,8 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
             low_bval=self.parameters["low_bval"],
             use_cuda=self.parameters["use_cuda"],
             initrand=self.parameters["initrand"],
+            image_id=True,
+            field=True,
         )
 
         # Step 4: Bias correction
@@ -434,11 +436,11 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
                 # Apply the transformation on the magnitude image
                 (bet_mag_fmap2b0, mag_fmap2b0, [("out_matrix_file", "in_matrix_file")]),
                 (bias_mag_fmap, mag_fmap2b0, [("output_image", "in_file")]),
-                (reference_b0, mag_fmap2b0, [("outputnode.out_file", "reference")]),
+                (reference_b0, mag_fmap2b0, [("outputnode.reference_b0", "reference")]),
                 # Apply the transformation on the calibrated fmap
                 (bet_mag_fmap2b0, fmap2b0, [("out_matrix_file", "in_matrix_file")]),
                 (calibrate_fmap, fmap2b0, [("output_node.calibrated_fmap", "in_file")]),
-                (reference_b0, fmap2b0, [("outputnode.out_file", "reference")]),
+                (reference_b0, fmap2b0, [("outputnode.reference_b0", "reference")]),
                 # # Smooth the registered (calibrated) fmap
                 (fmap2b0, smoothing, [("out_file", "in_file")]),
 
@@ -449,7 +451,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
                                    ("bvec", "inputnode.in_bvec"),
                                    ("image_id", "inputnode.image_id")]),
                 (smoothing, eddy, [("out_file", "inputnode.field")]),
-                (reference_b0, eddy, [("brainmask", "inputnode.in_mask")]),
+                (reference_b0, eddy, [("outputnode.brainmask", "inputnode.in_mask")]),
 
                 # Step 4: Bias correction
                 # =======================

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
@@ -430,7 +430,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
                                              ("delta_echo_time", "input_node.delta_echo_time")]),
                 # Register the BET magnitude fmap onto the BET b0
                 (bet_mag_fmap, bet_mag_fmap2b0, [("out_file", "in_file")]),
-                (reference_b0, bet_mag_fmap2b0, [("out_file", "reference")]),
+                (reference_b0, bet_mag_fmap2b0, [("reference_b0", "reference")]),
                 # Apply the transformation on the magnitude image
                 (bet_mag_fmap2b0, mag_fmap2b0, [("out_matrix_file", "in_matrix_file")]),
                 (bias_mag_fmap, mag_fmap2b0, [("output_image", "in_file")]),
@@ -449,7 +449,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
                                    ("bvec", "in_bvec"),
                                    ("image_id", "image_id")]),
                 (smoothing, eddy, [("out_file", "field")]),
-                (reference_b0, eddy, [("b0_mask", "in_mask")]),
+                (reference_b0, eddy, [("brainmask", "in_mask")]),
 
                 # Step 4: Bias correction
                 # =======================
@@ -462,7 +462,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
                 (init_node, compute_avg_b0, [("bval", "in_bval")]),
                 (bias, compute_avg_b0, [("out_file", "in_dwi")]),
                 # Compute b0 mask on corrected avg b0
-                (compute_avg_b0, mask_avg_b0, [("out_b0_average", "in_file")]),
+                (compute_avg_b0, mask_avg_b0, [("reference_b0", "in_file")]),
 
                 # Print end message
                 (init_node, print_end_message, [("image_id", "image_id")]),

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
@@ -430,32 +430,32 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
                                              ("delta_echo_time", "input_node.delta_echo_time")]),
                 # Register the BET magnitude fmap onto the BET b0
                 (bet_mag_fmap, bet_mag_fmap2b0, [("out_file", "in_file")]),
-                (reference_b0, bet_mag_fmap2b0, [("reference_b0", "reference")]),
+                (reference_b0, bet_mag_fmap2b0, [("outputnode.reference_b0", "reference")]),
                 # Apply the transformation on the magnitude image
                 (bet_mag_fmap2b0, mag_fmap2b0, [("out_matrix_file", "in_matrix_file")]),
                 (bias_mag_fmap, mag_fmap2b0, [("output_image", "in_file")]),
-                (reference_b0, mag_fmap2b0, [("out_file", "reference")]),
+                (reference_b0, mag_fmap2b0, [("outputnode.out_file", "reference")]),
                 # Apply the transformation on the calibrated fmap
                 (bet_mag_fmap2b0, fmap2b0, [("out_matrix_file", "in_matrix_file")]),
                 (calibrate_fmap, fmap2b0, [("output_node.calibrated_fmap", "in_file")]),
-                (reference_b0, fmap2b0, [("out_file", "reference")]),
+                (reference_b0, fmap2b0, [("outputnode.out_file", "reference")]),
                 # # Smooth the registered (calibrated) fmap
                 (fmap2b0, smoothing, [("out_file", "in_file")]),
 
                 # Step 3: Run FSL eddy
                 # ====================
-                (init_node, eddy, [("dwi", "in_file"),
-                                   ("bval", "in_bval"),
-                                   ("bvec", "in_bvec"),
-                                   ("image_id", "image_id")]),
-                (smoothing, eddy, [("out_file", "field")]),
-                (reference_b0, eddy, [("brainmask", "in_mask")]),
+                (init_node, eddy, [("dwi", "inputnode.in_file"),
+                                   ("bval", "inputnode.in_bval"),
+                                   ("bvec", "inputnode.in_bvec"),
+                                   ("image_id", "inputnode.image_id")]),
+                (smoothing, eddy, [("out_file", "inputnode.field")]),
+                (reference_b0, eddy, [("brainmask", "inputnode.in_mask")]),
 
                 # Step 4: Bias correction
                 # =======================
                 (init_node, bias, [("bval", "in_bval")]),
-                (eddy, bias, [("out_rotated_bvecs", "in_bvec"),
-                              ("out_corrected", "in_file")]),
+                (eddy, bias, [("outputnode.out_rotated_bvecs", "in_bvec"),
+                              ("outputnode.out_corrected", "in_file")]),
                 # Step 5: Final brainmask
                 # =======================
                 # Compute average b0 on corrected dataset (for brain mask extraction)
@@ -470,7 +470,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
 
                 # Output node
                 (init_node, self.output_node, [("bval", "preproc_bval")]),
-                (eddy, self.output_node, [("out_rotated_bvecs", "preproc_bvec")]),
+                (eddy, self.output_node, [("outputnode.out_rotated_bvecs", "preproc_bvec")]),
                 (bias, self.output_node, [("out_file", "preproc_dwi")]),
                 (mask_avg_b0, self.output_node, [("mask_file", "b0_mask")]),
                 (bet_mag_fmap2b0, self.output_node, [("out_file", "magnitude_on_b0")]),

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_utils.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_utils.py
@@ -57,9 +57,8 @@ def rename_into_caps(
     )
 
 
-def get_grad_fsl(bvec, bval):
-    grad_fsl = (bvec, bval)
-    return grad_fsl
+def get_grad_fsl(b_vectors_filename: str, b_values_filename) -> tuple:
+    return b_vectors_filename, b_values_filename
 
 
 def init_input_node(

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_workflows.py
@@ -1,3 +1,8 @@
+from typing import Optional
+
+from nipype.pipeline.engine import Workflow
+
+
 def prepare_phasediff_fmap(name="prepare_phasediff_fmap"):
     """This workflow adapts the fsl_prepare_fieldmap script from FSL for the FSL eddy command.
 
@@ -110,10 +115,10 @@ def compute_reference_b0(
     low_bval: float,
     use_cuda: bool,
     initrand: bool,
-    output_dir=None,
-    name="compute_reference_b0",
-):
-    """Step 1 of the DWI preprocessing using phasediff pipeline.
+    output_dir: Optional[str] = None,
+    name: str = "compute_reference_b0",
+) -> Workflow:
+    """Step 1 of the DWI preprocessing using phase diff pipeline.
 
     Compute the reference b0 (i.e. average b0 with EPI distortions)
 
@@ -121,21 +126,39 @@ def compute_reference_b0(
         - MRtrix3 to compute the whole brain mask
         - FSL to run Eddy and BET
 
-    It takes as inputs:
-        - "dwi": The path to the DWI image
-        - "b_vecors": The path to the associated B-vectors file
-        - "b_values": The path to the associated B-values file
-        - "total_readout_time": The total readout time extracted from JSON metadata
-        - "phase_encoding_direction": The phase encoding direction extracted from JSON metadata
-        - "image_id": Prefix to be used for output files
+    Parameters
+    ----------
+    low_bval: float
+        Threshold value to determine the B0 volumes in the DWI image
 
-    It is parametrized by:
-        - low_bval: float, threshold value to determine the B0 volumes in the DWI image
-        - use_cuda: bool, boolean to indicate whether cuda should be used or not
-        - initrand: bool, ???
-        - output_dir: str, path to output directory. If provided, the pipeline will write
-          its output in this folder.
-        - name: str, name of the pipeline
+    use_cuda: bool
+        Boolean to indicate whether cuda should be used or not
+
+    initrand: bool
+        ???
+
+    output_dir: str, optional
+        Path to output directory.
+        If provided, the pipeline will write its output in this folder.
+        Default to None.
+
+    name: str, optional
+        Name of the pipeline. Default='compute_reference_b0'.
+
+    Returns
+    -------
+    Workflow :
+        The Nipype workflow.
+        This workflow has the following inputs:
+            - "dwi": The path to the DWI image
+            - "b_vecors": The path to the associated B-vectors file
+            - "b_values": The path to the associated B-values file
+            - "total_readout_time": The total readout time extracted from JSON metadata
+            - "phase_encoding_direction": The phase encoding direction extracted from JSON metadata
+            - "image_id": Prefix to be used for output files
+        And the following outputs:
+            - "reference_b0": The path to the compute reference B0 volume
+            - "brainmask": The path to the computed whole brain mask
     """
     import nipype.interfaces.fsl as fsl
     import nipype.interfaces.io as nio

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_workflows.py
@@ -152,7 +152,7 @@ def compute_reference_b0(
         This workflow has the following inputs:
             - "dwi_filename": The path to the DWI image
             - "b_vectors_filename": The path to the associated B-vectors file
-            - "b_values": The path to the associated B-values file
+            - "b_values_filename": The path to the associated B-values file
             - "total_readout_time": The total readout time extracted from JSON metadata
             - "phase_encoding_direction": The phase encoding direction extracted from JSON metadata
             - "image_id": Prefix to be used for output files

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_workflows.py
@@ -182,6 +182,7 @@ def compute_reference_b0(
         low_bval=low_bval,
         use_cuda=use_cuda,
         initrand=initrand,
+        image_id=True,
         name="pre_eddy",
     )
 

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_pipeline.py
@@ -300,7 +300,7 @@ class DwiPreprocessingUsingT1(cpe.Pipeline):
         )
         # Head-motion correction + Eddy-currents correction
         eddy_fsl = eddy_fsl_pipeline(
-            low_bval=self.parameters["low_bval"],
+            b_value_threshold=self.parameters["low_bval"],
             use_cuda=self.parameters["use_cuda"],
             initrand=self.parameters["initrand"],
         )
@@ -361,10 +361,10 @@ class DwiPreprocessingUsingT1(cpe.Pipeline):
                 # Head-motion correction + eddy current correction
                 (init_node, eddy_fsl, [("total_readout_time", "inputnode.total_readout_time"),
                                        ("phase_encoding_direction", "inputnode.phase_encoding_direction")]),
-                (prepare_b0, eddy_fsl, [("out_b0_dwi_merge", "inputnode.in_file"),
-                                        ("out_updated_bval", "inputnode.in_bval"),
-                                        ("out_updated_bvec", "inputnode.in_bvec"),
-                                        ("out_reference_b0", "inputnode.ref_b0")]),
+                (prepare_b0, eddy_fsl, [("out_b0_dwi_merge", "inputnode.dwi_filename"),
+                                        ("out_updated_bval", "inputnode.b_values_filename"),
+                                        ("out_updated_bvec", "inputnode.b_vectors_filename"),
+                                        ("out_reference_b0", "inputnode.ref_b0")]),  # TODO: check if really needed...
                 (mask_b0_pre, eddy_fsl, [("mask_file", "inputnode.in_mask")]),
                 # Magnetic susceptibility correction
                 (init_node, sdc, [("t1w", "inputnode.T1")]),

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
@@ -45,7 +45,7 @@ def eddy_fsl_pipeline(
         This workflow has the following inputs:
             - "dwi_filename": The path to the DWI image
             - "b_vectors_filename": The path to the associated B-vectors file
-            - "b_value_filename": The path to the associated B-values file
+            - "b_values_filename": The path to the associated B-values file
             - "in_mask": The path to the mask image to be provided to Eddy
             - "image_id": Prefix to be used for output files
             - "field": The path to the field image to be used by Eddy
@@ -69,7 +69,7 @@ def eddy_fsl_pipeline(
             fields=[
                 "dwi_filename",
                 "b_vectors_filename",
-                "b_value_filename",
+                "b_values_filename",
                 "in_mask",
                 "image_id",
                 "field",
@@ -96,7 +96,7 @@ def eddy_fsl_pipeline(
 
     generate_index = pe.Node(
         niu.Function(
-            input_names=["b_value_filename", "b_value_threshold"],
+            input_names=["b_values_filename", "b_value_threshold"],
             output_names=["out_file"],
             function=generate_index_file,
         ),
@@ -127,10 +127,10 @@ def eddy_fsl_pipeline(
             [("phase_encoding_direction", "fsl_phase_encoding_direction")],
         ),
         (inputnode, generate_acq, [("image_id", "image_id")]),
-        (inputnode, generate_index, [("b_value_filename", "b_value_filename")]),
+        (inputnode, generate_index, [("b_values_filename", "b_values_filename")]),
         (inputnode, generate_index, [("image_id", "image_id")]),
         (inputnode, eddy, [("b_vectors_filename", "in_bvec")]),
-        (inputnode, eddy, [("b_value_filename", "in_bval")]),
+        (inputnode, eddy, [("b_values_filename", "in_bval")]),
         (inputnode, eddy, [("dwi_filename", "in_file")]),
         (inputnode, eddy, [("in_mask", "in_mask")]),
         (generate_acq, eddy, [("out_file", "in_acqp")]),

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
@@ -1,6 +1,4 @@
-def eddy_fsl_pipeline(
-    low_bval, use_cuda, initrand, field=None, name="eddy_fsl"
-):
+def eddy_fsl_pipeline(low_bval, use_cuda, initrand, field=None, name="eddy_fsl"):
     """Use FSL eddy for head motion correction and eddy current distortion correction."""
     import nipype.interfaces.utility as niu
     import nipype.pipeline.engine as pe

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
@@ -1,4 +1,11 @@
-def eddy_fsl_pipeline(low_bval, use_cuda, initrand, field=None, name="eddy_fsl"):
+def eddy_fsl_pipeline(
+    low_bval,
+    use_cuda,
+    initrand,
+    image_id: bool = False,
+    field: bool = False,
+    name="eddy_fsl",
+):
     """Use FSL eddy for head motion correction and eddy current distortion correction."""
     import nipype.interfaces.utility as niu
     import nipype.pipeline.engine as pe
@@ -14,7 +21,7 @@ def eddy_fsl_pipeline(low_bval, use_cuda, initrand, field=None, name="eddy_fsl")
                 "in_bval",
                 "in_mask",
                 "image_id",
-                "ref_b0",
+                "field",
                 "total_readout_time",
                 "phase_encoding_direction",
             ]
@@ -49,8 +56,6 @@ def eddy_fsl_pipeline(low_bval, use_cuda, initrand, field=None, name="eddy_fsl")
     eddy.inputs.repol = True
     eddy.inputs.use_cuda = use_cuda
     eddy.inputs.initrand = initrand
-    if field:
-        eddy.inputs.field = field
 
     outputnode = pe.Node(
         niu.IdentityInterface(
@@ -60,31 +65,37 @@ def eddy_fsl_pipeline(low_bval, use_cuda, initrand, field=None, name="eddy_fsl")
     )
 
     wf = pe.Workflow(name=name)
-    # fmt: off
-    wf.connect(
-        [
-            (inputnode, generate_acq, [('in_file', 'in_dwi')]),
-            (inputnode, generate_acq, [('total_readout_time', 'total_readout_time')]),
-            (inputnode, generate_acq, [('phase_encoding_direction', 'fsl_phase_encoding_direction')]),
-            (inputnode, generate_acq, [('image_id', 'image_id')]),
 
-            (inputnode, generate_index, [('in_bval', 'in_bval')]),
-            (inputnode, generate_index, [('image_id', 'image_id')]),
+    connections = [
+        (inputnode, generate_acq, [("in_file", "in_dwi")]),
+        (inputnode, generate_acq, [("total_readout_time", "total_readout_time")]),
+        (
+            inputnode,
+            generate_acq,
+            [("phase_encoding_direction", "fsl_phase_encoding_direction")],
+        ),
+        (inputnode, generate_acq, [("image_id", "image_id")]),
+        (inputnode, generate_index, [("in_bval", "in_bval")]),
+        (inputnode, generate_index, [("image_id", "image_id")]),
+        (inputnode, eddy, [("in_bvec", "in_bvec")]),
+        (inputnode, eddy, [("in_bval", "in_bval")]),
+        (inputnode, eddy, [("in_file", "in_file")]),
+        (inputnode, eddy, [("in_mask", "in_mask")]),
+        (generate_acq, eddy, [("out_file", "in_acqp")]),
+        (generate_index, eddy, [("out_file", "in_index")]),
+        (eddy, outputnode, [("out_parameter", "out_parameter")]),
+        (eddy, outputnode, [("out_corrected", "out_corrected")]),
+        (eddy, outputnode, [("out_rotated_bvecs", "out_rotated_bvecs")]),
+    ]
 
-            (inputnode, eddy, [('in_bvec', 'in_bvec')]),
-            (inputnode, eddy, [('in_bval', 'in_bval')]),
-            (inputnode, eddy, [('in_file', 'in_file')]),
-            (inputnode, eddy, [('in_mask', 'in_mask')]),
-            (inputnode, eddy, [('image_id', 'out_base')]),
-            (generate_acq, eddy, [('out_file', 'in_acqp')]),
-            (generate_index, eddy, [('out_file', 'in_index')]),
+    if image_id:
+        connections += [(inputnode, eddy, [("image_id", "out_base")])]
 
-            (eddy, outputnode, [('out_parameter', 'out_parameter')]),
-            (eddy, outputnode, [('out_corrected', 'out_corrected')]),
-            (eddy, outputnode, [('out_rotated_bvecs', 'out_rotated_bvecs')])
-        ]
-    )
-    # fmt: on
+    if field:
+        connections += [(inputnode, eddy, [("field", "field")])]
+
+    wf.connect(connections)
+
     return wf
 
 

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
@@ -1,12 +1,63 @@
+from nipype.pipeline.engine import Workflow
+
+
 def eddy_fsl_pipeline(
-    low_bval,
-    use_cuda,
-    initrand,
+    low_bval: float,
+    use_cuda: bool,
+    initrand: bool,
     image_id: bool = False,
     field: bool = False,
-    name="eddy_fsl",
-):
-    """Use FSL eddy for head motion correction and eddy current distortion correction."""
+    name: str = "eddy_fsl",
+) -> Workflow:
+    """Build a FSL-based pipeline for head motion correction and eddy current distortion correction.
+
+    This pipeline needs FSL as it relies on the Eddy executable.
+
+    Parameters
+    ----------
+    low_bval : float
+        Threshold value to determine the B0 volumes in the DWI image.
+
+    use_cuda : bool
+        Boolean to indicate whether cuda should be used or not.
+
+    initrand : bool
+        ????
+
+    image_id : bool, optional
+        Boolean to indicate whether the Eddy node should expect
+        a value for its 'out_base' parameter. This is used for
+        building the names of the output files.
+        Default=False.
+
+    field : bool, optional
+        Boolean to indicate whether the Eddy node should expect
+        a value for its 'field' input.
+        Default=False.
+
+    name : str, optional
+        Name of the pipeline. Default='eddy_fsl'.
+
+    Returns
+    -------
+    Workflow :
+        The Nipype workflow.
+        This workflow has the following inputs:
+            - "in_file": The path to the DWI image
+            - "in_bvec": The path to the associated B-vectors file
+            - "in_bval": The path to the associated B-values file
+            - "in_mask": The path to the mask image to be provided to Eddy
+            - "image_id": Prefix to be used for output files
+            - "field": The path to the field image to be used by Eddy
+            - "ref_b0": ???
+            - "total_readout_time": The total readout time extracted from JSON metadata
+            - "phase_encoding_direction": The phase encoding direction extracted from JSON metadata
+
+        And the following outputs:
+            - "out_parameter": Path to the file storing the output parameters
+            - "out_corrected": Path to the corrected image
+            - "out_rotated_bvecs": Path to the file holding the rotated B-vectors
+    """
     import nipype.interfaces.utility as niu
     import nipype.pipeline.engine as pe
     from nipype.interfaces.fsl.epi import Eddy

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
@@ -22,6 +22,7 @@ def eddy_fsl_pipeline(
                 "in_mask",
                 "image_id",
                 "field",
+                "ref_b0",
                 "total_readout_time",
                 "phase_encoding_direction",
             ]

--- a/clinica/utils/dwi.py
+++ b/clinica/utils/dwi.py
@@ -256,12 +256,14 @@ def check_dwi_volume(in_dwi, in_bvec, in_bval):
         )
 
 
-def generate_index_file(in_bval, low_bval=5.0, image_id=None):
+def generate_index_file(
+    b_values_filename: str, b_value_threshold: float = 5.0, image_id=None
+):
     """Generate [`image_id`]_index.txt file for FSL eddy command.
 
     Args:
-        in_bval (str): Bval file.
-        low_bval (float): Define the b0 volumes as all volume bval <= low_bval. Default to 5.0.
+        b_values_filename (str): Bval file.
+        b_value_threshold (float): Define the b0 volumes as all volume bval <= low_bval. Default to 5.0.
         image_id (str, optional): Optional prefix. Defaults to None.
 
     Returns:
@@ -271,14 +273,14 @@ def generate_index_file(in_bval, low_bval=5.0, image_id=None):
 
     import numpy as np
 
-    assert os.path.isfile(in_bval)
-    bvals = np.loadtxt(in_bval)
-    idx_low_bvals = np.where(bvals <= low_bval)
+    assert os.path.isfile(b_values_filename)
+    bvals = np.loadtxt(b_values_filename)
+    idx_low_bvals = np.where(bvals <= b_value_threshold)
     b0_index = idx_low_bvals[0].tolist()
 
     if not b0_index:
         raise ValueError(
-            f"Could not find b-value <= {low_bval} in bval file ({in_bval}). Found values: {bvals}"
+            f"Could not find b-value <= {b_value_threshold} in bval file ({b_values_filename}). Found values: {bvals}"
         )
 
     if image_id:
@@ -306,12 +308,15 @@ def generate_index_file(in_bval, low_bval=5.0, image_id=None):
 
 
 def generate_acq_file(
-    in_dwi, fsl_phase_encoding_direction, total_readout_time, image_id=None
+    dwi_filename: str,
+    fsl_phase_encoding_direction: str,
+    total_readout_time,
+    image_id=None,
 ):
     """Generate [`image_id`]_acq.txt file for FSL eddy command.
 
     Args:
-        in_dwi (str): DWI file.
+        dwi_filename (str): DWI file.
         fsl_phase_encoding_direction (str): PhaseEncodingDirection from BIDS specifications in FSL format (i.e. x/y/z instead of i/j/k).
         total_readout_time (str): TotalReadoutTime from BIDS specifications.
         image_id (str, optional): Optional prefix. Defaults to None.
@@ -328,7 +333,7 @@ def generate_acq_file(
         out_acq = os.path.abspath(f"{image_id}_acq.txt")
     else:
         out_acq = os.path.abspath("acq.txt")
-    vols = nb.load(in_dwi).get_data().shape[-1]
+    vols = nb.load(dwi_filename).get_data().shape[-1]
     arr = np.ones([vols, 4])
     for i in range(vols):
         if fsl_phase_encoding_direction == "y-":

--- a/test/nonregression/pipelines/test_run_pipelines_dwi.py
+++ b/test/nonregression/pipelines/test_run_pipelines_dwi.py
@@ -54,7 +54,32 @@ def test_dwi_preprocessing_using_t1(cmdopt, tmp_path):
 
 @pytest.mark.slow
 def test_dwi_compute_reference_b0(cmdopt, tmp_path):
-    """Test step 1 of pipeline DWIPreprocessingUsingPhaseDiff."""
+    """Test step 1 of pipeline DWIPreprocessingUsingPhaseDiff.
+
+    This is a slow test. Expect approximatively a 2.5 hours runtime.
+
+    We use the same input files as for the DWIPreprocessingUsingPhaseDiff pipeline.
+    However, since we are testing the step 1 in isolation, we don't have the
+    BIDS querying logic available to us.
+    The compute_reference_b0 is not BIDS-aware, it just expects three files:
+        - the DWI image
+        - the associated b-values
+        - and the associated b-vectors
+    
+    These files are directly available in the input_dir (no BIDS structure, files
+    are directly at the root level.
+    
+    It also needs the phase encoding direction and total readout time which are
+    available in the JSON file (also available in the input_dir).
+    In the main pipeline, the input node is performing the extraction of these metadata
+    from the JSON file. Here, we perform this extraction direclty with the
+    `extract_metadata_from_json` and `bids_dir_to_fsl_dir`functions.
+    
+    The compute_reference_b0 workflow produces two outputs that are compared
+    against their references:
+        - The reference B0 volume
+        - The brainmask computed on the B0 volume
+    """
     from clinica.pipelines.dwi_preprocessing_using_fmap.dwi_preprocessing_using_phasediff_fmap_workflows import (
         compute_reference_b0,
     )
@@ -84,8 +109,8 @@ def test_dwi_compute_reference_b0(cmdopt, tmp_path):
         output_dir=str(tmp_path / "tmp"),
         name="compute_reference_b0",
     )
-    wf.inputs.inputnode.bval = str(input_dir / "sub-01_ses-M000_dwi.bval")
-    wf.inputs.inputnode.bvec = str(input_dir / "sub-01_ses-M000_dwi.bvec")
+    wf.inputs.inputnode.b_values = str(input_dir / "sub-01_ses-M000_dwi.bval")
+    wf.inputs.inputnode.b_vectors = str(input_dir / "sub-01_ses-M000_dwi.bvec")
     wf.inputs.inputnode.dwi = str(input_dir / "sub-01_ses-M000_dwi.nii.gz")
     wf.inputs.inputnode.image_id = "sub-01_ses-M000"
     wf.inputs.inputnode.total_readout_time = total_readout_time
@@ -93,17 +118,14 @@ def test_dwi_compute_reference_b0(cmdopt, tmp_path):
 
     wf.run()
 
-    out_file = fspath(
-        tmp_path / "tmp" / "reference_b0" / "sub-01_ses-M000_avg_b0_brain.nii.gz"
-    )
-    ref_file = fspath(ref_dir / "sub-01_ses-M000_avg_b0_brain.nii.gz")
+    for folder, filename in zip(
+        ["reference_b0", "brainmask"],
+        ["sub-01_ses-M000_avg_b0_brain.nii.gz", "brainmask.nii.gz"]
+    ):
+        out_file = fspath(tmp_path / "tmp" / folder / filename)
+        ref_file = fspath(ref_dir / folder / filename)
 
-    assert similarity_measure(out_file, ref_file, 0.99)
-
-    out_file = fspath(tmp_path / "tmp" / "brainmask" / "sbrainmask.nii.gz")
-    ref_file = fspath(ref_dir / "brainmask.nii.gz")
-
-    assert similarity_measure(out_file, ref_file, 0.99)
+        assert similarity_measure(out_file, ref_file, 0.99)
 
 
 @pytest.mark.slow

--- a/test/nonregression/pipelines/test_run_pipelines_dwi.py
+++ b/test/nonregression/pipelines/test_run_pipelines_dwi.py
@@ -104,15 +104,15 @@ def test_dwi_compute_reference_b0(cmdopt, tmp_path):
     phase_encoding_direction = bids_dir_to_fsl_dir(phase_encoding_direction)
 
     wf = compute_reference_b0(
-        low_bval=5.0,
+        b_value_threshold=5.0,
         use_cuda=False,
         initrand=False,
         output_dir=str(tmp_path / "tmp"),
         name="compute_reference_b0",
     )
-    wf.inputs.inputnode.b_values = str(input_dir / "sub-01_ses-M000_dwi.bval")
-    wf.inputs.inputnode.b_vectors = str(input_dir / "sub-01_ses-M000_dwi.bvec")
-    wf.inputs.inputnode.dwi = str(input_dir / "sub-01_ses-M000_dwi.nii.gz")
+    wf.inputs.inputnode.b_values_filename = str(input_dir / "sub-01_ses-M000_dwi.bval")
+    wf.inputs.inputnode.b_vectors_filename = str(input_dir / "sub-01_ses-M000_dwi.bvec")
+    wf.inputs.inputnode.dwi_filename = str(input_dir / "sub-01_ses-M000_dwi.nii.gz")
     wf.inputs.inputnode.image_id = "sub-01_ses-M000"
     wf.inputs.inputnode.total_readout_time = total_readout_time
     wf.inputs.inputnode.phase_encoding_direction = phase_encoding_direction

--- a/test/nonregression/pipelines/test_run_pipelines_dwi.py
+++ b/test/nonregression/pipelines/test_run_pipelines_dwi.py
@@ -56,29 +56,30 @@ def test_dwi_preprocessing_using_t1(cmdopt, tmp_path):
 def test_dwi_compute_reference_b0(cmdopt, tmp_path):
     """Test step 1 of pipeline DWIPreprocessingUsingPhaseDiff.
 
-    This is a slow test. Expect approximatively a 2.5 hours runtime.
+    This is a slow test. Expect approximately a 2.5 hours runtime.
 
     We use the same input files as for the DWIPreprocessingUsingPhaseDiff pipeline.
+
     However, since we are testing the step 1 in isolation, we don't have the
-    BIDS querying logic available to us.
-    The compute_reference_b0 is not BIDS-aware, it just expects three files:
+    BIDS querying logic available to us. The compute_reference_b0 pipeline is
+    not BIDS-aware, it just expects three files:
         - the DWI image
         - the associated b-values
         - and the associated b-vectors
-    
+
     These files are directly available in the input_dir (no BIDS structure, files
-    are directly at the root level.
-    
+    are directly at the root level).
+
     It also needs the phase encoding direction and total readout time which are
     available in the JSON file (also available in the input_dir).
-    In the main pipeline, the input node is performing the extraction of these metadata
-    from the JSON file. Here, we perform this extraction direclty with the
-    `extract_metadata_from_json` and `bids_dir_to_fsl_dir`functions.
-    
+    In the main pipeline, the input node is performing the extraction of these
+    metadata from the JSON file. Here, we perform this extraction directly with
+    the `extract_metadata_from_json` and `bids_dir_to_fsl_dir`functions.
+
     The compute_reference_b0 workflow produces two outputs that are compared
-    against their references:
+    against their reference values:
         - The reference B0 volume
-        - The brainmask computed on the B0 volume
+        - The brain mask computed on the B0 volume
     """
     from clinica.pipelines.dwi_preprocessing_using_fmap.dwi_preprocessing_using_phasediff_fmap_workflows import (
         compute_reference_b0,
@@ -120,7 +121,7 @@ def test_dwi_compute_reference_b0(cmdopt, tmp_path):
 
     for folder, filename in zip(
         ["reference_b0", "brainmask"],
-        ["sub-01_ses-M000_avg_b0_brain.nii.gz", "brainmask.nii.gz"]
+        ["sub-01_ses-M000_avg_b0_brain.nii.gz", "brainmask.nii.gz"],
     ):
         out_file = fspath(tmp_path / "tmp" / folder / filename)
         ref_file = fspath(ref_dir / folder / filename)


### PR DESCRIPTION
The goal of this PR is to simplify the `DWIPreprocessingUsingPhaseDiff` workflow.

This workflow is already written as a sequence of steps separated by comments. Having these steps implemented in separate workflows would make things much easier to test and understand.

Furthermore, the pipeline relies on `Eddy` in various places but doesn't use the `eddy_fsl_pipeline` defined for the `DWIPreprocessingUsingT1` pipeline. 

This PR thus proposes to:

- extract the first step of the pipeline in its own workflow `compute_reference_b0`
- within this extracted workflow, use the `eddy_fsl_pipeline` instead of re-doing everything from scratch
- replace the third step by another call to `eddy_fsl_pipeline` for the same reasons

Note: To do that, I had to slightly modify the `eddy_fsl_pipeline` from the `DWIPreprocessingUsingT1` workflows module. This makes me think that we should have a module for workflows common to multiple DWI pipelines.

This PR adds a functional test that compares the output of the `compute_reference_b0` workflow against reference values. I have computed these reference values with the pipeline implementation defined on `dev` (without the modifications of this PR) and checked that the tests still pass with the modifications done here.

The added functional test needs the data from this PR: https://github.com/aramis-lab/clinica_data_ci/pull/27