### PR TITLE
ADNI2BIDS: Log when dataframes extracted from clinical data are empty

### DIFF
--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -967,6 +967,9 @@ def create_adni_sessions_dict(
                     df_subj_session, df_filtered, df_sessions, location
                 )
             else:
+                cprint(
+                    f"Clinical dataframe extracted from {location} is empty after filtering."
+                )
                 dict_column_correspondence = dict(
                     zip(df_sessions["ADNI"], df_sessions["BIDS CLINICA"])
                 )


### PR DESCRIPTION
Related to #966

Simple PR proposing to add some logging when the filtering of clinical data results in an empty dataframe in ADNI2BIDS.
This will make it easier to understand potential ValueError you might get if all CSV files parsing results in empty dataframes.