### PR TITLE
[GENFI] Handle T1 converted as T2

### DIFF
--- a/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_utils.py
+++ b/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_utils.py
@@ -61,13 +61,6 @@ def filter_dicoms(df: DataFrame) -> DataFrame:
     ]
 
     df = df.drop_duplicates(subset=["source"])
-    # df = df.assign(
-    #     series_desc=lambda x: x.source_path.apply(
-    #         lambda y: pdcm.dcmread(y).SeriesDescription
-    #     ),
-    #     acq_date=lambda x: x.source_path.apply(lambda y: pdcm.dcmread(y).StudyDate),
-    #     manufacturer=lambda x: x.source_path.apply(lambda y: _handle_manufacturer(y)),
-    # )
     df = df.assign(
         series_desc=lambda x: x.source_path.apply(
             lambda y: _handle_series_description(y)

--- a/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_utils.py
+++ b/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_utils.py
@@ -78,8 +78,8 @@ def filter_dicoms(df: DataFrame) -> DataFrame:
 def _handle_series_description(x: str) -> str:
     """This function handles the series description used to identify the modality later on.
 
-    In the  case of T1 and T2, some dicoms are misnamed. Therefore we use the echo time and repetition time
-    which are supposed to be very different for a T1 and T2, to check the series description corresponds to what has been done.
+    In the case of T1 and T2, some dicoms are misnamed. The echo time and repetition time
+    are supposed to be very different between a T1 and T2. Therefore, we use this proxy to check that the series description is coherent.
     The values used are in milliseconds, and have been chosen arbitrarily.
     """
     MAX_ECHO_TIME_FOR_A_T1 = 60

--- a/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_utils.py
+++ b/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_utils.py
@@ -61,6 +61,13 @@ def filter_dicoms(df: DataFrame) -> DataFrame:
     ]
 
     df = df.drop_duplicates(subset=["source"])
+    # df = df.assign(
+    #     series_desc=lambda x: x.source_path.apply(
+    #         lambda y: pdcm.dcmread(y).SeriesDescription
+    #     ),
+    #     acq_date=lambda x: x.source_path.apply(lambda y: pdcm.dcmread(y).StudyDate),
+    #     manufacturer=lambda x: x.source_path.apply(lambda y: _handle_manufacturer(y)),
+    # )
     df = df.assign(
         series_desc=lambda x: x.source_path.apply(
             lambda y: _handle_series_description(y)


### PR DESCRIPTION
Some T1 are not correctly converted. This is due to the fact that the conversion is based on the series description and that for a large amount of T1, it is wrongly described as a T2 (not the other way around, as far as we know). `dcm2niix` makes the same mistake as well.
Therefore, we if the `SeriesDescription` is T1 or T2, we check the `EchoTime` and `RepetitionTime` that characterise T1 or T2.

This PR will need a change in the data CI because of that.