### PR TITLE
[TEST] Add unit tests for groups utils

### DIFF
--- a/clinica/utils/group.py
+++ b/clinica/utils/group.py
@@ -4,22 +4,53 @@ See CAPS specifications for details about groups.
 """
 
 
-def check_group_label(group_label):
-    """Check that `group_label` is compliant with specifications."""
+def check_group_label(group_label: str) -> None:
+    """Check that `group_label` is compliant with specifications.
+
+    The group label must be a string composed of alphanumeric
+    characters (alphabets or numbers). This means that a group
+    label cannot contain spaces nor special characters.
+
+    Parameters
+    ----------
+    group_label : str
+        The group label to verify.
+
+    Raises
+    ------
+    ValueError :
+        If the provided group label is not compliant.
+    """
     if not group_label.isalnum():
         raise ValueError(
-            f"Not valid group_label value: it must be composed only by letters "
+            "Not valid group_label value: it must be composed only by letters "
             f"and/or numbers (given value: {group_label})."
         )
 
 
-def extract_group_ids(caps_directory):
-    """Extract list of group IDs (e.g. ['group-AD', 'group-HC']) based on `caps_directory`/groups folder."""
+def extract_group_ids(caps_directory: str) -> list:
+    """Extract a list of group IDs from a CAPS folder.
+
+    The function searches for sub-folders of `caps_directory/groups`.
+    According to the CAPS specifications, these sub-folders should be named
+    with their group IDs (e.g. ['group-AD', 'group-HC']).
+
+    If the provided CAPS folder does not contain a "groups" subfolder,
+    the function returns a list with an empty string.
+
+    Parameters
+    ----------
+    caps_directory : str
+        The CAPS folder to search for group IDs.
+
+    Returns
+    -------
+    list of str :
+        The list of group IDs found inside the provided CAPS folder.
+    """
     import os
 
     try:
-        group_ids = os.listdir(os.path.join(caps_directory, "groups"))
+        return os.listdir(os.path.join(caps_directory, "groups"))
     except FileNotFoundError:
-        group_ids = [""]
-
-    return group_ids
+        return [""]

--- a/clinica/utils/ux.py
+++ b/clinica/utils/ux.py
@@ -141,12 +141,16 @@ def print_crash_files_and_exit(log_file, working_directory):
 
 def print_groups_in_caps_directory(caps_directory):
     """Print group IDs based on `caps_directory`/groups folder."""
-    from .group import extract_group_ids
     from .stream import cprint
 
+    cprint(_get_group_message(caps_directory))
+
+
+def _get_group_message(caps_directory: str) -> str:
+    from .group import extract_group_ids
+
     group_ids = extract_group_ids(caps_directory)
-    if group_ids == [""]:
-        cprint("No group was found in CAPS directory")
-    else:
+    if group_ids:
         found_groups = ", ".join(g_id.replace("group-", "") for g_id in group_ids)
-        cprint(f"Groups that exist in your CAPS directory are {found_groups}.")
+        return f"Groups that exist in your CAPS directory are {found_groups}."
+    return "No group was found in CAPS directory"

--- a/test/unittests/utils/test_group.py
+++ b/test/unittests/utils/test_group.py
@@ -35,16 +35,52 @@ def test_check_group_label_errors(label):
         check_group_label(label)
 
 
+@pytest.mark.parametrize("folder_name", ["group-AD", "group-foo", "group-foo12bar"])
+def test_check_group_dir(tmp_path, folder_name):
+    from clinica.utils.group import _check_group_dir
+
+    assert _check_group_dir(tmp_path / folder_name) is None
+
+
+@pytest.mark.parametrize(
+    "folder_name", ["foo", "foo-group", "groupfoo12bar", "foo.txt"]
+)
+def test_check_group_dir_errors(tmp_path, folder_name):
+    from clinica.utils.group import _check_group_dir
+
+    with pytest.raises(
+        ValueError,
+        match="Group directory",
+    ):
+        _check_group_dir(tmp_path / folder_name)
+
+
 def test_extract_group_ids_empty(tmp_path):
     from clinica.utils.group import extract_group_ids
 
-    assert extract_group_ids(str(tmp_path)) == [""]
-    assert extract_group_ids(str(tmp_path / "group")) == [""]
+    assert extract_group_ids(tmp_path) == []
+    assert extract_group_ids(tmp_path / "group") == []
     (tmp_path / "group").mkdir()
-    assert extract_group_ids(str(tmp_path / "group")) == [""]
+    assert extract_group_ids(tmp_path / "group") == []
 
 
 def test_extract_group_ids(tmp_path):
+    from clinica.utils.group import extract_group_ids
+
+    groups_folder = tmp_path / "groups"
+    groups_folder.mkdir()
+    expected_group_ids = ["group-AD", "group-foo", "group-X"]
+    for group_id in expected_group_ids:
+        (groups_folder / group_id).mkdir()
+
+    assert set(extract_group_ids(tmp_path)) == set(expected_group_ids)
+
+    (groups_folder / "file.txt").touch()
+
+    assert set(extract_group_ids(tmp_path)) == set(expected_group_ids)
+
+
+def test_extract_group_ids_errors(tmp_path):
     from clinica.utils.group import extract_group_ids
 
     groups_folder = tmp_path / "groups"
@@ -53,12 +89,7 @@ def test_extract_group_ids(tmp_path):
     for group_id in expected_group_ids:
         (groups_folder / group_id).mkdir()
 
-    assert set(extract_group_ids(str(tmp_path))) == set(expected_group_ids)
-
-    # The extract_group_ids function currently gets easily fooled
-    # as it doesn't perform any checks on the content of the group folder...
-    (groups_folder / "file.txt").touch()
-
-    assert set(extract_group_ids(str(tmp_path))) == set(
-        expected_group_ids + ["file.txt"]
-    )
+    with pytest.raises(
+        ValueError, match=f"Group directory {groups_folder / 'foo'} is not valid"
+    ):
+        extract_group_ids(tmp_path)

--- a/test/unittests/utils/test_group.py
+++ b/test/unittests/utils/test_group.py
@@ -1,0 +1,64 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "label",
+    ["A", "a1", "123", "0xY2", "mygroup"],
+)
+def test_check_group_label(label):
+    from clinica.utils.group import check_group_label
+
+    assert check_group_label(label) is None
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "",
+        "$",
+        "@group1",
+        "group1+group2",
+        "my group",
+        " ",
+        "#12",
+        "my_group",
+        "my_group2",
+    ],
+)
+def test_check_group_label_errors(label):
+    from clinica.utils.group import check_group_label
+
+    with pytest.raises(
+        ValueError,
+        match="Not valid group_label value",
+    ):
+        check_group_label(label)
+
+
+def test_extract_group_ids_empty(tmp_path):
+    from clinica.utils.group import extract_group_ids
+
+    assert extract_group_ids(str(tmp_path)) == [""]
+    assert extract_group_ids(str(tmp_path / "group")) == [""]
+    (tmp_path / "group").mkdir()
+    assert extract_group_ids(str(tmp_path / "group")) == [""]
+
+
+def test_extract_group_ids(tmp_path):
+    from clinica.utils.group import extract_group_ids
+
+    groups_folder = tmp_path / "groups"
+    groups_folder.mkdir()
+    expected_group_ids = ["group-AD", "group-foo", "group-X", "foo"]
+    for group_id in expected_group_ids:
+        (groups_folder / group_id).mkdir()
+
+    assert set(extract_group_ids(str(tmp_path))) == set(expected_group_ids)
+
+    # The extract_group_ids function currently gets easily fooled
+    # as it doesn't perform any checks on the content of the group folder...
+    (groups_folder / "file.txt").touch()
+
+    assert set(extract_group_ids(str(tmp_path))) == set(
+        expected_group_ids + ["file.txt"]
+    )

--- a/test/unittests/utils/test_ux.py
+++ b/test/unittests/utils/test_ux.py
@@ -1,0 +1,21 @@
+def test_get_group_message_empty(tmp_path):
+    from clinica.utils.ux import _get_group_message
+
+    assert _get_group_message(tmp_path) == "No group was found in CAPS directory"
+
+    (tmp_path / "foo.nii.gz").touch()
+
+    assert _get_group_message(tmp_path) == "No group was found in CAPS directory"
+
+
+def test_get_group_message(tmp_path):
+    from clinica.utils.ux import _get_group_message
+
+    (tmp_path / "groups").mkdir()
+    for group in ("group-AD", "group-foo", "group-foobar66"):
+        (tmp_path / "groups" / group).mkdir()
+
+    assert (
+        _get_group_message(tmp_path)
+        == "Groups that exist in your CAPS directory are AD, foo, foobar66."
+    )


### PR DESCRIPTION
Small PR adding unit tests for utility functions in `clinica.utils.groups`.
Also add type hints and Numpydoc compliance.

I noticed that the `extract_group_ids` function simply lists the folder `caps_directory/groups` without any check, and can easily return things that are invalid group IDs (like file names if there are some within `caps_directory/groups`). 
This could be on purpose if the function assumes a validated CAPS folder (but should be clarified in the docstring I think). Otherwise, it could be useful to add a small safety check.