### PR TITLE
[GENFI] TSV improvements

### DIFF
--- a/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_utils.py
+++ b/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_utils.py
@@ -746,14 +746,13 @@ def write_bids(
     to = Path(to)
     fs = LocalFileSystem(auto_mkdir=True)
     # Ensure BIDS hierarchy is written first.
-    print("participants: ", participants)
+
     participants = (
         participants.reset_index()
         .drop(["session_id", "modality", "run_num", "bids_filename", "source"], axis=1)
         .drop_duplicates()
         .set_index("participant_id")
     )
-    print("participants: ", participants)
     with fs.transaction:
         with fs.open(
             str(to / "dataset_description.json"), "w"
@@ -771,7 +770,7 @@ def write_bids(
         with fs.open(str(sessions_filepath), "w") as sessions_file:
             write_to_tsv(sessions, sessions_file)
     scans = scans.reset_index().set_index(["bids_full_path"], verify_integrity=True)
-    dcm2nixx_bids_path = []
+    dcm2niix_bids_path = []
     dcm2niix_success_list = []
     for bids_full_path, metadata in scans.iterrows():
         try:
@@ -784,18 +783,8 @@ def write_bids(
             metadata["bids_filename"],
             True,
         )
-        dcm2nixx_bids_path.append(bids_full_path)
+        dcm2niix_bids_path.append(bids_full_path)
         dcm2niix_success_list.append(dcm2niix_success)
-        # if dcm2niix_success:
-        #     scans_filepath = (
-        #         to
-        #         / str(metadata.participant_id)
-        #         / str(metadata.session_id)
-        #         / f"{metadata.participant_id}_{metadata.session_id}_scan.tsv"
-        #     )
-        # print(scans_filepath)
-        # with fs.open(str(scans_filepath), "w") as scans_file:
-        #     write_to_tsv(scans, scans_file)
         if (
             "dwi" in metadata["bids_filename"]
             and "Philips" in metadata.manufacturer
@@ -808,7 +797,7 @@ def write_bids(
             )
 
     dcm2niix_success_df = pd.DataFrame(
-        list(zip(dcm2nixx_bids_path, dcm2niix_success_list)),
+        list(zip(dcm2niix_bids_path, dcm2niix_success_list)),
         columns=["bids_full_path", "dcm2niix_success"],
     )
     converted_scans = scans.merge(
@@ -817,7 +806,6 @@ def write_bids(
         ["participant_id", "session_id", "modality", "run_num", "bids_filename"],
         verify_integrity=True,
     )
-    print(converted_scans)
     for grouped_by, df in converted_scans.groupby(["participant_id", "session_id"]):
         participant_id, session_id = grouped_by
         df_to_write = (

--- a/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_utils.py
+++ b/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_utils.py
@@ -770,8 +770,16 @@ def write_bids(
         with fs.open(str(sessions_filepath), "w") as sessions_file:
             write_to_tsv(sessions, sessions_file)
     scans = scans.reset_index().set_index(["bids_full_path"], verify_integrity=True)
-    dcm2niix_bids_path = []
-    dcm2niix_success_list = []
+    scans_columns_names = pd.DataFrame(
+        [
+            "modality",
+            "run_num",
+            "bids_filename",
+            "source_path",
+            "manufacturer",
+            "number_of_parts",
+        ]
+    )
     for bids_full_path, metadata in scans.iterrows():
         try:
             os.makedirs(to / (Path(bids_full_path).parent))
@@ -783,45 +791,40 @@ def write_bids(
             metadata["bids_filename"],
             True,
         )
-        dcm2niix_bids_path.append(bids_full_path)
-        dcm2niix_success_list.append(dcm2niix_success)
-        if (
-            "dwi" in metadata["bids_filename"]
-            and "Philips" in metadata.manufacturer
-            and dcm2niix_success
-        ):
-            merge_philips_diffusion(
-                to / Path(bids_full_path).with_suffix(".json"),
-                metadata.number_of_parts,
-                metadata.run_num,
+        if dcm2niix_success:
+            scans_filepath = (
+                to
+                / str(metadata.participant_id)
+                / str(metadata.session_id)
+                / f"{metadata.participant_id}_{metadata.session_id}_scan.tsv"
             )
+            if not Path(scans_filepath).exists():
+                index_to_write = scans_columns_names.to_csv(
+                    index=False, header=False, lineterminator="\t"
+                )
+                with open(scans_filepath, "a") as scans_file:
+                    scans_file.write(f"{index_to_write}\n")
 
-    dcm2niix_success_df = pd.DataFrame(
-        list(zip(dcm2niix_bids_path, dcm2niix_success_list)),
-        columns=["bids_full_path", "dcm2niix_success"],
-    )
-    converted_scans = scans.merge(
-        dcm2niix_success_df, how="inner", on="bids_full_path"
-    ).set_index(
-        ["participant_id", "session_id", "modality", "run_num", "bids_filename"],
-        verify_integrity=True,
-    )
-    for grouped_by, df in converted_scans.groupby(["participant_id", "session_id"]):
-        participant_id, session_id = grouped_by
-        df_to_write = (
-            df.reset_index()
-            .drop(columns=["participant_id", "session_id", "number_of_parts"])
-            .set_index("bids_full_path")
-        )
-        scans_filepath = (
-            to
-            / str(participant_id)
-            / str(session_id)
-            / f"{participant_id}_{session_id}_scan.tsv"
-        )
-        with fs.open(str(scans_filepath), "w") as scans_file:
-            write_to_tsv(df_to_write, scans_file)
-
+            row_to_write = (
+                metadata.drop(["participant_id", "session_id"])
+                .to_csv(
+                    index=False,
+                    header=False,
+                    lineterminator="\t",
+                )
+                .rstrip("\t")
+            )
+            with open(scans_filepath, "a") as scans_file:
+                scans_file.write(f"{row_to_write}\n")
+            if (
+                "dwi" in metadata["bids_filename"]
+                and "Philips" in metadata.manufacturer
+            ):
+                merge_philips_diffusion(
+                    to / Path(bids_full_path).with_suffix(".json"),
+                    metadata.number_of_parts,
+                    metadata.run_num,
+                )
     correct_fieldmaps_name(to)
     return
 

--- a/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_utils.py
+++ b/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_utils.py
@@ -798,7 +798,7 @@ def write_bids(
                 / str(metadata.session_id)
                 / f"{metadata.participant_id}_{metadata.session_id}_scan.tsv"
             )
-            if not Path(scans_filepath).exists():
+            if not scans_filepath.exists():
                 index_to_write = scans_columns_names.to_csv(
                     index=False, header=False, lineterminator="\t"
                 )


### PR DESCRIPTION
This PR aims at two things:

- [x] Correcting current issues of the `participants.tsv` and `sessions.tsv`, mainly ensuring we don't have useless information.
- [ ] Adding a `scans.tsv`, which comes in handy since it gives details about `modalities` and `runs`, as well as an information that has been required, the `path_to_the_original_dicom`.

This work will need a data CI PR, since it adds new files (`scans.tsv`) to the architecture, and should therefore break current tests.