### PR TITLE
Oasis3 improvements

### DIFF
--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_to_bids_cli.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_to_bids_cli.py
@@ -23,8 +23,6 @@ def cli(
     from clinica.utils.check_dependency import check_dcm2niix
     from clinica.utils.stream import cprint
 
-    check_dcm2niix()
-
     convert_images(dataset_directory, bids_directory, clinical_data_directory)
 
     cprint("Conversion to BIDS succeeded.")

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -113,7 +113,7 @@ def identify_modality(source_path: str) -> str:
     from pathlib import Path
 
     try:
-        return (Path(str(source_path)).name).split(".")[0].split("_")[-1]
+        return (Path(source_path).name).split(".")[0].split("_")[-1]
     except:
         return "nan"
 

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -333,5 +333,6 @@ def write_bids(
     # Perform import of imaging data next.
     for filename, metadata in scans.iterrows():
         path = Path(dataset_directory) / metadata.source_dir
-        install_bids(sourcedata_dir=path, bids_filename=to / filename)
+        if str(filename).split("_")[-1].split(".")[0] != "nan":
+            install_bids(sourcedata_dir=path, bids_filename=to / filename)
     return scans.index.to_list()

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -153,7 +153,7 @@ def intersect_data(df_source: DataFrame, dict_df: dict) -> Tuple[DataFrame, Data
         df_source.modality.map(
             {
                 "T1w_MR": {"datatype": "anat", "suffix": "T1w"},
-                "T2w_MR": {"datatype": "anat", "suffix": "T2w"},
+                # "T2w_MR": {"datatype": "anat", "suffix": "T2w"},
                 "T2star_MR": {"datatype": "anat", "suffix": "T2star"},
                 "FLAIR_MR": {"datatype": "anat", "suffix": "FLAIR"},
                 "pet_FDG": {"datatype": "pet", "suffix": "pet", "trc_label": "18FFDG"},

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -154,7 +154,7 @@ def intersect_data(df_source: DataFrame, dict_df: dict) -> Tuple[DataFrame, Data
             {
                 "T1w_MR": {"datatype": "anat", "suffix": "T1w"},
                 "T2w_MR": {"datatype": "anat", "suffix": "T2w"},
-                "T2_star_MR": {"datatype": "anat", "suffix": "T2star"},
+                "T2star_MR": {"datatype": "anat", "suffix": "T2star"},
                 "FLAIR_MR": {"datatype": "anat", "suffix": "FLAIR"},
                 "pet_FDG": {"datatype": "pet", "suffix": "pet", "trc_label": "18FFDG"},
                 "pet_PIB": {"datatype": "pet", "suffix": "pet", "trc_label": "11CPIB"},

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -81,7 +81,7 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
         "path"
     )
     source_file_series = source_path_series.apply(
-        lambda x: (Path(str(x)).name).split(".")[0].split("_")[-1]
+        lambda x: identify_modality(x)
     ).rename("modality")
     source_run_series = source_path_series.apply(
         lambda x: identify_runs(str(x))
@@ -107,6 +107,12 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
         "_".join, axis=1
     )
     return df_source
+
+
+def identify_modality(x: str) -> str:
+    from pathlib import Path
+
+    return (Path(str(x)).name).split(".")[0].split("_")[-1]
 
 
 def identify_runs(x: str) -> str:
@@ -348,6 +354,10 @@ def write_bids(
     # Perform import of imaging data next.
     for filename, metadata in scans.iterrows():
         path = Path(dataset_directory) / metadata.source_dir
-        if str(filename).split("_")[-1].split(".")[0] != "nan":
+        if extract_suffix_from_filename(str(filename)) != "nan":
             install_bids(sourcedata_dir=path, bids_filename=to / filename)
     return scans.index.to_list()
+
+
+def extract_suffix_from_filename(filename: str) -> str:
+    return filename.split("_")[-1].split(".")[0]

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -178,7 +178,7 @@ def intersect_data(df_source: DataFrame, dict_df: dict) -> Tuple[DataFrame, Data
                 "dwi_MR": {"datatype": "dwi", "suffix": "dwi"},
                 "T1w_MR": {"datatype": "anat", "suffix": "T1w"},
                 # "T2w_MR": {"datatype": "anat", "suffix": "T2w"},
-                "T2star_MR": {"datatype": "anat", "suffix": "T2star"},
+                "T2star_MR": {"datatype": "anat", "suffix": "T2starw"},
                 "FLAIR_MR": {"datatype": "anat", "suffix": "FLAIR"},
                 "pet_FDG": {"datatype": "pet", "suffix": "pet", "trc_label": "18FFDG"},
                 "pet_PIB": {"datatype": "pet", "suffix": "pet", "trc_label": "11CPIB"},

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -73,7 +73,7 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
     source_path_series = pd.Series(
         find_imaging_data(imaging_data_directory), name="source_path"
     )
-    print("source_path_series: ", source_path_series)
+
     source_dir_series = source_path_series.apply(lambda x: Path(str(x)).parent).rename(
         "source_dir"
     )
@@ -93,10 +93,12 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
         ],
         axis=1,
     )
-    df_source = df_source.rename(
-        {0: "Subject", 1: "modality_2", 2: "Date"}, axis="columns"
-    ).drop_duplicates()
 
+    df_source = (
+        df_source.rename({0: "Subject", 1: "modality_2", 2: "Date"}, axis="columns")
+        .drop_duplicates()
+        .sort_values(by=["source_path"])
+    )
     df_source = df_source.assign(participant_id=lambda df: "sub-" + df.Subject)
     df_source["modality"] = df_source[["modality", "modality_2"]].apply(
         "_".join, axis=1
@@ -152,6 +154,7 @@ def intersect_data(df_source: DataFrame, dict_df: dict) -> Tuple[DataFrame, Data
     df_source = df_source.join(
         df_source.modality.map(
             {
+                "dwi_MR": {"datatype": "dwi", "suffix": "dwi"},
                 "T1w_MR": {"datatype": "anat", "suffix": "T1w"},
                 # "T2w_MR": {"datatype": "anat", "suffix": "T2w"},
                 "T2star_MR": {"datatype": "anat", "suffix": "T2star"},

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -97,7 +97,6 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
         ],
         axis=1,
     )
-    print("df_source: ", df_source)
     df_source = (
         df_source.rename({0: "Subject", 1: "modality_2", 2: "Date"}, axis="columns")
         .drop_duplicates()
@@ -114,7 +113,7 @@ def identify_runs(x: str) -> str:
     import re
 
     try:
-        return re.search(r"run-\d+")[0]
+        return re.search(r"run-\d+", x)[0]
     except:
         return "run-01"
 
@@ -188,7 +187,7 @@ def intersect_data(df_source: DataFrame, dict_df: dict) -> Tuple[DataFrame, Data
                 lambda x: f"{x.participant_id}/{x.ses}/{x.datatype}/"
                 f"{x.participant_id}_{x.ses}"
                 f"{'_trc-'+x.trc_label if pd.notna(x.trc_label) else ''}"
-                f"_{x.suffix}.nii.gz",
+                f"_{x.run_number}_{x.suffix}.nii.gz",
                 axis=1,
             )
         )
@@ -197,7 +196,7 @@ def intersect_data(df_source: DataFrame, dict_df: dict) -> Tuple[DataFrame, Data
             filename=lambda df: df.apply(
                 lambda x: f"{x.participant_id}/{x.ses}/{x.datatype}/"
                 f"{x.participant_id}_{x.ses}"
-                f"_{x.suffix}.nii.gz",
+                f"_{x.run_number}_{x.suffix}.nii.gz",
                 axis=1,
             )
         )

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -177,7 +177,6 @@ def intersect_data(df_source: DataFrame, dict_df: dict) -> Tuple[DataFrame, Data
             {
                 "dwi_MR": {"datatype": "dwi", "suffix": "dwi"},
                 "T1w_MR": {"datatype": "anat", "suffix": "T1w"},
-                # "T2w_MR": {"datatype": "anat", "suffix": "T2w"},
                 "T2star_MR": {"datatype": "anat", "suffix": "T2starw"},
                 "FLAIR_MR": {"datatype": "anat", "suffix": "FLAIR"},
                 "pet_FDG": {"datatype": "pet", "suffix": "pet", "trc_label": "18FFDG"},

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -109,17 +109,20 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
     return df_source
 
 
-def identify_modality(x: str) -> str:
+def identify_modality(source_path: str) -> str:
     from pathlib import Path
 
-    return (Path(str(x)).name).split(".")[0].split("_")[-1]
+    try:
+        return (Path(str(source_path)).name).split(".")[0].split("_")[-1]
+    except:
+        return "nan"
 
 
-def identify_runs(x: str) -> str:
+def identify_runs(source_path: str) -> str:
     import re
 
     try:
-        return re.search(r"run-\d+", x)[0]
+        return re.search(r"run-\d+", source_path)[0]
     except:
         return "run-01"
 
@@ -360,4 +363,5 @@ def write_bids(
 
 
 def extract_suffix_from_filename(filename: str) -> str:
+
     return filename.split("_")[-1].split(".")[0]

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_utils.py
@@ -83,6 +83,9 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
     source_file_series = source_path_series.apply(
         lambda x: (Path(str(x)).name).split(".")[0].split("_")[-1]
     ).rename("modality")
+    source_run_series = source_path_series.apply(
+        lambda x: identify_runs(str(x))
+    ).rename("run_number")
     df_source = pd.concat(
         [
             source_path_series,
@@ -90,10 +93,11 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
             source_dir_series,
             file_spec_series.str.split("_", expand=True),
             source_file_series,
+            source_run_series,
         ],
         axis=1,
     )
-
+    print("df_source: ", df_source)
     df_source = (
         df_source.rename({0: "Subject", 1: "modality_2", 2: "Date"}, axis="columns")
         .drop_duplicates()
@@ -104,6 +108,15 @@ def read_imaging_data(imaging_data_directory: PathLike) -> DataFrame:
         "_".join, axis=1
     )
     return df_source
+
+
+def identify_runs(x: str) -> str:
+    import re
+
+    try:
+        return re.search(r"run-\d+")[0]
+    except:
+        return "run-01"
 
 
 def find_imaging_data(path_to_source_data: PathLike) -> Iterable[PathLike]:

--- a/docs/Converters/OASIS3TOBIDS.md
+++ b/docs/Converters/OASIS3TOBIDS.md
@@ -87,19 +87,26 @@ To download the images of the OASIS-3 dataset:
 
     a. For the "Scan Format" select *both* BIDS and NIFTI. Otherwise, you will be missing data.
     
-    b. For the "Scan Types", select only T1w and pet, since it is the only format converted right now.
+    b. For the "Scan Types", select only the modalities you desire. Do note that if it is not amongst the modality handled by this converter, it will not be converted.
     
     c. For the "Additional Resources", select BIDS.
     
     d. For the "Assessments", do not select anything.
+
+    e. For the "Download Data", select "Simplify downloaded archive structure" and not the other options.
     
 4. Click submit to download. We advise that you use the XNAT Desktop Client which will be more efficient than download through your web browser.
 
 ## Supported modalities
 
-Please note that this converter only processes T1-weighted MRI images and the clinical data. Support for additional
-modalities may be implemented later.
+Please note that this converter currently processes the clinical data and the following modalities : 
+- T1W
+- T2star
+- Flair
+- DWI
+- PET 
 
+Support for additional modalities may be implemented later.
 For participants with multiple T1-weighted images available, the average of the motion-corrected co-registered
 individual images resampled to 1-mm isotropic resolution is given priority.
 


### PR DESCRIPTION
This PR improves a few key points:

- [x] Handling overflow of data: the downloading of data the converter did handle made it generate nan folders and nan files
- [x] Removing the `dcm2niix_check` as it useless
- [x] Handling FLAIR, T2star, and dwi
- [x] Handling run numbers thus converting more of the data and overcoming the uncertainty on which of the runs was converted.
- [x] Documentation update
- [x] Data CI update