### PR TITLE
[TEST] Add unit test for longitudinal utils

### DIFF
--- a/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_correction_utils.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_correction_utils.py
@@ -2,6 +2,7 @@ def init_input_node(caps_dir, participant_id, session_id, long_id, output_dir):
     """Initialize the pipeline."""
     import os
     import platform
+    from pathlib import Path
     from tempfile import mkdtemp
 
     from clinica.utils.longitudinal import read_sessions
@@ -29,7 +30,7 @@ def init_input_node(caps_dir, participant_id, session_id, long_id, output_dir):
     os.makedirs(subjects_dir, exist_ok=True)
 
     # Create symbolic link containing cross-sectional segmentation(s) in SUBJECTS_DIR so that recon-all can run
-    for s_id in read_sessions(caps_dir, participant_id, long_id):
+    for s_id in read_sessions(Path(caps_dir), participant_id, long_id):
         cross_sectional_path = os.path.join(
             caps_dir,
             "subjects",

--- a/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_template_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_template_pipeline.py
@@ -75,6 +75,7 @@ class T1FreeSurferTemplate(cpe.Pipeline):
     def build_input_node(self):
         """Build and connect an input node to the pipeline."""
         import os
+        from pathlib import Path
 
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -131,7 +132,7 @@ class T1FreeSurferTemplate(cpe.Pipeline):
                     for p_id, s_id in zip(self.subjects, self.sessions)
                 ]
                 processed_sessions_per_participant = [
-                    read_sessions(self.caps_directory, p_id, l_id)
+                    read_sessions(Path(self.caps_directory), p_id, l_id)
                     for (p_id, l_id) in zip(
                         processed_participants, processed_long_sessions
                     )

--- a/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_template_utils.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_template_utils.py
@@ -163,6 +163,7 @@ def save_to_caps(
     """
     import os
     import shutil
+    from pathlib import Path
 
     from clinica.utils.longitudinal import save_long_id
     from clinica.utils.stream import cprint
@@ -184,7 +185,9 @@ def save_to_caps(
         os.path.expanduser(caps_dir), "subjects", participant_id, long_id
     )
     if not os.path.isfile(os.path.join(sessions_tsv_path, f"{long_id}_sessions.tsv")):
-        save_long_id(list_session_ids, sessions_tsv_path, f"{long_id}_sessions.tsv")
+        save_long_id(
+            list_session_ids, Path(sessions_tsv_path), f"{long_id}_sessions.tsv"
+        )
 
     # Save FreeSurfer segmentation
     representative_file = os.path.join(image_id, "mri", "aparc+aseg.mgz")

--- a/clinica/utils/longitudinal.py
+++ b/clinica/utils/longitudinal.py
@@ -1,102 +1,158 @@
 """This module contains utilities for longitudinal pipelines. See CAPS specifications for details about long ID."""
+from pathlib import Path
+from typing import List, Optional
 
 
-def get_long_id(list_session_id):
-    """Extract longitudinal ID from a set of session IDs.
+def get_long_id(session_ids: List[str]) -> str:
+    """Extract longitudinal ID from a list of session IDs.
 
-    This will create a unique identifier for a participant and its corresponding sessions. Sessions labels are sorted
-    alphabetically before being merged in order to generate the longitudinal ID.
+    This will create a unique identifier for a participant and
+    its corresponding sessions. Sessions labels are sorted alphabetically
+    before being merged in order to generate the longitudinal ID.
 
-    Args:
-        list_session_id (list[str]): List of session IDs
-            (e.g. ["ses-M000"] or ["ses-M000", "ses-M018", "ses-M036"])
+    Parameters
+    ----------
+    session_ids : list of str
+        List of session IDs (e.g. ["ses-M000"] or ["ses-M000", "ses-M018", "ses-M036"]).
 
-    Returns:
-        Longitudinal ID (str)
+    Returns
+    -------
+    str :
+        Longitudinal ID.
 
-    Example:
-        >>> from clinica.utils.longitudinal import get_long_id
-        >>> get_long_id(['ses-M000'])
-        'long-M000'
-        >>> get_long_id(['ses-M000', 'ses-M018', 'ses-M036'])
-        'long-M000M018M036'
-        >>> get_long_id(['ses-M018', 'ses-M036', 'ses-M000']) # Session IDs do not need to be sorted
-        'long-M000M018M036'
+    Examples
+    --------
+    >>> from clinica.utils.longitudinal import get_long_id
+    >>> get_long_id(['ses-M000'])
+    'long-M000'
+    >>> get_long_id(['ses-M000', 'ses-M018', 'ses-M036'])
+    'long-M000M018M036'
+    >>> get_long_id(['ses-M018', 'ses-M036', 'ses-M000'])
+    'long-M000M018M036'
     """
-    sorted_list = sorted(list_session_id)
-    list_session_label = [session_id[4:] for session_id in sorted_list]
-    long_id = "long-" + "".join(list_session_label)
+    if not all([session_id.startswith("ses-") for session_id in session_ids]):
+        raise ValueError(
+            "Expected a list of session IDs of the form ses-XXX, "
+            f"but received {session_ids} instead."
+        )
+    return "long-" + "".join(
+        [session_id.lstrip("ses-") for session_id in sorted(session_ids)]
+    )
 
-    return long_id
 
-
-def get_participants_long_id(list_participant_id, list_session_id):
+def get_participants_long_id(
+    participant_ids: List[str], session_ids: List[str]
+) -> List[str]:
     """Extract list of longitudinal IDs from a set of participant and session IDs.
 
-    Example:
-        >>> from clinica.utils.longitudinal import get_participants_long_id
-        >>> get_participants_long_id(['sub-CLNC01', 'sub-CLNC01', 'sub-CLNC02'], ['ses-M000', 'ses-M018', 'ses-M000'])
-        ['long-M000M018', 'long-M000M018', 'long-M000']
+    Parameters
+    ----------
+    participant_ids : list of str
+        List of participant IDs for which to compute the longitudinal IDs.
+
+    session_ids : list of str
+        List of session IDs for which to compute the longitudinal IDs.
+
+    Returns
+    -------
+    list of str :
+        The computed longitudinal IDs.
+
+    Examples
+    --------
+    >>> from clinica.utils.longitudinal import get_participants_long_id
+    >>> get_participants_long_id(['sub-CLNC01', 'sub-CLNC01', 'sub-CLNC02'], ['ses-M000', 'ses-M018', 'ses-M000'])
+    ['long-M000M018', 'long-M000M018', 'long-M000']
     """
     from .participant import get_unique_subjects
 
-    unique_subject_list, per_subject_session_list = get_unique_subjects(
-        list_participant_id, list_session_id
-    )
+    _, sessions_for_each_subject = get_unique_subjects(participant_ids, session_ids)
 
-    list_long_id = []
-    for i in range(0, len(unique_subject_list)):
-        list_long_id = list_long_id + [get_long_id(per_subject_session_list[i])] * len(
-            per_subject_session_list[i]
-        )
+    long_ids = []
+    for sessions in sessions_for_each_subject:
+        long_ids += [get_long_id(sessions)] * len(sessions)
 
-    return list_long_id
+    return long_ids
 
 
-def save_long_id(list_session_id, output_dir, file_name=None):
-    """Save long ID to `file_name`."""
-    import os
+def save_long_id(
+    session_ids: List[str],
+    output_dir: Path,
+    file_name: Optional[str] = None,
+) -> None:
+    """Save the list of session IDs to given `file_name`.
 
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    Parameters
+    ----------
+    session_ids : list of str
+        The list of session IDs to save.
 
-    long_id = get_long_id(list_session_id)
-    file_name = file_name or f"{long_id}_sessions.tsv"
-    sessions_tsv = open(os.path.join(output_dir, file_name), "w")
-    sessions_tsv.write("session_id\n")
+    output_dir : Path
+        The path to the output directory in which to save the session IDs.
 
-    for session_id in sorted(list_session_id):
-        sessions_tsv.write(session_id + "\n")
+    file_name : str, optional
+        The file name to use. If None, this will be computed as:
+        '{longitudinal_id}_sessions.tsv'
+    """
+    if not output_dir.exists():
+        output_dir.mkdir(parents=True)
+    file_name = file_name or f"{get_long_id(session_ids)}_sessions.tsv"
+    content = "\n".join(sorted(session_ids))
+    with open(output_dir / file_name, "w") as fp:
+        fp.write(f"session_id\n{content}\n")
 
-    sessions_tsv.close()
 
+def read_sessions(
+    caps_dir: Path,
+    participant_id: str,
+    longitudinal_id: str,
+) -> List[str]:
+    """Extract sessions IDs from `caps_dir`/subjects/`participant_id`/`long_id`/`long_id`_sessions.tsv.
 
-def read_sessions(caps_dir, participant_id, long_id):
-    """Extract sessions IDs from `caps_dir`/subjects/`participant_id`/`long_id`/`long_id`_sessions.tsv."""
-    import os
+    Parameters
+    ----------
+    caps_dir : Path
+        Path to CAPS folder.
 
-    import pandas
+    participant_id : str
+        ID of subject for which to extract session IDs.
+
+    longitudinal_id : str
+        Longitudinal ID for which to extract session IDs.
+
+    Returns
+    -------
+    List of str :
+        The extracted list of session IDs.
+
+    Raises
+    ------
+    ClinicaException :
+        If expected session TSV file does not exist.
+        If 'session_id' is not in the session dataframe.
+    """
+    import pandas as pd
 
     from clinica.utils.exceptions import ClinicaException
 
-    sessions_file = os.path.join(
-        os.path.expanduser(caps_dir),
-        "subjects",
-        participant_id,
-        long_id,
-        f"{long_id}_sessions.tsv",
+    sessions_file = (
+        caps_dir
+        / "subjects"
+        / participant_id
+        / longitudinal_id
+        / f"{longitudinal_id}_sessions.tsv"
     )
-    if not os.path.isfile(sessions_file):
+
+    if not sessions_file.is_file():
         raise ClinicaException(
             "The TSV file with sessions associated "
-            f"to {participant_id} for longitudinal ID {long_id} is missing "
+            f"to {participant_id} for longitudinal ID {longitudinal_id} is missing "
             f"(expected path: {sessions_file})."
         )
-    ss_df = pandas.read_csv(sessions_file, sep="\t")
-    if "session_id" not in list(ss_df.columns.values):
+    df = pd.read_csv(sessions_file, sep="\t")
+    if "session_id" not in df.columns:
         raise ClinicaException(
-            "The TSV file does not contain session_id column "
-            f"(path: {sessions_file})."
+            f"The TSV file does not contain session_id column (path: {sessions_file})."
         )
 
-    return list(ss_df.session_id)
+    return list(df.session_id)

--- a/test/unittests/utils/test_longitudinal.py
+++ b/test/unittests/utils/test_longitudinal.py
@@ -1,0 +1,111 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "session_ids,expected",
+    [
+        (["ses-M000"], "long-M000"),
+        (["ses-M000", "ses-M018", "ses-M036"], "long-M000M018M036"),
+        (["ses-M018", "ses-M036", "ses-M000"], "long-M000M018M036"),
+        (["ses-foo", "ses-bar", "ses-baz", "ses-foobar"], "long-barbazfoofoobar"),
+    ],
+)
+def test_get_long_id(session_ids, expected):
+    from clinica.utils.longitudinal import get_long_id
+
+    assert get_long_id(session_ids) == expected
+
+
+@pytest.mark.parametrize(
+    "session_ids",
+    [
+        ["foo", "bar", "baz"],
+        ["1", "2", "3"],
+        ["SES-M000", "SES-M001"],
+    ],
+)
+def test_get_long_id_errors(session_ids):
+    from clinica.utils.longitudinal import get_long_id
+
+    with pytest.raises(
+        ValueError,
+        match="Expected a list of session IDs of the form ses-XXX",
+    ):
+        get_long_id(session_ids)
+
+
+@pytest.mark.parametrize(
+    "participant_ids,session_ids,expected",
+    [
+        (
+            ["sub-CLNC01", "sub-CLNC01", "sub-CLNC02"],
+            ["ses-M000", "ses-M018", "ses-M000"],
+            ["long-M000M018", "long-M000M018", "long-M000"],
+        )
+    ],
+)
+def test_get_participants_long_id(participant_ids, session_ids, expected):
+    from clinica.utils.longitudinal import get_participants_long_id
+
+    assert get_participants_long_id(participant_ids, session_ids) == expected
+
+
+def test_save_long_id(tmp_path):
+    from clinica.utils.longitudinal import save_long_id
+
+    output_dir = tmp_path / "out"
+    save_long_id(
+        ["ses-M000", "ses-M018", "ses-M036"], output_dir, "longitudinal_ids.tsv"
+    )
+
+    assert (output_dir / "longitudinal_ids.tsv").exists()
+    saved_ids = (output_dir / "longitudinal_ids.tsv").read_text()
+    assert saved_ids == "session_id\nses-M000\nses-M018\nses-M036\n"
+
+    save_long_id(["ses-M000", "ses-M018", "ses-M036"], output_dir)
+
+    assert (output_dir / "long-M000M018M036_sessions.tsv").exists()
+    saved_ids = (output_dir / "long-M000M018M036_sessions.tsv").read_text()
+    assert saved_ids == "session_id\nses-M000\nses-M018\nses-M036\n"
+
+
+def test_read_sessions_no_file_error(tmp_path):
+    from clinica.utils.exceptions import ClinicaException
+    from clinica.utils.longitudinal import read_sessions
+
+    with pytest.raises(
+        ClinicaException,
+        match="The TSV file with sessions associated",
+    ):
+        read_sessions(tmp_path, "foo", "bar")
+
+
+def test_read_sessions_wrong_column_error(tmp_path):
+    from clinica.utils.exceptions import ClinicaException
+    from clinica.utils.longitudinal import read_sessions
+
+    input_folder = tmp_path / "subjects" / "sub-01" / "long-M000M018M036"
+    input_folder.mkdir(parents=True)
+    tsv_file = input_folder / "long-M000M018M036_sessions.tsv"
+    tsv_file.write_text("foo_bar\nses-M000\nses-M018\nses-M036\n")
+
+    with pytest.raises(
+        ClinicaException,
+        match="The TSV file does not contain session_id column ",
+    ):
+        read_sessions(tmp_path, "sub-01", "long-M000M018M036")
+
+
+def test_read_sessions(tmp_path):
+    from clinica.utils.longitudinal import read_sessions
+
+    input_folder = tmp_path / "subjects" / "sub-01" / "long-M000M018M036"
+    input_folder.mkdir(parents=True)
+    tsv_file = input_folder / "long-M000M018M036_sessions.tsv"
+    tsv_file.write_text("session_id\nses-M000\nses-M018\nses-M036\n")
+
+    assert read_sessions(tmp_path, "sub-01", "long-M000M018M036") == [
+        "ses-M000",
+        "ses-M018",
+        "ses-M036",
+    ]


### PR DESCRIPTION
Small PR which proposes:

- to add unit tests to utility functions of `clinica.utils.longitudinal`.
- to add type hints and make docstrings Numpydoc compliant.
- to make some minor code refactoring.