### PR TITLE
[MAINT] remove `get_sessions_map_AIBL`

### DIFF
--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -181,25 +181,6 @@ def create_participants_df(
     return participant_df
 
 
-def get_sessions_map_AIBL(bids_ids, bids_dir):
-    """Create a dictionary map between BIDs session IDs and AIBL session ids
-
-    Args:
-        bids_ids: ids of all the subjects to be included in dictionary
-        bids_dir: for later use if the sessions are to be retrieve automatically
-
-    Returns: a dictionary with the map for each subject id
-    """
-
-    ses_dict = {}
-    ses_map = {"M000": "bl", "M018": "m18", "M036": "m36", "M054": "m54"}
-
-    for id in bids_ids:
-        ses_dict[id] = ses_map
-
-    return ses_dict
-
-
 def create_sessions_dict_OASIS(
     clinical_data_dir,
     bids_dir,

--- a/clinica/iotools/converters/aibl_to_bids/aibl_utils.py
+++ b/clinica/iotools/converters/aibl_to_bids/aibl_utils.py
@@ -902,11 +902,10 @@ def create_scans_dict_AIBL(input_path, clinical_data_dir, clinical_spec_path):
         path.basename(sub_path)
         for sub_path in glob.glob(path.join(input_path, "sub-AIBL*"))
     ]
-
-    # This dictionary should be automatically computed from the dataset
-    #
-    ses_dict = bids.get_sessions_map_AIBL(bids_ids, input_path)
-
+    ses_dict = {
+        bids_id: {"M000": "bl", "M018": "m18", "M036": "m36", "M054": "m54"}
+        for bids_id in bids_ids
+    }
     scans_dict = bids.create_scans_dict(
         clinical_data_dir,
         "AIBL",


### PR DESCRIPTION
This PR proposes to remove the function `get_sessions_map_AIBL` which was in the wrong utility module (iotools bids utils instead of AIBL utils) and wasn't using some of its inputs.
Since it basically does a dictionary comprehension without providing much additional value, I think we can remove it completely.