### PR TITLE
[REF TEST] Refactor `compute_default_filename`

### DIFF
--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -9,7 +9,13 @@ from nibabel.nifti1 import Nifti1Header
 from numpy import ndarray
 
 
-def _check_output_tsv_path(out_path: Path) -> Path:
+def _validate_output_tsv_path(out_path: Path) -> Path:
+    """Validate that provided file path is a TSV file.
+
+    If folders do not exist, this function will create them.
+    If provided path is a directory, this function will return
+    a file named 'merge.tsv' within this directory.
+    """
     out_path = out_path.resolve()
     if out_path.is_dir():
         out_path = out_path / "merge.tsv"
@@ -47,6 +53,7 @@ def create_merge_file(
     import json
     import os
     from os import path
+    from pathlib import Path
 
     import numpy as np
     import pandas as pd
@@ -86,7 +93,7 @@ def create_merge_file(
         sub_ses_df = sub_ses_df.drop_duplicates(subset=["participant_id", "session_id"])
         sub_ses_df.set_index(["participant_id", "session_id"], inplace=True)
 
-    out_path = _check_output_tsv_path(out_tsv)
+    out_path = _validate_output_tsv_path(Path(out_tsv))
     merged_df = pd.DataFrame(columns=participants_df.columns.values)
 
     # BIDS part

--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -1,6 +1,7 @@
 """Data handling scripts."""
 
 from os import PathLike
+from pathlib import Path
 from typing import Iterable, List
 
 import click
@@ -8,21 +9,18 @@ from nibabel.nifti1 import Nifti1Header
 from numpy import ndarray
 
 
-def compute_default_filename(out_path):
-    from os import path
-
-    abspath = path.abspath(out_path)
-    # If given path is a directory, append a filename
-    if path.isdir(abspath):
-        tsv_path = path.join(out_path, "merge.tsv")
-    elif "." not in path.basename(abspath):
-        tsv_path = f"{out_path}.tsv"
-    else:
-        if path.splitext(out_path)[1] != ".tsv":
-            raise TypeError("Output path extension must be tsv.")
-        tsv_path = out_path
-
-    return tsv_path
+def _check_output_tsv_path(out_path: Path) -> Path:
+    out_path = out_path.resolve()
+    if out_path.is_dir():
+        out_path = out_path / "merge.tsv"
+    elif "." not in out_path.name:
+        out_path = out_path.with_suffix(".tsv")
+    elif out_path.suffix != ".tsv":
+        raise TypeError("Output path extension must be tsv.")
+    out_dir = out_path.parent
+    if not out_dir.exists():
+        out_dir.mkdir(parents=True)
+    return out_path
 
 
 def create_merge_file(
@@ -88,11 +86,7 @@ def create_merge_file(
         sub_ses_df = sub_ses_df.drop_duplicates(subset=["participant_id", "session_id"])
         sub_ses_df.set_index(["participant_id", "session_id"], inplace=True)
 
-    out_path = compute_default_filename(out_tsv)
-    out_dir = path.dirname(out_path)
-    if len(out_dir) > 0:
-        os.makedirs(out_dir, exist_ok=True)
-
+    out_path = _check_output_tsv_path(out_tsv)
     merged_df = pd.DataFrame(columns=participants_df.columns.values)
 
     # BIDS part
@@ -247,7 +241,7 @@ def create_merge_file(
                 last_column_name
             )
 
-        summary_path = path.splitext(out_path)[0] + "_summary.tsv"
+        summary_path = path.splitext(str(out_path))[0] + "_summary.tsv"
         merged_summary_df.to_csv(summary_path, sep="\t", index=False)
 
         tmp = merged_df.select_dtypes(include=[np.number])

--- a/test/unittests/iotools/utils/test_data_handling.py
+++ b/test/unittests/iotools/utils/test_data_handling.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_vox_to_world_space_method_1():
     """Test function `vox_to_world_space_method_1`."""
 
@@ -20,3 +23,30 @@ def test_vox_to_world_space_method_1():
         vox_to_world_space_method_1(coordinates_vol=center_coordinates, header=head),
         np.array([1.0, 0.5, 0.5]),
     )
+
+
+def test_check_output_tsv_path(tmp_path):
+    from clinica.iotools.utils.data_handling import _check_output_tsv_path
+
+    (tmp_path / "foo.tsv").touch()
+
+    assert _check_output_tsv_path(tmp_path) == tmp_path / "merge.tsv"
+    assert _check_output_tsv_path(tmp_path / "foo.tsv") == tmp_path / "foo.tsv"
+    assert (
+        _check_output_tsv_path(tmp_path / "bids" / "foo.tsv")
+        == tmp_path / "bids" / "foo.tsv"
+    )
+    assert (tmp_path / "bids").exists()
+    assert not (tmp_path / "bids" / "foo.tsv").exists()
+
+
+def test_check_output_tsv_path_error(tmp_path):
+    from clinica.iotools.utils.data_handling import _check_output_tsv_path
+
+    (tmp_path / "bar.txt").touch()
+
+    with pytest.raises(
+        TypeError,
+        match="Output path extension must be tsv.",
+    ):
+        _check_output_tsv_path(tmp_path / "bar.txt")

--- a/test/unittests/iotools/utils/test_data_handling.py
+++ b/test/unittests/iotools/utils/test_data_handling.py
@@ -25,23 +25,23 @@ def test_vox_to_world_space_method_1():
     )
 
 
-def test_check_output_tsv_path(tmp_path):
-    from clinica.iotools.utils.data_handling import _check_output_tsv_path
+def test_validate_output_tsv_path(tmp_path):
+    from clinica.iotools.utils.data_handling import _validate_output_tsv_path
 
     (tmp_path / "foo.tsv").touch()
 
-    assert _check_output_tsv_path(tmp_path) == tmp_path / "merge.tsv"
-    assert _check_output_tsv_path(tmp_path / "foo.tsv") == tmp_path / "foo.tsv"
+    assert _validate_output_tsv_path(tmp_path) == tmp_path / "merge.tsv"
+    assert _validate_output_tsv_path(tmp_path / "foo.tsv") == tmp_path / "foo.tsv"
     assert (
-        _check_output_tsv_path(tmp_path / "bids" / "foo.tsv")
+        _validate_output_tsv_path(tmp_path / "bids" / "foo.tsv")
         == tmp_path / "bids" / "foo.tsv"
     )
     assert (tmp_path / "bids").exists()
     assert not (tmp_path / "bids" / "foo.tsv").exists()
 
 
-def test_check_output_tsv_path_error(tmp_path):
-    from clinica.iotools.utils.data_handling import _check_output_tsv_path
+def test_validate_output_tsv_path_error(tmp_path):
+    from clinica.iotools.utils.data_handling import _validate_output_tsv_path
 
     (tmp_path / "bar.txt").touch()
 
@@ -49,4 +49,4 @@ def test_check_output_tsv_path_error(tmp_path):
         TypeError,
         match="Output path extension must be tsv.",
     ):
-        _check_output_tsv_path(tmp_path / "bar.txt")
+        _validate_output_tsv_path(tmp_path / "bar.txt")


### PR DESCRIPTION
Small refactoring of `compute_default_filename` in `data_handling.py`.

- rename and make function private
- use pathlib methods instead of string manipulations
- move folder creation logic within this function to simplify caller's code
- add small docstring
- add unit tests