### PR TITLE
[REF] Extract Step 2 of `DWIPreprocessingUsingPhasediff` into its own workflow

### DIFF
--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
@@ -390,7 +390,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
                 init_node,
                 fmap_calibration_and_registration,
                 [
-                    ("fmap_magnitude", "inputnode.magnitude_fmap"),
+                    ("fmap_magnitude", "inputnode.bias_magnitude_fmap"),
                     ("fmap_phasediff", "inputnode.fmap_phasediff"),
                     ("delta_echo_time", "inputnode.delta_echo_time"),
                 ],

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_workflows.py
@@ -501,16 +501,16 @@ def calibrate_and_register_fmap(
             [("out_file", "in_file")],
         ),
         # Output connections
-        (smooth_calibrated_fmap, outputnode, ["out_file", "smooth_calibrated_fmap"]),
+        (smooth_calibrated_fmap, outputnode, [("out_file", "smooth_calibrated_fmap")]),
         (
             register_bet_magnitude_fmap_onto_b0,
             outputnode,
-            ["out_file", "bet_magnitude_fmap_registered_onto_b0"],
+            [("out_file", "bet_magnitude_fmap_registered_onto_b0")],
         ),
         (
             apply_xfm_on_calibrated_fmap,
             outputnode,
-            ["out_file", "registered_calibrated_fmap"],
+            [("out_file", "registered_calibrated_fmap")],
         ),
     ]
 

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_workflows.py
@@ -322,3 +322,222 @@ def compute_reference_b0(
     wf.connect(connections)
 
     return wf
+
+
+def calibrate_and_register_fmap(
+    output_dir: Optional[str] = None,
+    name: str = "calibrate_and_register_fmap",
+) -> Workflow:
+    """Step 2 of the DWI preprocessing using phase diff pipeline.
+
+    Calibrate and register the field map.
+
+    This pipeline needs:
+        - ANTS
+        - FSL
+
+    Parameters
+    ----------
+    output_dir: str, optional
+        Path to output directory.
+        If provided, the pipeline will write its output in this folder.
+        Default to None.
+
+    name: str, optional
+        Name of the pipeline. Default='calibrate_and_register_fmap'.
+
+    Returns
+    -------
+    Workflow :
+        The Nipype workflow.
+        This workflow has the following inputs:
+            - "bias_magnitude_fmap": The path to the bias magnitude field map
+            - "fmap_phasediff": ??
+            - "reference_b0": The path to the computed reference B0 volume.
+              This is one of the outputs from the step 1 compute_reference_b0 workflow.
+            - "delta_echo_time": ???
+        And the following outputs:
+            - "smooth_calibrated_fmap": The path to the smoothed and calibrated field map
+            - "bet_magnitude_fmap_registered_onto_b0": The path to the bet magnitude field
+              map registered onto the B0 volume
+    """
+    import nipype.interfaces.ants as ants
+    import nipype.interfaces.fsl as fsl
+    import nipype.interfaces.io as nio
+    import nipype.interfaces.utility as niu
+    import nipype.pipeline.engine as npe
+
+    inputnode = npe.Node(
+        niu.IdentityInterface(
+            fields=[
+                "bias_magnitude_fmap",
+                "fmap_phasediff",
+                "reference_b0",
+                "delta_echo_time",
+            ]
+        ),
+        name="inputnode",
+    )
+
+    # Bias field correction of the magnitude image
+    bias_magnitude_fmap = npe.Node(
+        ants.N4BiasFieldCorrection(dimension=3),
+        name="bias_magnitude_fmap",
+    )
+
+    # Brain extraction of the magnitude image
+    bet_magnitude_fmap = npe.Node(
+        fsl.BET(frac=0.4, mask=True),
+        name="bet_magnitude_fmap",
+    )
+
+    # Calibrate FMap
+    calibrate_fmap = prepare_phasediff_fmap(name="calibrate_fmap")
+
+    # Register the BET magnitude fmap onto the BET b0
+    register_bet_magnitude_fmap_onto_b0 = npe.Node(
+        interface=fsl.FLIRT(),
+        name="register_bet_magnitude_fmap_onto_b0",
+    )
+    register_bet_magnitude_fmap_onto_b0.inputs.dof = 6
+    register_bet_magnitude_fmap_onto_b0.inputs.output_type = "NIFTI_GZ"
+
+    # Apply the transformation on the calibrated fmap
+    apply_xfm_on_calibrated_fmap = npe.Node(
+        interface=fsl.ApplyXFM(),
+        name="apply_xfm_on_calibrated_fmap",
+    )
+    apply_xfm_on_calibrated_fmap.inputs.output_type = "NIFTI_GZ"
+
+    # Apply the transformation on the magnitude image
+    apply_xfm_on_magnitude_fmap = apply_xfm_on_calibrated_fmap.clone("2e-2-MagFMapToB0")
+
+    # Smooth the registered (calibrated) fmap
+    smooth_calibrated_fmap = npe.Node(
+        interface=fsl.maths.IsotropicSmooth(),
+        name="smooth_calibrated_fmap",
+    )
+    smooth_calibrated_fmap.inputs.sigma = 4.0
+
+    outputnode = npe.Node(
+        niu.IdentityInterface(
+            fields=[
+                "smooth_calibrated_fmap",
+                "bet_magnitude_fmap_registered_onto_b0",
+                "registered_calibrated_fmap",
+            ]
+        ),
+        name="outputnode",
+    )
+
+    if output_dir:
+        write_results = npe.Node(name="write_results", interface=nio.DataSink())
+        write_results.inputs.base_directory = output_dir
+        write_results.inputs.parameterization = False
+
+    wf = npe.Workflow(name=name)
+
+    connections = [
+        # Bias field correction of the magnitude image
+        (inputnode, bias_magnitude_fmap, [("bias_magnitude_fmap", "input_image")]),
+        # Brain extraction of the magnitude image
+        (bias_magnitude_fmap, bet_magnitude_fmap, [("output_image", "in_file")]),
+        # Calibration of the FMap
+        (
+            bet_magnitude_fmap,
+            calibrate_fmap,
+            [
+                ("mask_file", "input_node.fmap_mask"),
+                ("out_file", "input_node.fmap_magnitude"),
+            ],
+        ),
+        (
+            inputnode,
+            calibrate_fmap,
+            [
+                ("fmap_phasediff", "input_node.fmap_phasediff"),
+                ("delta_echo_time", "input_node.delta_echo_time"),
+            ],
+        ),
+        # Register the BET magnitude fmap onto the BET b0
+        (
+            bet_magnitude_fmap,
+            register_bet_magnitude_fmap_onto_b0,
+            [("out_file", "in_file")],
+        ),
+        (
+            inputnode,
+            register_bet_magnitude_fmap_onto_b0,
+            [("reference_b0", "reference")],
+        ),
+        # Apply the transformation on the magnitude image
+        (
+            register_bet_magnitude_fmap_onto_b0,
+            apply_xfm_on_magnitude_fmap,
+            [("out_matrix_file", "in_matrix_file")],
+        ),
+        (
+            bias_magnitude_fmap,
+            apply_xfm_on_magnitude_fmap,
+            [("output_image", "in_file")],
+        ),
+        (inputnode, apply_xfm_on_magnitude_fmap, [("reference_b0", "reference")]),
+        # Apply the transformation on the calibrated fmap
+        (
+            register_bet_magnitude_fmap_onto_b0,
+            apply_xfm_on_calibrated_fmap,
+            [("out_matrix_file", "in_matrix_file")],
+        ),
+        (
+            calibrate_fmap,
+            apply_xfm_on_calibrated_fmap,
+            [("output_node.calibrated_fmap", "in_file")],
+        ),
+        (inputnode, apply_xfm_on_calibrated_fmap, [("reference_b0", "reference")]),
+        # Smooth the registered (calibrated) fmap
+        (
+            apply_xfm_on_calibrated_fmap,
+            smooth_calibrated_fmap,
+            [("out_file", "in_file")],
+        ),
+        # Output connections
+        (smooth_calibrated_fmap, outputnode, ["out_file", "smooth_calibrated_fmap"]),
+        (
+            register_bet_magnitude_fmap_onto_b0,
+            outputnode,
+            ["out_file", "bet_magnitude_fmap_registered_onto_b0"],
+        ),
+        (
+            apply_xfm_on_calibrated_fmap,
+            outputnode,
+            ["out_file", "registered_calibrated_fmap"],
+        ),
+    ]
+
+    if output_dir:
+        connections += [
+            (
+                outputnode,
+                write_results,
+                [("smooth_calibrated_fmap", "smooth_calibrated_fmap")],
+            ),
+            (
+                outputnode,
+                write_results,
+                [
+                    (
+                        "bet_magnitude_fmap_registered_onto_b0",
+                        "bet_magnitude_fmap_registered_onto_b0",
+                    )
+                ],
+            ),
+            (
+                outputnode,
+                write_results,
+                [("registered_calibrated_fmap", "registered_calibrated_fmap")],
+            ),
+        ]
+
+    wf.connect(connections)
+
+    return wf

--- a/test/nonregression/pipelines/test_run_pipelines_dwi.py
+++ b/test/nonregression/pipelines/test_run_pipelines_dwi.py
@@ -226,7 +226,7 @@ def test_dwi_calibrate_and_register_fmap(cmdopt, tmp_path):
         out_file = fspath(tmp_path / "tmp" / folder / filename)
         ref_file = fspath(ref_dir / folder / filename)
 
-        assert similarity_measure(out_file, ref_file, 0.99)
+        assert similarity_measure(out_file, ref_file, 0.98)
 
 
 @pytest.mark.slow

--- a/test/nonregression/pipelines/test_run_pipelines_dwi.py
+++ b/test/nonregression/pipelines/test_run_pipelines_dwi.py
@@ -140,7 +140,8 @@ def test_prepare_phasediff_fmap(cmdopt, tmp_path):
         prepare_phasediff_fmap,
     )
     from clinica.utils.filemanip import extract_metadata_from_json
