### PR TITLE
[CI] Fix the destination folder to deploy the documentation

### DIFF
--- a/.jenkins/docs.Jenkinsfile
+++ b/.jenkins/docs.Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
               ],
               usePromotionTimestamp: false,
               useWorkspaceInPromotion: false,
-              verbose: false
+              verbose: true
             )
           ]
         )


### PR DESCRIPTION
This PR intend to fix the the name of the target folder when deploying the documentation (for the case of tagged commits).