### PR TITLE
[ENH] Improve BIDS compatibility of `T1Linear` and `FLAIRLinear` CAPS outputs

### DIFF
--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -181,7 +181,14 @@ class AnatLinear(cpe.Pipeline):
 
         from clinica.utils.nipype import container_from_filename, fix_join
 
-        from .anat_linear_utils import get_substitutions_datasink
+        if self.name == "flair-linear":
+            from .anat_linear_utils import (
+                get_substitutions_datasink_flair as get_substitutions,
+            )
+        else:
+            from .anat_linear_utils import (
+                get_substitutions_datasink_t1_linear as get_substitutions,
+            )
 
         # Writing node
         write_node = npe.Node(name="WriteCaps", interface=DataSink())
@@ -193,13 +200,12 @@ class AnatLinear(cpe.Pipeline):
         # Get substitutions to rename files
         get_ids = npe.Node(
             interface=nutil.Function(
-                input_names=["bids_file", "pipeline_name"],
-                output_names=["subst_ls"],
-                function=get_substitutions_datasink,
+                input_names=["bids_image_id"],
+                output_names=["substitutions"],
+                function=get_substitutions,
             ),
             name="GetIDs",
         )
-        get_ids.inputs.pipeline_name = self.name
         # Find container path from t1w filename
         container_path = npe.Node(
             nutil.Function(
@@ -213,8 +219,9 @@ class AnatLinear(cpe.Pipeline):
         self.connect(
             [
                 (self.input_node, container_path, [("anat", "bids_or_caps_filename")]),
+                (self.output_node, get_ids, [("image_id", "bids_image_id")]),
                 (container_path, write_node, [(("container", fix_join, self.name.replace("-", "_")), "container")]),
-                (get_ids, write_node, [("subst_ls", "substitutions")]),
+                (get_ids, write_node, [("substitutions", "substitutions")]),
                 (self.output_node, write_node, [("image_id", "@image_id")]),
                 (self.output_node, write_node, [("outfile_reg", "@outfile_reg")]),
                 (self.output_node, write_node, [("affine_mat", "@affine_mat")]),

--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -194,7 +194,7 @@ class AnatLinear(cpe.Pipeline):
         get_ids = npe.Node(
             interface=nutil.Function(
                 input_names=["bids_file", "pipeline_name"],
-                output_names=["image_id_out", "subst_ls"],
+                output_names=["subst_ls"],
                 function=get_substitutions_datasink,
             ),
             name="GetIDs",
@@ -213,10 +213,9 @@ class AnatLinear(cpe.Pipeline):
         self.connect(
             [
                 (self.input_node, container_path, [("anat", "bids_or_caps_filename")]),
-                (self.output_node, get_ids, [("image_id", "bids_file")]),
                 (container_path, write_node, [(("container", fix_join, self.name.replace("-", "_")), "container")]),
                 (get_ids, write_node, [("subst_ls", "substitutions")]),
-                (get_ids, write_node, [("image_id_out", "@image_id")]),
+                (self.output_node, write_node, [("image_id", "@image_id")]),
                 (self.output_node, write_node, [("outfile_reg", "@outfile_reg")]),
                 (self.output_node, write_node, [("affine_mat", "@affine_mat")]),
             ]

--- a/clinica/pipelines/t1_linear/anat_linear_utils.py
+++ b/clinica/pipelines/t1_linear/anat_linear_utils.py
@@ -1,5 +1,25 @@
-def get_substitutions_datasink(bids_file, pipeline_name):
-    suffix = "T1w" if pipeline_name == "t1-linear" else "flair"
+def get_substitutions_datasink(bids_file: str, pipeline_name: str) -> tuple:
+    """Return file name substitutions for renaming.
+
+    Parameters
+    ----------
+    bids_file : str
+        This is the original BIDS file name without the extension.
+        This will be used to get all the BIDS entities that shouldn't
+        be modified (subject, session...).
+
+    pipeline_name : str
+        The name of the pipeline.
+
+    Returns
+    -------
+    bids_file : str
+        The input BIDS file. Why do we need to do this ????
+
+    substitutions : Tuple of str
+        Tuple of length 3 containing the substitutions to perform.
+    """
+    suffix = "T1w" if pipeline_name == "t1-linear" else "FLAIR"
     substitutions = [
         (
             f"{bids_file}Warped_cropped.nii.gz",

--- a/clinica/pipelines/t1_linear/anat_linear_utils.py
+++ b/clinica/pipelines/t1_linear/anat_linear_utils.py
@@ -1,10 +1,10 @@
-def get_substitutions_datasink(bids_file: str, pipeline_name: str) -> tuple:
+def get_substitutions_datasink(bids_image_id: str, pipeline_name: str) -> list:
     """Return file name substitutions for renaming.
 
     Parameters
     ----------
-    bids_file : str
-        This is the original BIDS file name without the extension.
+    bids_image_id : str
+        This is the original image BIDS file name without the extension.
         This will be used to get all the BIDS entities that shouldn't
         be modified (subject, session...).
 
@@ -13,28 +13,25 @@ def get_substitutions_datasink(bids_file: str, pipeline_name: str) -> tuple:
 
     Returns
     -------
-    bids_file : str
-        The input BIDS file. Why do we need to do this ????
-
-    substitutions : Tuple of str
-        Tuple of length 3 containing the substitutions to perform.
+    substitutions : List of tuples of str
+        List of length 3 containing the substitutions to perform.
     """
     suffix = "T1w" if pipeline_name == "t1-linear" else "FLAIR"
-    substitutions = [
+    bids_image_id_without_suffix = bids_image_id.rstrip(f"_{suffix}")
+    return [
         (
-            f"{bids_file}Warped_cropped.nii.gz",
-            f"{bids_file}_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_{suffix}.nii.gz",
+            f"{bids_image_id}Warped_cropped.nii.gz",
+            f"{bids_image_id_without_suffix}_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_{suffix}.nii.gz",
         ),
         (
-            f"{bids_file}0GenericAffine.mat",
-            f"{bids_file}_space-MNI152NLin2009cSym_res-1x1x1_affine.mat",
+            f"{bids_image_id}0GenericAffine.mat",
+            f"{bids_image_id_without_suffix}_space-MNI152NLin2009cSym_res-1x1x1_affine.mat",
         ),
         (
-            f"{bids_file}Warped.nii.gz",
-            f"{bids_file}_space-MNI152NLin2009cSym_res-1x1x1_{suffix}.nii.gz",
+            f"{bids_image_id}Warped.nii.gz",
+            f"{bids_image_id_without_suffix}_space-MNI152NLin2009cSym_res-1x1x1_{suffix}.nii.gz",
         ),
     ]
-    return bids_file, substitutions
 
 
 # Function used by the nipype interface.

--- a/clinica/pipelines/t1_linear/anat_linear_utils.py
+++ b/clinica/pipelines/t1_linear/anat_linear_utils.py
@@ -1,4 +1,20 @@
-def get_substitutions_datasink(bids_image_id: str, pipeline_name: str) -> list:
+def get_substitutions_datasink_flair(bids_image_id: str) -> list:
+    from clinica.pipelines.t1_linear.anat_linear_utils import (  # noqa
+        _get_substitutions_datasink,
+    )
+
+    return _get_substitutions_datasink(bids_image_id, "FLAIR")
+
+
+def get_substitutions_datasink_t1_linear(bids_image_id: str) -> list:
+    from clinica.pipelines.t1_linear.anat_linear_utils import (  # noqa
+        _get_substitutions_datasink,
+    )
+
+    return _get_substitutions_datasink(bids_image_id, "T1w")
+
+
+def _get_substitutions_datasink(bids_image_id: str, suffix: str) -> list:
     """Return file name substitutions for renaming.
 
     Parameters
@@ -8,15 +24,14 @@ def get_substitutions_datasink(bids_image_id: str, pipeline_name: str) -> list:
         This will be used to get all the BIDS entities that shouldn't
         be modified (subject, session...).
 
-    pipeline_name : str
-        The name of the pipeline.
+    suffix : str
+        The suffix to use for the new file.
 
     Returns
     -------
     substitutions : List of tuples of str
         List of length 3 containing the substitutions to perform.
     """
-    suffix = "T1w" if pipeline_name == "t1-linear" else "FLAIR"
     bids_image_id_without_suffix = bids_image_id.rstrip(f"_{suffix}")
     return [
         (

--- a/test/unittests/pipelines/t1_linear/test_anat_linear_utils.py
+++ b/test/unittests/pipelines/t1_linear/test_anat_linear_utils.py
@@ -1,0 +1,26 @@
+import pytest
+
+
+@pytest.mark.parametrize("pipeline_name", ["t1-linear", "flair-linear", "fooo"])
+def test_get_substitutions_datasink(pipeline_name):
+    from clinica.pipelines.t1_linear.anat_linear_utils import get_substitutions_datasink
+
+    suffix = "T1w" if pipeline_name == "t1-linear" else "FLAIR"
+    bids_filename = f"sub-ADNI022S0004_ses-M000_{suffix}"
+
+    a, b = get_substitutions_datasink(bids_filename, pipeline_name)
+
+    assert a == bids_filename
+    assert len(b) == 3
+    assert b[0] == (
+        f"sub-ADNI022S0004_ses-M000_{suffix}Warped_cropped.nii.gz",
+        f"sub-ADNI022S0004_ses-M000_{suffix}_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_{suffix}.nii.gz",
+    )
+    assert b[1] == (
+        f"sub-ADNI022S0004_ses-M000_{suffix}0GenericAffine.mat",
+        f"sub-ADNI022S0004_ses-M000_{suffix}_space-MNI152NLin2009cSym_res-1x1x1_affine.mat",
+    )
+    assert b[2] == (
+        f"sub-ADNI022S0004_ses-M000_{suffix}Warped.nii.gz",
+        f"sub-ADNI022S0004_ses-M000_{suffix}_space-MNI152NLin2009cSym_res-1x1x1_{suffix}.nii.gz",
+    )

--- a/test/unittests/pipelines/t1_linear/test_anat_linear_utils.py
+++ b/test/unittests/pipelines/t1_linear/test_anat_linear_utils.py
@@ -1,14 +1,15 @@
 import pytest
 
 
-@pytest.mark.parametrize("pipeline_name", ["t1-linear", "flair-linear", "fooo"])
-def test_get_substitutions_datasink(pipeline_name):
-    from clinica.pipelines.t1_linear.anat_linear_utils import get_substitutions_datasink
+@pytest.mark.parametrize("suffix", ["T1w", "FLAIR", "fooo"])
+def test_get_substitutions_datasink(suffix):
+    from clinica.pipelines.t1_linear.anat_linear_utils import (
+        _get_substitutions_datasink,
+    )
 
-    suffix = "T1w" if pipeline_name == "t1-linear" else "FLAIR"
     bids_image_id = f"sub-ADNI022S0004_ses-M000_{suffix}"
 
-    substitutions = get_substitutions_datasink(bids_image_id, pipeline_name)
+    substitutions = _get_substitutions_datasink(bids_image_id, suffix)
 
     assert len(substitutions) == 3
     assert substitutions[0] == (

--- a/test/unittests/pipelines/t1_linear/test_anat_linear_utils.py
+++ b/test/unittests/pipelines/t1_linear/test_anat_linear_utils.py
@@ -6,21 +6,20 @@ def test_get_substitutions_datasink(pipeline_name):
     from clinica.pipelines.t1_linear.anat_linear_utils import get_substitutions_datasink
 
     suffix = "T1w" if pipeline_name == "t1-linear" else "FLAIR"
-    bids_filename = f"sub-ADNI022S0004_ses-M000_{suffix}"
+    bids_image_id = f"sub-ADNI022S0004_ses-M000_{suffix}"
 
-    a, b = get_substitutions_datasink(bids_filename, pipeline_name)
+    substitutions = get_substitutions_datasink(bids_image_id, pipeline_name)
 
-    assert a == bids_filename
-    assert len(b) == 3
-    assert b[0] == (
+    assert len(substitutions) == 3
+    assert substitutions[0] == (
         f"sub-ADNI022S0004_ses-M000_{suffix}Warped_cropped.nii.gz",
-        f"sub-ADNI022S0004_ses-M000_{suffix}_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_{suffix}.nii.gz",
+        f"sub-ADNI022S0004_ses-M000_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_{suffix}.nii.gz",
     )
-    assert b[1] == (
+    assert substitutions[1] == (
         f"sub-ADNI022S0004_ses-M000_{suffix}0GenericAffine.mat",
-        f"sub-ADNI022S0004_ses-M000_{suffix}_space-MNI152NLin2009cSym_res-1x1x1_affine.mat",
+        f"sub-ADNI022S0004_ses-M000_space-MNI152NLin2009cSym_res-1x1x1_affine.mat",
     )
-    assert b[2] == (
+    assert substitutions[2] == (
         f"sub-ADNI022S0004_ses-M000_{suffix}Warped.nii.gz",
-        f"sub-ADNI022S0004_ses-M000_{suffix}_space-MNI152NLin2009cSym_res-1x1x1_{suffix}.nii.gz",
+        f"sub-ADNI022S0004_ses-M000_space-MNI152NLin2009cSym_res-1x1x1_{suffix}.nii.gz",
     )


### PR DESCRIPTION
Similar to #935 but for `T1Linear` and `FLAIRLinear`.

This is what we currently produce:

```
├── in
│   ├── bids
│   │   ├── dataset_description.json
│   │   └── sub-01
│   │       └── ses-M000
│   │           └── anat
│   │               └── sub-01_ses-M000_T1w.nii.gz
│   └── subjects.tsv
└── ref
    └── caps
        └── subjects
            └── sub-01
                └── ses-M000
                    └── t1_linear
                        ├── sub-01_ses-M000_T1w_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_T1w.nii.gz
                        ├── sub-01_ses-M000_T1w_space-MNI152NLin2009cSym_res-1x1x1_T1w.nii.gz
                        └── sub-01_ses-M000_T1w_space-MNI152NLin2009cSym_res-1x1x1_affine.mat
```

This PR requires the data PR https://github.com/aramis-lab/clinica_data_ci/pull/49