### PR TITLE
[ENH] Enable the `clinica_file_reader` to work with run numbers

### DIFF
--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -446,10 +446,11 @@ def _select_run(files: List[str]) -> str:
 def _get_run_number(filename: str) -> str:
     import re
 
-    matches = re.findall(r"_run-[0-9]*", filename)
-    if len(matches) == 1:
-        return matches[0].lstrip("_run-")
-    raise ValueError(f"Filename {filename} should contain one and only one run entity.")
+    matches = re.match(r".*_run-(\d+).*", filename)
+    if matches:
+        return matches[1]
+    else:
+        raise ValueError(f"Filename {filename} should contain one and only one run entity.")
 
 
 def _check_information(information: Dict) -> None:

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -449,8 +449,7 @@ def _get_run_number(filename: str) -> str:
     matches = re.match(r".*_run-(\d+).*", filename)
     if matches:
         return matches[1]
-    else:
-        raise ValueError(f"Filename {filename} should contain one and only one run entity.")
+    raise ValueError(f"Filename {filename} should contain one and only one run entity.")
 
 
 def _check_information(information: Dict) -> None:

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -307,8 +307,8 @@ def _are_multiple_runs(files: List[str]) -> bool:
     from pathlib import Path
 
     files = [Path(_) for _ in files]
-    # Exit quickly if at least one file does not have the entity run
-    if any(["_run-" not in f.name for f in files]):
+    # Exit quickly if less than one file or if at least one file does not have the entity run
+    if len(files) < 2 or any(["_run-" not in f.name for f in files]):
         return False
     try:
         _check_common_parent_path(files)

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -3,8 +3,9 @@
 import hashlib
 import os
 from collections import namedtuple
+from functools import partial
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 RemoteFileStructure = namedtuple("RemoteFileStructure", ["filename", "url", "checksum"])
 
