### PR TITLE
[REF, TEST] Add tests and refactor ADNI `get_preferred_visit_name`

### DIFF
--- a/test/unittests/iotools/converters/adni_to_bids/test_adni_utils.py
+++ b/test/unittests/iotools/converters/adni_to_bids/test_adni_utils.py
@@ -27,6 +27,72 @@ def test_bids_id_to_loni(input_value, expected):
     assert bids_id_to_loni(input_value) == expected
 
 
+def test_adni_study_error():
+    from clinica.iotools.converters.adni_to_bids.adni_utils import ADNIStudy
+
+    with pytest.raises(
+        ValueError,
+        match="Invalid study name for ADNI: foo.",
+    ):
+        ADNIStudy.from_string("foo")
+
+
+@pytest.mark.parametrize(
+    "study_name,visit_code,expected",
+    [
+        ("ADNI3", "bl", "ADNI Screening"),
+        ("ADNI3", "M000", "ADNI3 Year 0.0 Visit"),
+        ("ADNI3", "M006", "ADNI3 Year 0.5 Visit"),
+        ("ADNI3", "M012", "ADNI3 Year 1.0 Visit"),
+        ("ADNI3", "M013", "ADNI3 Year 1.0833333333333333 Visit"),
+        ("ADNI2", "bl", "ADNI2 Screening MRI-New Pt"),
+        ("ADNI2", "m03", "ADNI2 Month 3 MRI-New Pt"),
+        ("ADNI2", "m06", "ADNI2 Month 6-New Pt"),
+        ("ADNI2", "M000", "ADNI2 Year 0.0 Visit"),
+        ("ADNI2", "M006", "ADNI2 Year 0.5 Visit"),
+        ("ADNI2", "M012", "ADNI2 Year 1.0 Visit"),
+        ("ADNI2", "M013", "ADNI2 Year 1.0833333333333333 Visit"),
+        ("ADNI1", "bl", "ADNI Screening"),
+        ("ADNIGO", "bl", "ADNIGO Screening MRI"),
+        ("ADNI1", "m03", "ADNIGO Month 3 MRI"),
+        ("ADNIGO", "m03", "ADNIGO Month 3 MRI"),
+        ("ADNI1", "m00", "ADNI1/GO Month 0"),
+        ("ADNIGO", "m00", "ADNI1/GO Month 0"),
+        ("ADNI1", "m07", "ADNI1/GO Month 7"),
+        ("ADNIGO", "m07", "ADNI1/GO Month 7"),
+        ("ADNI1", "m12", "ADNI1/GO Month 12"),
+        ("ADNIGO", "m12", "ADNI1/GO Month 12"),
+        ("ADNI1", "m53", "ADNI1/GO Month 53"),
+        ("ADNIGO", "m53", "ADNI1/GO Month 53"),
+        ("ADNI1", "m54", "ADNIGO Month 54"),
+        ("ADNIGO", "m54", "ADNIGO Month 54"),
+    ],
+)
+def test_get_preferred_visit_name(study_name, visit_code, expected):
+    from clinica.iotools.converters.adni_to_bids.adni_utils import (
+        ADNIStudy,
+        _get_preferred_visit_name,
+    )
+
+    assert (
+        _get_preferred_visit_name(ADNIStudy.from_string(study_name), visit_code)
+        == expected
+    )
+
+
+def test_get_preferred_visit_name_visit_code_error():
+    from clinica.iotools.converters.adni_to_bids.adni_utils import (
+        ADNIStudy,
+        _get_preferred_visit_name,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot extract month from visit code",
+    ):
+        _get_preferred_visit_name(ADNIStudy.from_string("ADNI3"), "")
+
+
 @pytest.mark.parametrize(
     "csv_filename,expected_visit_code",
     [


### PR DESCRIPTION
This PR proposes to:

- Make `get_preferred_visit_name` "private" (becomes `_get_preferred_visit_name`) since it is only used in this module.
- Refactor the code to make it easier to understand (the complex imbrication of `if/elif/else` wasn't easy to follow).
- Raise meaningful errors when unexpected values are received.
- Add unit tests.

There are a few weird things that I discovered when writing the unit tests prior to refactoring. I kept them for backward compatibility concerns but it might be worth taking a closer look....