### PR TITLE
[REF TEST] refactor and add unit tests to DWI EPI pipeline utility functions

### DIFF
--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_utils.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_utils.py
@@ -132,14 +132,17 @@ def rotate_b_vectors(b_vectors_filename: str, matrix_filenames: list) -> str:
     coordinates in the original image. Therefore, this matrix should be inverted first, as
     we want to know the target position of :math:`\\vec{r}`.
     """
-    import os
+    from pathlib import Path
 
     import numpy as np
 
-    name, fext = os.path.splitext(os.path.basename(b_vectors_filename))
-    if fext == ".gz":
-        name, _ = os.path.splitext(name)
-    rotated_b_vectors_filename = os.path.abspath(f"{name}_rotated.bvec")
+    b_vectors_filename = Path(b_vectors_filename)
+    stem = (
+        Path(b_vectors_filename.stem).stem
+        if b_vectors_filename.suffix == ".gz"
+        else b_vectors_filename.stem
+    )
+    rotated_b_vectors_filename = b_vectors_filename.with_name(f"{stem}_rotated.bvec")
     b_vectors = np.loadtxt(b_vectors_filename).T
 
     if len(b_vectors) != len(matrix_filenames):
@@ -158,7 +161,7 @@ def rotate_b_vectors(b_vectors_filename: str, matrix_filenames: list) -> str:
 
     np.savetxt(rotated_b_vectors_filename, np.array(rotated_b_vectors).T, fmt="%0.15f")
 
-    return rotated_b_vectors_filename
+    return str(rotated_b_vectors_filename)
 
 
 def ants_apply_transforms(

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_workflows.py
@@ -191,10 +191,10 @@ def epi_pipeline(
 
     from .dwi_preprocessing_using_t1_utils import (
         ants_apply_transforms,
+        broadcast_matrix_filename_to_match_b_vector_length,
         change_itk_transform_type,
         delete_temp_dirs,
-        expend_matrix_list,
-        rotate_bvecs,
+        rotate_b_vectors,
     )
 
     inputnode = pe.Node(
@@ -212,18 +212,18 @@ def epi_pipeline(
 
     expend_matrix = pe.Node(
         interface=niu.Function(
-            input_names=["in_matrix", "in_bvec"],
+            input_names=["matrix_filename", "b_vectors_filename"],
             output_names=["out_matrix_list"],
-            function=expend_matrix_list,
+            function=broadcast_matrix_filename_to_match_b_vector_length,
         ),
         name="expend_matrix",
     )
 
     rot_bvec = pe.Node(
         niu.Function(
-            input_names=["in_matrix", "in_bvec"],
+            input_names=["matrix_filenames", "b_vectors_filename"],
             output_names=["out_file"],
-            function=rotate_bvecs,
+            function=rotate_b_vectors,
         ),
         name="Rotate_Bvec",
     )
@@ -349,10 +349,10 @@ def epi_pipeline(
             (split, pick_ref, [("out_files", "inlist")]),
             (pick_ref, flirt_b0_2_t1, [("out", "in_file")]),
             (inputnode, flirt_b0_2_t1, [("T1", "reference")]),
-            (inputnode, rot_bvec, [("bvec", "in_bvec")]),
-            (flirt_b0_2_t1, expend_matrix, [("out_matrix_file", "in_matrix")]),
-            (inputnode, expend_matrix, [("bvec", "in_bvec")]),
-            (expend_matrix, rot_bvec, [("out_matrix_list", "in_matrix")]),
+            (inputnode, rot_bvec, [("bvec", "b_vectors_filename")]),
+            (flirt_b0_2_t1, expend_matrix, [("out_matrix_file", "matrix_filename")]),
+            (inputnode, expend_matrix, [("bvec", "b_vectors_filename")]),
+            (expend_matrix, rot_bvec, [("out_matrix_list", "matrix_filenames")]),
             (inputnode, ants_registration, [("T1", "fixed_image")]),
             (flirt_b0_2_t1, ants_registration, [("out_file", "moving_image")]),
             (inputnode, c3d_flirt2ants, [("T1", "reference_file")]),

--- a/test/unittests/pipelines/dwi_preprocessing_using_t1/test_dwi_preprocessing_using_t1_utils.py
+++ b/test/unittests/pipelines/dwi_preprocessing_using_t1/test_dwi_preprocessing_using_t1_utils.py
@@ -1,12 +1,12 @@
 import os
-import tempfile
 from pathlib import Path
-from tempfile import tempdir
 
-import pandas as pd
+import numpy as np
 import pytest
 
 from clinica.pipelines.dwi_preprocessing_using_t1.dwi_preprocessing_using_t1_utils import (
+    broadcast_matrix_filename_to_match_b_vector_length,
+    change_itk_transform_type,
     delete_temp_dirs,
     extract_sub_ses_folder_name,
 )
@@ -18,6 +18,74 @@ def test_extract_sub_ses_folder_name():
             "/localdrive10TB/wd/dwi-preprocessing-using-t1/epi_pipeline/4336d63c8556bb56d4e9d1abc617fb3eaa3c38ea/MergeDWIs/Jacobian_image_maths_thresh_merged.nii.gz"
         )
         == "4336d63c8556bb56d4e9d1abc617fb3eaa3c38ea"
+    )
+
+
+def test_change_itk_transform_type_error(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        change_itk_transform_type(str(tmp_path / "affine.txt"))
+
+
+def test_change_itk_transform_type_empty_file(tmp_path):
+    (tmp_path / "affine.txt").touch()
+    assert change_itk_transform_type(str(tmp_path / "affine.txt")) == str(
+        tmp_path / "updated_affine.txt"
+    )
+    assert (tmp_path / "updated_affine.txt").read_text() == ""
+
+
+def test_change_itk_transform_type_no_transform_line(tmp_path):
+    origin_affine = tmp_path / "affine.txt"
+    origin_content = (
+        "fooo\nbar \n bazzzz\n transform\nTransform: AffineTransform_double_3_3"
+    )
+    origin_affine.write_text(origin_content)
+    assert change_itk_transform_type(str(origin_affine)) == str(
+        tmp_path / "updated_affine.txt"
+    )
+    assert (tmp_path / "updated_affine.txt").read_text() == origin_content
+
+
+def test_change_itk_transform_type(tmp_path):
+    origin_affine = tmp_path / "affine.txt"
+    origin_content = "fooo\nbar \n bazzzz\n transform\nTransform: MatrixOffsetTransformBase_double_3_3"
+    expected_content = (
+        "fooo\nbar \n bazzzz\n transform\nTransform: AffineTransform_double_3_3"
+    )
+    origin_affine.write_text(origin_content)
+    assert change_itk_transform_type(str(origin_affine)) == str(
+        tmp_path / "updated_affine.txt"
+    )
+    assert (tmp_path / "updated_affine.txt").read_text() == expected_content
+
+
+def test_broadcast_matrix_filename_to_match_b_vector_length_file_not_found_error(
+    tmp_path,
+):
+    with pytest.raises(FileNotFoundError):
+        broadcast_matrix_filename_to_match_b_vector_length(
+            "matrix.mat", str(tmp_path / "foo.txt")
+        )
+
+
+def test_broadcast_matrix_filename_to_match_b_vector_length_file_format_error(tmp_path):
+    filename = tmp_path / "vectors.bvec"
+    filename.write_text("foooo\nbarrrr\nbazzzz")
+    with pytest.raises(
+        ValueError,
+        match="could not convert string 'foooo' to float64",
+    ):
+        broadcast_matrix_filename_to_match_b_vector_length("matrix.mat", str(filename))
+
+
+def test_broadcast_matrix_filename_to_match_b_vector_length(tmp_path):
+    b_vectors = np.random.rand(6, 10)
+    np.savetxt(tmp_path / "vectors.bvec", b_vectors)
+    assert (
+        broadcast_matrix_filename_to_match_b_vector_length(
+            "matrix.mat", str(tmp_path / "vectors.bvec")
+        )
+        == ["matrix.mat"] * 10
     )
 
 

--- a/test/unittests/pipelines/dwi_preprocessing_using_t1/test_dwi_preprocessing_using_t1_utils.py
+++ b/test/unittests/pipelines/dwi_preprocessing_using_t1/test_dwi_preprocessing_using_t1_utils.py
@@ -3,12 +3,14 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 from clinica.pipelines.dwi_preprocessing_using_t1.dwi_preprocessing_using_t1_utils import (
     broadcast_matrix_filename_to_match_b_vector_length,
     change_itk_transform_type,
     delete_temp_dirs,
     extract_sub_ses_folder_name,
+    rotate_b_vectors,
 )
 
 
@@ -28,6 +30,7 @@ def test_change_itk_transform_type_error(tmp_path):
 
 def test_change_itk_transform_type_empty_file(tmp_path):
     (tmp_path / "affine.txt").touch()
+
     assert change_itk_transform_type(str(tmp_path / "affine.txt")) == str(
         tmp_path / "updated_affine.txt"
     )
@@ -40,6 +43,7 @@ def test_change_itk_transform_type_no_transform_line(tmp_path):
         "fooo\nbar \n bazzzz\n transform\nTransform: AffineTransform_double_3_3"
     )
     origin_affine.write_text(origin_content)
+
     assert change_itk_transform_type(str(origin_affine)) == str(
         tmp_path / "updated_affine.txt"
     )
@@ -53,6 +57,7 @@ def test_change_itk_transform_type(tmp_path):
         "fooo\nbar \n bazzzz\n transform\nTransform: AffineTransform_double_3_3"
     )
     origin_affine.write_text(origin_content)
+
     assert change_itk_transform_type(str(origin_affine)) == str(
         tmp_path / "updated_affine.txt"
     )
@@ -71,6 +76,7 @@ def test_broadcast_matrix_filename_to_match_b_vector_length_file_not_found_error
 def test_broadcast_matrix_filename_to_match_b_vector_length_file_format_error(tmp_path):
     filename = tmp_path / "vectors.bvec"
     filename.write_text("foooo\nbarrrr\nbazzzz")
+
     with pytest.raises(
         ValueError,
         match="could not convert string 'foooo' to float64",
@@ -79,14 +85,88 @@ def test_broadcast_matrix_filename_to_match_b_vector_length_file_format_error(tm
 
 
 def test_broadcast_matrix_filename_to_match_b_vector_length(tmp_path):
-    b_vectors = np.random.rand(6, 10)
-    np.savetxt(tmp_path / "vectors.bvec", b_vectors)
+    np.savetxt(tmp_path / "vectors.bvec", np.random.rand(6, 10))
+
     assert (
         broadcast_matrix_filename_to_match_b_vector_length(
             "matrix.mat", str(tmp_path / "vectors.bvec")
         )
         == ["matrix.mat"] * 10
     )
+
+
+def test_rotate_b_vectors_size_error(tmp_path):
+    """Test that a RuntimeError is raised when the number of b-vectors
+    is different from the number of matrices in the list.
+    """
+    np.savetxt(tmp_path / "vectors.bvec", np.random.rand(6, 10))
+
+    with pytest.raises(RuntimeError, match="Number of b-vectors"):
+        rotate_b_vectors(str(tmp_path / "vectors.bvec"), ["mat1", "mat2", "mat3"])
+
+
+def test_rotate_b_vectors_missing_b_vectors_file(tmp_path):
+    """Test that a FileNotFoundError is raised when the b-vectors file is missing."""
+    with pytest.raises(FileNotFoundError):
+        rotate_b_vectors(str(tmp_path / "foo.bvec"), ["mat1", "mat2"])
+
+
+def test_rotate_b_vectors_missing_rotation_matrix_file(tmp_path):
+    """Test that a FileNotFoundError is raised when one of the matrix file is missing."""
+    np.savetxt(tmp_path / "vectors.bvec", np.random.rand(3, 2))
+    np.savetxt(tmp_path / "mat1", np.eye(4))
+
+    with pytest.raises(
+        FileNotFoundError,
+        match="mat2 not found",
+    ):
+        rotate_b_vectors(
+            str(tmp_path / "vectors.bvec"),
+            [str(tmp_path / "mat1"), str(tmp_path / "mat2")],
+        )
+
+
+def test_rotate_b_vectors_all_zeros(tmp_path):
+    """Test that B-vectors composed only of zeros aren't rotated."""
+    np.savetxt(tmp_path / "vectors.bvec", np.zeros((3, 2)))
+    for i in range(1, 3):
+        np.savetxt(tmp_path / f"mat{i}", np.random.rand(3, 3))
+
+    rotated_b_vectors_file = rotate_b_vectors(
+        str(tmp_path / "vectors.bvec"), [str(tmp_path / "mat1"), str(tmp_path / "mat2")]
+    )
+
+    assert rotated_b_vectors_file == str(tmp_path / "vectors_rotated.bvec")
+    assert_array_equal(np.loadtxt(rotated_b_vectors_file), np.zeros((3, 2)))
+
+
+def test_rotate_b_vectors_with_identity(tmp_path):
+    """Test that b-vectors rotated with identity matrix are identical."""
+    origin_b_vectors = np.random.rand(3, 2)
+    normalized_origin_b_vectors = np.array(
+        [b / np.linalg.norm(b) for b in origin_b_vectors.T]
+    ).T
+    np.savetxt(tmp_path / "vectors.bvec", normalized_origin_b_vectors)
+    for i in range(1, 3):
+        np.savetxt(tmp_path / f"mat{i}", np.eye(4))
+
+    rotated_b_vectors_file = rotate_b_vectors(
+        str(tmp_path / "vectors.bvec"), [str(tmp_path / "mat1"), str(tmp_path / "mat2")]
+    )
+
+    assert rotated_b_vectors_file == str(tmp_path / "vectors_rotated.bvec")
+    assert_array_almost_equal(
+        np.loadtxt(rotated_b_vectors_file), normalized_origin_b_vectors
+    )
+
+
+def test_rotate_b_vectors_wrong_content_in_vector_file(tmp_path):
+    """Test that a ValueError is raised when vector file isn't valid."""
+    b_vectors_file = tmp_path / "foo.bvec"
+    b_vectors_file.write_text("fooo\nbar")
+
+    with pytest.raises(ValueError, match="could not convert string 'fooo' to float64"):
+        rotate_b_vectors(b_vectors_file, ["mat1"])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- refactor `change_itk_transform_type` to use more modern `pathlib` functionalities
- rename confusing `expend_matrix_list(in_matrix, in_bvec)` to `broadcast_matrix_filename_to_match_b_vector_length(matrix_filename: str, b_vectors_filename: str) -> list` and refactor
- rename `rotate_bvecs(in_bvec, in_matrix)` to `rotate_b_vectors(b_vectors_filename: str, matrix_filenames: list) -> str`
- Add type hints and documentation for the three functions
- Add unit tests for the three functions