@@ -245,6 +246,8 @@ def find_sub_ses_pattern_path(
     pattern : str
         Define the pattern of the final file.
     """
+    from clinica.utils.stream import cprint
+
     input_directory = Path(input_directory)
     if is_bids:
         origin_pattern = input_directory / subject / session
@@ -253,17 +256,200 @@ def find_sub_ses_pattern_path(
 
     current_pattern = origin_pattern / "**" / pattern
     current_glob_found = insensitive_glob(str(current_pattern), recursive=True)
-    # Error handling if more than 1 file are found, or when no file is found
     if len(current_glob_found) > 1:
-        error_str = f"\t*  ({subject} | {session}): More than 1 file found:\n"
-        for found_file in current_glob_found:
-            error_str += f"\t\t{found_file}\n"
-        error_encountered.append(error_str)
+        # If we have more than one file at this point, there are two possibilities:
+        #   - there is a problem somewhere which made us catch too many files
+        #           --> In this case, we raise an error.
+        #   - we have captured multiple runs for the same subject and session
+        #           --> In this case, we need to select one of these runs to proceed.
+        #               Ideally, this should be done via QC but for now, we simply
+        #               select the latest run and warn the user about it.
+        if _are_multiple_runs(current_glob_found):
+            selected = _select_run(current_glob_found)
+            list_of_found_files_for_reporting = ""
+            for filename in current_glob_found:
+                list_of_found_files_for_reporting += f"- {filename}\n"
+            cprint(
+                f"More than one run were found for subject {subject} and session {session} : "
+                f"\n\n{list_of_found_files_for_reporting}\n"
+                f"Clinica will proceed with the latest run available, that is \n\n-{selected}.",
+                lvl="warning",
+            )
+            results.append(selected)
+        else:
+            error_str = f"\t*  ({subject} | {session}): More than 1 file found:\n"
+            for found_file in current_glob_found:
+                error_str += f"\t\t{found_file}\n"
+            error_encountered.append(error_str)
     elif len(current_glob_found) == 0:
         error_encountered.append(f"\t* ({subject} | {session}): No file found\n")
     # Otherwise the file found is added to the result
     else:
         results.append(current_glob_found[0])
+
+
+def _are_multiple_runs(files: List[str]) -> bool:
+    """Returns whether the files in the provided list only differ through their run number.
+
+    The provided files must have exactly the same parent paths, extensions, and BIDS entities
+    excepted for the 'run' entity which must be different.
+
+    Parameters
+    ----------
+    files : List of str
+        The files to analyze.
+
+    Returns
+    -------
+    bool :
+        True if the provided files only differ through their run number, False otherwise.
+    """
+    from pathlib import Path
+
+    files = [Path(_) for _ in files]
+    # Exit quickly if at least one file does not have the entity run
+    if any(["_run-" not in f.name for f in files]):
+        return False
+    try:
+        _check_common_parent_path(files)
+        _check_common_extension(files)
+        common_suffix = _check_common_suffix(files)
+    except ValueError:
+        return False
+    found_entities = _get_entities(files, common_suffix)
+    for entity_name, entity_values in found_entities.items():
+        if entity_name != "run":
+            # All entities except run numbers should be the same
+            if len(entity_values) != 1:
+                return False
+        else:
+            # Run numbers should differ otherwise this is a BIDS violation at this point
+            if len(entity_values) != len(files):
+                return False
+    return True
+
+
+def _get_entities(files: List[Path], common_suffix: str) -> dict:
+    """Compute a dictionary where the keys are entity names and the values
+    are sets of all the corresponding entity values found while iterating over
+    the provided files.
+
+    Parameters
+    ----------
+    files : List of Path
+        List of paths to get entities of.
+
+    common_suffix : str
+        The suffix common to all the files. This suffix will be stripped
+        from the file names in order to only analyze BIDS entities.
+
+    Returns
+    -------
+    dict :
+        The entities dictionary.
+    """
+    from clinica.utils.filemanip import get_filename_no_ext
+
+    found_entities = dict()
+    for f in files:
+        entities = get_filename_no_ext(f.name).rstrip(common_suffix).split("_")
+        for entity in entities:
+            entity_name, entity_value = entity.split("-")
+            if entity_name in found_entities:
+                found_entities[entity_name].add(entity_value)
+            else:
+                found_entities[entity_name] = {entity_value}
+
+    return found_entities
+
+
+def _check_common_properties_of_files(
+    files: List[Path],
+    property_name: str,
+    property_extractor: Callable,
+) -> str:
+    """Verify that all provided files share the same property and return its value.
+
+    Parameters
+    ----------
+    files : List of Paths
+        List of file paths for which to verify common property.
+
+    property_name : str
+        The name of the property to verify.
+
+    property_extractor : Callable
+        The function which is responsible for the property extraction.
+        It must implement the interface `property_extractor(filename: Path) -> str`
+
+    Returns
+    -------
+    str :
+        The value of the common property.
+
+    Raises
+    ------
+    ValueError :
+        If the provided files do not have the same given property.
+    """
+    extracted_properties = {property_extractor(f) for f in files}
+    if len(extracted_properties) != 1:
+        raise ValueError(
+            f"The provided files do not share the same {property_name}."
+            f"The following {property_name}s were found: {extracted_properties}"
+        )
+    return extracted_properties.pop()
+
+
+def _get_parent_path(filename: Path) -> str:
+    return str(filename.parent)
+
+
+def _get_extension(filename: Path) -> str:
+    return "".join(filename.suffixes)
+
+
+def _get_suffix(filename: Path) -> str:
+    from clinica.utils.filemanip import get_filename_no_ext
+
+    return f"_{get_filename_no_ext(filename.name).split('_')[-1]}"
+
+
+_check_common_parent_path = partial(
+    _check_common_properties_of_files,
+    property_name="parent path",
+    property_extractor=_get_parent_path,
+)
+
+
+_check_common_extension = partial(
+    _check_common_properties_of_files,
+    property_name="extension",
+    property_extractor=_get_extension,
+)
+
+
+_check_common_suffix = partial(
+    _check_common_properties_of_files,
+    property_name="suffix",
+    property_extractor=_get_suffix,
+)
+
+
+def _select_run(files: List[str]) -> str:
+    import numpy as np
+
+    runs = [int(_get_run_number(f)) for f in files]
+    return files[np.argmax(runs)]
+
+
+def _get_run_number(filename: str) -> str:
+    import re
+
+    matches = re.findall(r"_run-[0-9]*", filename)
+    if len(matches) == 1:
+        return matches[0].lstrip("_run-")
+    raise ValueError(f"Filename {filename} should contain one and only one run entity.")
 
 
 def _check_information(information: Dict) -> None:

--- a/test/unittests/utils/test_utils_inputs.py
+++ b/test/unittests/utils/test_utils_inputs.py
@@ -10,6 +10,60 @@ from clinica.utils.testing_utils import (
 )
 
 
+def test_get_parent_path(tmp_path):
+    from clinica.utils.inputs import _get_parent_path
+
+    assert _get_parent_path(tmp_path / "bids" / "foo.txt") == str(tmp_path / "bids")
+
+
+@pytest.mark.parametrize("extension", [".txt", ".tar.gz", ".nii.gz", ".foo.bar.baz"])
+def test_get_extension(tmp_path, extension):
+    from clinica.utils.inputs import _get_extension
+
+    assert _get_extension(tmp_path / "bids" / f"foo{extension}") == extension
+
+
+@pytest.mark.parametrize(
+    "filename,expected_suffix",
+    [
+        ("foo.nii.gz", "_foo"),
+        ("sub-01_bar.txt", "_bar"),
+        ("sub-01_ses-M000_T1w.nii", "_T1w"),
+        ("sub-01_ses-M000_run-123_pet.nii.gz", "_pet"),
+    ],
+)
+def test_get_suffix(tmp_path, filename, expected_suffix):
+    from clinica.utils.inputs import _get_suffix
+
+    assert _get_suffix(tmp_path / "bids" / filename) == expected_suffix
+
+
+@pytest.mark.parametrize(
+    "filename,expected_run_number",
+    [
+        ("foo_run-01.txt", "01"),
+        ("foo_run-00006_bar.txt.gz", "00006"),
+        ("sub-01_ses-M000_run-03_pet.nii.gz", "03"),
+    ],
+)
+def test_get_run_number(tmp_path, filename, expected_run_number):
+    from clinica.utils.inputs import _get_run_number
+
+    assert _get_run_number(str(tmp_path / "bids" / filename)) == expected_run_number
+
+
+def test_select_run(tmp_path):
+    from clinica.utils.inputs import _select_run
+
+    files = [
+        str(tmp_path / "bids" / "foo_run-01.txt"),
+        str(tmp_path / "_run-00"),
+        str(tmp_path / "bids" / "sub-01" / "sub-01_ses-M00_run-003_dwi.nii.gz"),
+    ]
+
+    assert _select_run(files) == files[-1]
+
+
 def test_insensitive_glob(tmp_path):
     from clinica.utils.inputs import insensitive_glob
 

--- a/test/unittests/utils/test_utils_inputs.py
+++ b/test/unittests/utils/test_utils_inputs.py
@@ -64,6 +64,152 @@ def test_select_run(tmp_path):
     assert _select_run(files) == files[-1]
 
 
+def test_check_common_properties_of_files(tmp_path):
+    from clinica.utils.inputs import _check_common_properties_of_files
+
+    files = [
+        tmp_path / "bids" / "foo_bar_baz.foo.bar",
+        tmp_path / "bids" / "foo_pet.nii.gz",
+        tmp_path / "caps" / "foo_sub-01_ses-M000_T1w.json",
+        tmp_path / "foo" / "bar" / "foo_123.tar.gz",
+    ]
+
+    def first_entity_dummy_property_extractor(filename: Path) -> str:
+        """Dummy extractor for testing purposes."""
+        return filename.name.split("_")[0]
+
+    assert (
+        _check_common_properties_of_files(
+            files,
+            "first entity",
+            first_entity_dummy_property_extractor,
+        )
+        == "foo"
+    )
+
+
+def test_check_common_properties_of_files_error(tmp_path):
+    from clinica.utils.inputs import _check_common_properties_of_files
+
+    files = [
+        tmp_path / "bids" / "sub-01_ses-M000_pet.nii.gz",
+        tmp_path / "caps" / "sub-02_ses-M123_pet.nii",
+        tmp_path / "caps" / "foo.json",
+    ]
+
+    def first_letter_dummy_property_extractor(filename: Path) -> str:
+        """Dummy extractor for testing purposes."""
+        return filename.name[0]
+
+    with pytest.raises(
+        ValueError, match="The provided files do not share the same first letter."
+    ):
+        _check_common_properties_of_files(
+            files,
+            "first letter",
+            first_letter_dummy_property_extractor,
+        )
+
+
+def test_get_entities(tmp_path):
+    from clinica.utils.inputs import _get_entities
+
+    files = [
+        tmp_path / "bids" / "sub-01_ses-M000_run-01_pet.nii.gz",
+        tmp_path / "caps" / "sub-02_ses-M000_pet.nii.gz",
+        tmp_path / "foo" / "sub-01_ses-M000_run-02_pet.nii.gz",
+        tmp_path / "bids" / "sub-03_ses-M000_pet.json",
+    ]
+
+    assert _get_entities(files, "_pet") == {
+        "run": {"01", "02"},
+        "ses": {"M000"},
+        "sub": {"01", "02", "03"},
+    }
+
+
+@pytest.mark.parametrize(
+    "files",
+    [
+        [],
+        ["foo.txt"],
+        ["foo.txt", "bar.json", "baz.png"],
+        ["sub-01_ses-M000_run-01_pet.nii.gz"],
+        [
+            "sub-01_ses-M000_run-01_pet.nii.gz",
+            "sub-01_ses-M000_run-02_pet.nii.gz",
+            "sub-01_ses-M003_run-01_pet.nii.gz",
+        ],
+        [
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-01_pet.nii.gz",
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-02_pet.nii.gz",
+            "BIDS/sub-01/ses-M000/pet/sub-01_ses-M000_run-03_pet.nii.gz",
+        ],
+        [
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-01_pet.nii.gz",
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-02_pet.nii",
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-03_pet.nii.gz",
+        ],
+        [
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-01_T1w.nii.gz",
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-02_pet.nii.gz",
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-03_pet.nii.gz",
+        ],
+        [
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-01_pet.nii.gz",
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-02_pet.nii.gz",
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-01_pet.nii.gz",
+        ],
+        [
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-01_pet.nii.gz",
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M006_run-02_pet.nii.gz",
+            "bids/sub-01/ses-M000/pet/sub-02_ses-M000_run-03_pet.nii.gz",
+        ],
+    ],
+    ids=(
+        "empty list of files",
+        "single file without run entity",
+        "no run entity anywhere",
+        "single file",
+        "one file has a different entity value",
+        "parent paths are different",
+        "extensions are different",
+        "suffixes are different",
+        "run numbers are not different",
+        "entities are different",
+    ),
+)
+def test_are_not_multiple_runs(files):
+    from clinica.utils.inputs import _are_multiple_runs
+
+    assert not _are_multiple_runs(files)
+
+
+@pytest.mark.parametrize(
+    "files",
+    [
+        [
+            "sub-01_run-01_T1w.txt",
+            "sub-01_run-02_T1w.txt",
+        ],
+        [
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-01_pet.nii.gz",
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-02_pet.nii.gz",
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-03_pet.nii.gz",
+        ],
+        [
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-01_pet.nii.gz",
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-02_desc-crop_pet.nii.gz",  # debatable that this works...
+            "bids/sub-01/ses-M000/pet/sub-01_ses-M000_run-03_pet.nii.gz",
+        ],
+    ],
+)
+def test_are_multiple_runs(files):
+    from clinica.utils.inputs import _are_multiple_runs
+
+    assert _are_multiple_runs(files)
+
+
 def test_insensitive_glob(tmp_path):
     from clinica.utils.inputs import insensitive_glob
 
@@ -178,44 +324,91 @@ def test_check_caps_folder(tmp_path):
         check_caps_folder(tmp_path)
 
 
-def test_find_sub_ses_pattern_path(tmp_path):
+def test_find_sub_ses_pattern_path_error_no_file(tmp_path):
     """Test function `find_sub_ses_pattern_path`."""
     from clinica.utils.inputs import find_sub_ses_pattern_path
 
-    (tmp_path / "sub-01").mkdir()
-    (tmp_path / "sub-01" / "ses-M00").mkdir()
-    (tmp_path / "sub-01" / "ses-M00" / "anat").mkdir()
-
+    (tmp_path / "sub-01" / "ses-M00" / "anat").mkdir(parents=True)
     errors, results = [], []
+
     find_sub_ses_pattern_path(
         tmp_path, "sub-01", "ses-M00", errors, results, True, "sub-*_ses-*_t1w.nii*"
     )
+
     assert len(results) == 0
     assert len(errors) == 1
     assert errors[0] == "\t* (sub-01 | ses-M00): No file found\n"
 
-    (tmp_path / "sub-01" / "ses-M00" / "anat" / "sub-01_ses-M00_T1w.nii.gz").mkdir()
+
+def test_find_sub_ses_pattern_path_error_more_than_one_file(tmp_path):
+    """Test function `find_sub_ses_pattern_path`."""
+    from clinica.utils.inputs import find_sub_ses_pattern_path
 
     errors, results = [], []
+    (tmp_path / "sub-01" / "ses-M00" / "anat" / "sub-01_ses-M00_T1w.nii.gz").mkdir(
+        parents=True
+    )
+    (
+        tmp_path / "sub-01" / "ses-M00" / "anat" / "sub-01_ses-M00_foo-bar_T1w.nii.gz"
+    ).mkdir(parents=True)
+
     find_sub_ses_pattern_path(
         tmp_path, "sub-01", "ses-M00", errors, results, True, "sub-*_ses-*_t1w.nii*"
     )
+
+    assert len(results) == 0
+    assert len(errors) == 1
+    assert "\t*  (sub-01 | ses-M00): More than 1 file found:" in errors[0]
+
+
+def test_find_sub_ses_pattern_path(tmp_path):
+    """Test function `find_sub_ses_pattern_path`."""
+    from clinica.utils.inputs import find_sub_ses_pattern_path
+
+    (tmp_path / "sub-01" / "ses-M00" / "anat" / "sub-01_ses-M00_T1w.nii.gz").mkdir(
+        parents=True
+    )
+    errors, results = [], []
+
+    find_sub_ses_pattern_path(
+        tmp_path, "sub-01", "ses-M00", errors, results, True, "sub-*_ses-*_t1w.nii*"
+    )
+
     assert len(results) == 1
     assert len(errors) == 0
     assert Path(results[0]).relative_to(tmp_path) == Path(
         "sub-01/ses-M00/anat/sub-01_ses-M00_T1w.nii.gz"
     )
 
-    results = []
+
+def test_find_sub_ses_pattern_path_multiple_runs(tmp_path):
+    from clinica.utils.inputs import find_sub_ses_pattern_path
+
+    errors, results = [], []
     (
-        tmp_path / "sub-01" / "ses-M00" / "anat" / "sub-01_ses-M00_foo-bar_T1w.nii.gz"
-    ).mkdir()
+        tmp_path
+        / "sub-01"
+        / "ses-M06"
+        / "anat"
+        / "sub-01_ses-M06_run-01_foo-bar_T1w.nii.gz"
+    ).mkdir(parents=True)
+    (
+        tmp_path
+        / "sub-01"
+        / "ses-M06"
+        / "anat"
+        / "sub-01_ses-M06_run-02_foo-bar_T1w.nii.gz"
+    ).mkdir(parents=True)
+
     find_sub_ses_pattern_path(
-        tmp_path, "sub-01", "ses-M00", errors, results, True, "sub-*_ses-*_t1w.nii*"
+        tmp_path, "sub-01", "ses-M06", errors, results, True, "sub-*_ses-*_t1w.nii*"
     )
-    assert len(results) == 0
-    assert len(errors) == 1
-    assert "\t*  (sub-01 | ses-M00): More than 1 file found:" in errors[0]
+
+    assert len(results) == 1
+    assert len(errors) == 0
+    assert Path(results[0]).relative_to(tmp_path) == Path(
+        "sub-01/ses-M06/anat/sub-01_ses-M06_run-02_foo-bar_T1w.nii.gz"
+    )
 
 
 def test_check_information():


### PR DESCRIPTION
## Description

### The issue being addressed

This is a work-in-progress-PR to analyze how we could support run numbers in Clinica.

Some of our converters like GENFI2BIDS or OASIS32BIDS already output files with run numbers and pipelines have different behaviors in regard of this unsupported entity.

### The proposed solution

Most of the related logic lies around the `clinica_file_reader` function which relies on `_read_files_parallel` or `_read_files_sequential`. These two function take as input a BIDS/CAPS folder, a subject, a session, and a query, and they expect to get a single file based on these inputs.

If the input BIDS dataset contains some files with run numbers and if the query captures the different runs of a given acquisition, then the file reader will raise an error saying that too many files were found.

This PR investigates how we could allow the file reader to handle the fact that a query returns multiple files. If this happens, we need to verify that the files found only differ through their run numbers. Otherwise, this is indeed an error and we raise as before. 

If the files are really different runs, then I believe it makes sense to select only one of the runs to proceed (otherwise I'm not sure what would happen. I suspect the pipelines will crash with unexpected number of files in the input nodes, but we could try to see for real...).

This selection could be done in multiple ways:

- Use QC information if available (ideal solution but requires some work. Also, since this information isn't always present, we need a default solution).
- Enable the user to specify which run to use (should be possible through a CLI option I suppose, but same issue, we need a default way of handling the runs if the user didn't specify anything...).
- Pick the latest run assuming it is the best (obviously can be False but should be a not-too-bad heuristic. This is what this PR proposes to implement).

## Example

Assuming a BIDS input dataset like this:

```
├── dataset_description.json
├── sub-02
│   └── ses-M000
│       └── anat
│           ├── sub-02_ses-M000_run-01_T1w.nii.gz
│           └── sub-02_ses-M000_run-02_T1w.nii.gz
└── sub-ADNI022S0004
    └── ses-M000
        └── anat
            └── sub-ADNI022S0004_ses-M000_T1w.nii.gz
```

This is what the file reader does with the proposed implementation.

```python
In [1]: from clinica.utils.inputs import clinica_file_reader

In [2]: from clinica.utils.input_files import T1W_NII

In [3]: anat_files = clinica_file_reader(["sub-02"], ["ses-M000"], "/Users/nicolas.gensollen/GitRepos/clinica_data_ci/data_ci/T1Linear/in/bids/", T1W_NII)
More than one run were found for subject sub-02 and session ses-M000 :

- /Users/nicolas.gensollen/GitRepos/clinica_data_ci/data_ci/T1Linear/in/bids/sub-02/ses-M000/anat/sub-02_ses-M000_run-01_T1w.nii.gz
- /Users/nicolas.gensollen/GitRepos/clinica_data_ci/data_ci/T1Linear/in/bids/sub-02/ses-M000/anat/sub-02_ses-M000_run-02_T1w.nii.gz

Clinica will proceed with the latest run available, that is

-/Users/nicolas.gensollen/GitRepos/clinica_data_ci/data_ci/T1Linear/in/bids/sub-02/ses-M000/anat/sub-02_ses-M000_run-02_T1w.nii.gz.

In [4]: anat_files
Out[4]:
(['/Users/nicolas.gensollen/GitRepos/clinica_data_ci/data_ci/T1Linear/in/bids/sub-02/ses-M000/anat/sub-02_ses-M000_run-02_T1w.nii.gz'],
 'Clinica encountered 0 problem(s) while getting T1w MRI:\n')

In [5]: anat_files = clinica_file_reader(["sub-ADNI022S0004"], ["ses-M000"], "/Users/nicolas.gensollen/GitRepos/clinica_data_ci/data_ci/T1Linear/in/bids/", T1W_NII)

In [6]: anat_files
Out[6]:
(['/Users/nicolas.gensollen/GitRepos/clinica_data_ci/data_ci/T1Linear/in/bids/sub-ADNI022S0004/ses-M000/anat/sub-ADNI022S0004_ses-M000_T1w.nii.gz'],
 'Clinica encountered 0 problem(s) while getting T1w MRI:\n')
```

Thoughts, comments, suggestions, or ideas are more than welcome !