### PR TITLE
[FIX] Fix bad session labels in `T1Linear` pipeline

### DIFF
--- a/clinica/pipelines/t1_linear/anat_linear_utils.py
+++ b/clinica/pipelines/t1_linear/anat_linear_utils.py
@@ -32,6 +32,7 @@ def _get_substitutions_datasink(bids_image_id: str, suffix: str) -> list:
     substitutions : List of tuples of str
         List of length 3 containing the substitutions to perform.
     """
+    # TODO: Use str.removesuffix once Python 3.8 compatibility is dropped.
     if bids_image_id.endswith(f"_{suffix}"):
         bids_image_id_without_suffix = bids_image_id[: -(len(suffix) + 1)]
     else:

--- a/clinica/pipelines/t1_linear/anat_linear_utils.py
+++ b/clinica/pipelines/t1_linear/anat_linear_utils.py
@@ -32,7 +32,12 @@ def _get_substitutions_datasink(bids_image_id: str, suffix: str) -> list:
     substitutions : List of tuples of str
         List of length 3 containing the substitutions to perform.
     """
-    bids_image_id_without_suffix = bids_image_id.rstrip(f"_{suffix}")
+    if bids_image_id.endswith(f"_{suffix}"):
+        bids_image_id_without_suffix = bids_image_id[: -(len(suffix) + 1)]
+    else:
+        raise ValueError(
+            f"bids image ID {bids_image_id} should end with provided {suffix}."
+        )
     return [
         (
             f"{bids_image_id}Warped_cropped.nii.gz",


### PR DESCRIPTION
Fix issue discovered in #998 with session labels in the output files of `T1Linear`.

Because of the behavior of the Python `rstrip()` string method, when stripping the suffix "T1w", the session labels ending with such characters "1", "T", or "w" are stripped from these...

Here is an example where the last "1" is removed in the output :

```
$ tree
.
├── bids
│   ├── sub-001
│   │   └── ses-01
│   │       └── anat
│   │           └── sub-001_ses-01_T1w.nii.gz
│   ├── sub-002
│   │   └── ses-01
│   │       └── anat
│   │           └── sub-002_ses-01_T1w.nii.gz
│   └── sub-003
│       └── ses-01
│           └── anat
│               └── sub-003_ses-01_T1w.nii.gz
├── caps
│   └── subjects
│       ├── sub-001
│       │   └── ses-01
│       │       └── t1_linear
│       │           ├── sub-001_ses-0_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_T1w.nii.gz
│       │           ├── sub-001_ses-0_space-MNI152NLin2009cSym_res-1x1x1_T1w.nii.gz
│       │           └── sub-001_ses-0_space-MNI152NLin2009cSym_res-1x1x1_affine.mat
│       ├── sub-002
│       │   └── ses-01
│       │       └── t1_linear
│       │           ├── sub-002_ses-0_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_T1w.nii.gz
│       │           ├── sub-002_ses-0_space-MNI152NLin2009cSym_res-1x1x1_T1w.nii.gz
│       │           └── sub-002_ses-0_space-MNI152NLin2009cSym_res-1x1x1_affine.mat
│       └── sub-003
│           └── ses-01
│               └── t1_linear
│                   ├── sub-003_ses-0_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_T1w.nii.gz
│                   ├── sub-003_ses-0_space-MNI152NLin2009cSym_res-1x1x1_T1w.nii.gz
│                   └── sub-003_ses-0_space-MNI152NLin2009cSym_res-1x1x1_affine.mat
```
