### PR TITLE
CI: Enable cache for Poetry

### DIFF
--- a/.github/workflows/test_converters.yml
+++ b/.github/workflows/test_converters.yml
@@ -20,6 +20,10 @@ jobs:
       - macOS
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: poetry
       - uses: snok/install-poetry@v1
       - name: Run non-regression tests for converters
         run: |
@@ -35,13 +39,17 @@ jobs:
           --junitxml=./test-reports/run_converters_mac.xml \
           --disable-warnings \
           ./nonregression/iotools/test_run_converters.py
-  
+
   test-converters-Linux:
     runs-on:
       - self-hosted
       - Linux
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: poetry
       - uses: snok/install-poetry@v1
       - name: Run non-regression tests for converters
         run: |

--- a/.github/workflows/test_converters.yml
+++ b/.github/workflows/test_converters.yml
@@ -20,11 +20,14 @@ jobs:
       - macOS
     steps:
       - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: '1.6.1'
+          virtualenvs-create: false
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: poetry
-      - uses: snok/install-poetry@v1
       - name: Run non-regression tests for converters
         run: |
           make env.conda
@@ -46,11 +49,14 @@ jobs:
       - Linux
     steps:
       - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: '1.6.1'
+          virtualenvs-create: false
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: poetry
-      - uses: snok/install-poetry@v1
       - name: Run non-regression tests for converters
         run: |
           make env.conda

--- a/.github/workflows/test_converters.yml
+++ b/.github/workflows/test_converters.yml
@@ -13,6 +13,10 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+env:
+  POETRY_VERSION: '1.6.1'
+  PYTHON_VERSION: '3.10'
+
 jobs:
   test-converters-MacOS:
     runs-on:
@@ -22,11 +26,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1
         with:
-          version: '1.6.1'
+          version: ${{ env.POETRY_VERSION }}
           virtualenvs-create: false
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
       - name: Run non-regression tests for converters
         run: |
@@ -51,11 +55,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1
         with:
-          version: '1.6.1'
+          version: ${{ env.POETRY_VERSION }}
           virtualenvs-create: false
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
       - name: Run non-regression tests for converters
         run: |

--- a/.github/workflows/test_converters.yml
+++ b/.github/workflows/test_converters.yml
@@ -28,10 +28,6 @@ jobs:
         with:
           version: ${{ env.POETRY_VERSION }}
           virtualenvs-create: false
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
       - name: Run non-regression tests for converters
         run: |
           make env.conda

--- a/.github/workflows/test_instantiation.yml
+++ b/.github/workflows/test_instantiation.yml
@@ -20,6 +20,10 @@ jobs:
       - macOS
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: poetry
       - uses: snok/install-poetry@v1
       - name: Run instantiation tests
         run: |
@@ -37,13 +41,17 @@ jobs:
           --junitxml=./test-reports/instantiation_mac.xml \
           --disable-warnings \
           ./instantiation/
-  
+
   test-instantiation-Linux:
     runs-on:
       - self-hosted
       - Linux
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: poetry
       - uses: snok/install-poetry@v1
       - name: Run instantiation tests
         run: |

--- a/.github/workflows/test_instantiation.yml
+++ b/.github/workflows/test_instantiation.yml
@@ -13,6 +13,10 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+env:
+  POETRY_VERSION: '1.6.1'
+  PYTHON_VERSION: '3.10'
+
 jobs:
   test-instantiation-MacOS:
     runs-on:
@@ -22,11 +26,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1
         with:
-          version: '1.6.1'
+          version: ${{ env.POETRY_VERSION }}
           virtualenvs-create: false
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
       - name: Run instantiation tests
         run: |
@@ -53,11 +57,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1
         with:
-          version: '1.6.1'
+          version: ${{ env.POETRY_VERSION }}
           virtualenvs-create: false
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
       - name: Run instantiation tests
         run: |

--- a/.github/workflows/test_instantiation.yml
+++ b/.github/workflows/test_instantiation.yml
@@ -20,11 +20,14 @@ jobs:
       - macOS
     steps:
       - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: '1.6.1'
+          virtualenvs-create: false
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: poetry
-      - uses: snok/install-poetry@v1
       - name: Run instantiation tests
         run: |
           make env.conda
@@ -48,11 +51,14 @@ jobs:
       - Linux
     steps:
       - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: '1.6.1'
+          virtualenvs-create: false
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: poetry
-      - uses: snok/install-poetry@v1
       - name: Run instantiation tests
         run: |
           make env.conda

--- a/.github/workflows/test_instantiation.yml
+++ b/.github/workflows/test_instantiation.yml
@@ -28,10 +28,6 @@ jobs:
         with:
           version: ${{ env.POETRY_VERSION }}
           virtualenvs-create: false
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
       - name: Run instantiation tests
         run: |
           make env.conda

--- a/.github/workflows/test_non_regression_fast.yml
+++ b/.github/workflows/test_non_regression_fast.yml
@@ -20,11 +20,14 @@ jobs:
       - macOS
     steps:
       - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: '1.6.1'
+          virtualenvs-create: false
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: poetry
-      - uses: snok/install-poetry@v1
       - name: Run instantiation tests
         run: |
           make env.conda
@@ -50,11 +53,14 @@ jobs:
       - Linux
     steps:
       - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: '1.6.1'
+          virtualenvs-create: false
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: poetry
-      - uses: snok/install-poetry@v1
       - name: Run instantiation tests
         run: |
           make env.conda

--- a/.github/workflows/test_non_regression_fast.yml
+++ b/.github/workflows/test_non_regression_fast.yml
@@ -20,6 +20,10 @@ jobs:
       - macOS
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: poetry
       - uses: snok/install-poetry@v1
       - name: Run instantiation tests
         run: |
@@ -39,13 +43,17 @@ jobs:
           -n 4 \
           -m "fast" \
           ./nonregression/
-  
+
   test-non-regression-fast-Linux:
     runs-on:
       - self-hosted
       - Linux
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: poetry
       - uses: snok/install-poetry@v1
       - name: Run instantiation tests
         run: |

--- a/.github/workflows/test_non_regression_fast.yml
+++ b/.github/workflows/test_non_regression_fast.yml
@@ -13,6 +13,10 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+env:
+  POETRY_VERSION: '1.6.1'
+  PYTHON_VERSION: '3.10'
+
 jobs:
   test-non-regression-fast-MacOS:
     runs-on:
@@ -22,11 +26,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1
         with:
-          version: '1.6.1'
+          version: ${{ env.POETRY_VERSION }}
           virtualenvs-create: false
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
       - name: Run instantiation tests
         run: |
@@ -55,11 +59,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1
         with:
-          version: '1.6.1'
+          version: ${{ env.POETRY_VERSION }}
           virtualenvs-create: false
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
       - name: Run instantiation tests
         run: |

--- a/.github/workflows/test_non_regression_fast.yml
+++ b/.github/workflows/test_non_regression_fast.yml
@@ -28,10 +28,6 @@ jobs:
         with:
           version: ${{ env.POETRY_VERSION }}
           virtualenvs-create: false
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
       - name: Run instantiation tests
         run: |
           make env.conda


### PR DESCRIPTION
Should speed Conda environment setup by re-using the previous Poetry cache if the project's lock file has not been modified.

This PR implements the following:
- Persistence of Poetry's cache using `actions/setup-python`
- Ensure Poetry uses the Conda environment instead of creating a new one
- Pin the version of Python and Poetry to avoid accidental upgrades

This is restricted to Linux *only*, since the macOS runner machines cannot use `actions/setup-python` as they are configured today.