### PR TITLE
Fix variables for spatial svm

### DIFF
--- a/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
+++ b/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
@@ -16,7 +16,7 @@ class SpatialSVM(cpe.Pipeline):
         self.parameters.setdefault("group_label", None)
         check_group_label(self.parameters["group_label"])
 
-        if "orig_input_data" not in self.parameters.keys():
+        if "orig_input_data_ml" not in self.parameters.keys():
             raise KeyError(
                 "Missing compulsory orig_input_data key in pipeline parameter."
             )
@@ -83,7 +83,7 @@ class SpatialSVM(cpe.Pipeline):
         )
         all_errors = []
 
-        if self.parameters["orig_input_data"] == "t1-volume":
+        if self.parameters["orig_input_data_ml"] == "t1-volume":
             caps_files_information = {
                 "pattern": os.path.join(
                     "t1",
@@ -95,7 +95,7 @@ class SpatialSVM(cpe.Pipeline):
                 "description": "graymatter tissue segmented in T1w MRI in Ixi549 space",
                 "needed_pipeline": "t1-volume-tissue-segmentation",
             }
-        elif self.parameters["orig_input_data"] == "pet-volume":
+        elif self.parameters["orig_input_data_ml"] == "pet-volume":
             if not (
                 self.parameters["acq_label"]
                 and self.parameters["suvr_reference_region"]
@@ -115,7 +115,7 @@ class SpatialSVM(cpe.Pipeline):
             )
         else:
             raise ValueError(
-                f"Image type {self.parameters['orig_input_data']} unknown."
+                f"Image type {self.parameters['orig_input_data_ml']} unknown."
             )
 
         try:
@@ -200,7 +200,7 @@ class SpatialSVM(cpe.Pipeline):
         datasink = npe.Node(nio.DataSink(), name="sinker")
         datasink.inputs.base_directory = self.caps_directory
         datasink.inputs.parameterization = True
-        if self.parameters["orig_input_data"] == "t1-volume":
+        if self.parameters["orig_input_data_ml"] == "t1-volume":
             datasink.inputs.regexp_substitutions = [
                 (
                     r"(.*)/regularized_image/.*/(.*(sub-(.*)_ses-(.*))_T1w(.*)_probability(.*))$",
@@ -226,7 +226,7 @@ class SpatialSVM(cpe.Pipeline):
                 ),
             ]
 
-        elif self.parameters["orig_input_data"] == "pet-volume":
+        elif self.parameters["orig_input_data_ml"] == "pet-volume":
             datasink.inputs.regexp_substitutions = [
                 (
                     r"(.*)/regularized_image/.*/(.*(sub-(.*)_ses-(.*))_(task.*)_pet(.*))$",

--- a/test/instantiation/test_instantiate_all_pipelines.py
+++ b/test/instantiation/test_instantiate_all_pipelines.py
@@ -381,7 +381,7 @@ def test_instantiate_spatial_svm(cmdopt):
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "SpatialSVM"
-    parameters = {"group_label": "ADNIbl", "orig_input_data": "t1-volume"}
+    parameters = {"group_label": "ADNIbl", "orig_input_data_ml": "t1-volume"}
     pipeline = SpatialSVM(
         caps_directory=fspath(root / "in" / "caps"),
         tsv_file=fspath(root / "in" / "subjects.tsv"),

--- a/test/nonregression/pipelines/test_run_pipelines_ml.py
+++ b/test/nonregression/pipelines/test_run_pipelines_ml.py
@@ -152,7 +152,7 @@ def run_spatial_svm(
     # Copy necessary data from in to out
     shutil.copytree(input_dir / "caps", caps_dir, copy_function=shutil.copy)
 
-    parameters = {"group_label": "ADNIbl", "orig_input_data": "t1-volume"}
+    parameters = {"group_label": "ADNIbl", "orig_input_data_ml": "t1-volume"}
     pipeline = SpatialSVM(
         caps_directory=fspath(caps_dir),
         tsv_file=fspath(tsv),


### PR DESCRIPTION
The command-line `machinelearning-prepare-spatial-svm` currently does not work, because the variable requested by the pipeline is `orig_input_data`, and the it is provided `orig_input_data_ml`