### PR TITLE
[ENH TEST] Improve `compare_folders` error message

### DIFF
--- a/test/nonregression/testing_tools.py
+++ b/test/nonregression/testing_tools.py
@@ -301,7 +301,7 @@ def _format_line_differences(lines: list) -> str:
     msg = ""
     for line in lines:
         left, right = line
-        msg += f"\t\t- {_format_tree_line(left)} != {_format_tree_line(right)}\n"
+        msg += f"\t- {_format_tree_line(left)} != {_format_tree_line(right)}\n"
 
     return msg
 

--- a/test/unittests/test_testing_tools.py
+++ b/test/unittests/test_testing_tools.py
@@ -240,7 +240,7 @@ def test_compare_folders_empty_nested(tmp_path):
     dir2 = tmp_path / "folder2" / "subfolder2"
     dir2.mkdir(parents=True)
 
-    assert compare_folders(dir1, dir2, tmp_path)
+    assert compare_folders(tmp_path / "folder1", tmp_path / "folder2", tmp_path)
 
 
 def test_compare_folders(tmp_path):
@@ -298,10 +298,10 @@ def test_compare_folders_multiple_mismatches(tmp_path):
         E                   + file2.xt
         E
         E            There are 4 lines with a mismatch :
-        E           		- subfolder2 != subfolder3
-        E           		- file2.xt != file4.xt
-        E           		- subfolder3 != subfolder4
-        E           		- file3.xt != file2.xt
+        E           	- subfolder2 != subfolder3
+        E           	- file2.xt != file4.xt
+        E           	- subfolder3 != subfolder4
+        E           	- file3.xt != file2.xt
     """
     from test.nonregression.testing_tools import compare_folders
 


### PR DESCRIPTION
This PR proposes to improve the error message of the testing utility function `compare_folders`.

The function currently returns `True` if the two folders have the same file trees and raises a `ValueError` otherwise. The error message contains both trees. 

It is easy to spot differences when the folders are not too large/deep, but quickly becomes difficult when they increase in size. 

For instance, I'm having troubles seing the differences when non-regression tests for converters fail as the folders are quite large for these pipelines.

This PR adds a section at the end of the error message: it gives the number of lines which differ between the two trees and it prints the differences explicitly.

Here is a small example:

```python
>>> compare_folders(out_folder, ref_folder, tmp_path)
E           ValueError: Comparison of out and ref directories shows mismatch :
E            The content of the OUT directory :
E               + subfolder1
E                   + file1.txt
E               + subfolder2
E                   + file2.xt
E               + subfolder3
E                   + file3.xt
E
E            The content of the REF directory :
E               + subfolder1
E                   + file1.txt
E               + subfolder3
E                   + file4.xt
E               + subfolder4
E                   + file2.xt
E
E            There are 4 lines with a mismatch :
E           		- subfolder2 != subfolder3
E           		- file2.xt != file4.xt
E           		- subfolder3 != subfolder4
E           		- file3.xt != file2.xt
```