-    base_dir = Path(cmdopt["input"]) 
+
+    base_dir = Path(cmdopt["input"])
     input_dir, tmp_dir, ref_dir = configure_paths(
         base_dir, tmp_path, "DWIPreparePhasediffFmap"
     )

--- a/test/nonregression/pipelines/test_run_pipelines_dwi.py
+++ b/test/nonregression/pipelines/test_run_pipelines_dwi.py
@@ -176,7 +176,10 @@ def test_prepare_phasediff_fmap(cmdopt, tmp_path):
 
 @pytest.mark.fast
 def test_dwi_calibrate_and_register_fmap(cmdopt, tmp_path):
-    """Test step 2 of pipeline DWIPreprocessingUsingPhaseDiff."""
+    """Test step 2 of pipeline DWIPreprocessingUsingPhaseDiff.
+
+    This is a fast test which should run in about 1 minute.
+    """
     from clinica.pipelines.dwi_preprocessing_using_fmap.dwi_preprocessing_using_phasediff_fmap_workflows import (
         calibrate_and_register_fmap,
     )
@@ -193,7 +196,7 @@ def test_dwi_calibrate_and_register_fmap(cmdopt, tmp_path):
     )
     delta_echo_time = abs(echo_time2 - echo_time1)
 
-    wf = calibrate_and_register_fmap()
+    wf = calibrate_and_register_fmap(output_dir=str(tmp_path / "tmp"))
     wf.inputs.inputnode.reference_b0 = str(
         input_dir / "sub-01_ses-M000_avg_b0_brain.nii.gz"
     )


### PR DESCRIPTION
Similar to #893 for Step 1, this PR proposes to extract the Step 2 of the `DWIPreprocessingUsingPhaseDiff` pipeline into its own workflow: `calibrate_and_register_fmap`
This PR also proposes to add functional tests for the extracted workflow in isolation. 
The added test is classified as "fast" as it is running in about 1 minute. It requires the data I have generated here: https://github.com/aramis-lab/clinica_data_ci/pull/29