### PR TITLE
Do not need shutils.move() in mris_expand(in_surface) 

### DIFF
--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -444,18 +444,17 @@ def mris_expand(in_surface):
         out_file + "013",
     ]
     out_in_node = [os.path.abspath("./" + os.path.basename(x)) for x in out_filelist]
-    for i in range(len(out_filelist)):
-        shutil.move(out_filelist[i], out_in_node[i])
 
     # Remove useless surfaces (0%, 5%, 10%, 15%, 20%, 25% and 30% of thickness)
+    _to_remove = os.path.abspath("./" + os.path.basename(out_file))
     to_remove = [
-        out_file + "000",
-        out_file + "001",
-        out_file + "002",
-        out_file + "003",
-        out_file + "004",
-        out_file + "005",
-        out_file + "006",
+        _to_remove + "000",
+        _to_remove + "001",
+        _to_remove + "002",
+        _to_remove + "003",
+        _to_remove + "004",
+        _to_remove + "005",
+        _to_remove + "006",
     ]
     for i in range(len(to_remove)):
         os.remove(to_remove[i])


### PR DESCRIPTION
lh.white_expXXX files do not need to move, they should remain in the tmp folder, and they will still be correctly copy/move to the subject's surf folder in the next procedure.
This the issue I opened previously (pet_surface pipeline fail to find lh.white_expXXX files), and I think this is a solution to that problem.