### PR TITLE
[INFRA] Fix outdated documentation

### DIFF
--- a/.jenkins/docs.Jenkinsfile
+++ b/.jenkins/docs.Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
                   makeEmptyDirs: false,
                   noDefaultExcludes: false,
                   patternSeparator: '[, ]+',
-                  remoteDirectory: 'clinica/docs/private/${BRANCH_NAME}/',
+                  remoteDirectory: 'clinica/docs/public/${BRANCH_NAME}/',
                   remoteDirectorySDF: false,
                   removePrefix: '${BRANCH_NAME}',
                   sourceFiles: "${BRANCH_NAME}/**"

--- a/.jenkins/docs.Jenkinsfile
+++ b/.jenkins/docs.Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
               configName: 'web',
               transfers: [
                 sshTransfer(
-                  cleanRemote: false,
+                  cleanRemote: true,
                   excludes: '',
                   execCommand: '',
                   execTimeout: 120000,
@@ -59,7 +59,7 @@ pipeline {
                   makeEmptyDirs: false,
                   noDefaultExcludes: false,
                   patternSeparator: '[, ]+',
-                  remoteDirectory: 'clinica/docs/public/',
+                  remoteDirectory: 'clinica/docs/private/',
                   remoteDirectorySDF: false,
                   removePrefix: '',
                   sourceFiles: "${BRANCH_NAME}/**"

--- a/.jenkins/docs.Jenkinsfile
+++ b/.jenkins/docs.Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
                   makeEmptyDirs: false,
                   noDefaultExcludes: false,
                   patternSeparator: '[, ]+',
-                  remoteDirectory: 'clinica/docs/private/',
+                  remoteDirectory: 'clinica/docs/private/${BRANCH_NAME}/',
                   remoteDirectorySDF: false,
                   removePrefix: '',
                   sourceFiles: "${BRANCH_NAME}/**"

--- a/.jenkins/docs.Jenkinsfile
+++ b/.jenkins/docs.Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                   patternSeparator: '[, ]+',
                   remoteDirectory: 'clinica/docs/private/${BRANCH_NAME}/',
                   remoteDirectorySDF: false,
-                  removePrefix: '',
+                  removePrefix: '${BRANCH_NAME}',
                   sourceFiles: "${BRANCH_NAME}/**"
                 )
               ],


### PR DESCRIPTION
This PR fixes the issue of the outdated documentation we currently have.

The problem comes from the fact that the deployment step does not overwrite the remote if a folder already exists with the same name. This means that a documentation version is created for the first commit of each PR, creating a folder `PR-XXX` on the remote, but this folder is not updated afterwards. 

Way more problematic, the development version of the documentation, which is the default documentation that users browse when going to the online docs, currently shows an outdated version of the docs since it internally corresponds to a folder named "dev" which was created a while back, but is never overwritten.

This PR sets the `cleanRemote` option of the SSHPublisher to `True` with a change in the remote path to be the actual subfolder corresponding to the branch (i.e `dev` or `PR-981` for example). This is very important because the publisher would otherwise clean all content on the remote server including documentation for previous versions of Clinica.