### PR TITLE
Use pathlib in pipelines

### DIFF
--- a/clinica/pipelines/dwi_connectome/dwi_connectome_pipeline.py
+++ b/clinica/pipelines/dwi_connectome/dwi_connectome_pipeline.py
@@ -54,7 +54,7 @@ class DwiConnectome(Pipeline):
         """
         return ["response", "fod", "tracts", "nodes", "connectomes"]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         import re
 
@@ -182,7 +182,7 @@ class DwiConnectome(Pipeline):
                 "Bad preprocessed DWI space. Please check your CAPS folder."
             )
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         import nipype.interfaces.io as nio
         import nipype.interfaces.utility as nutil
@@ -232,7 +232,7 @@ class DwiConnectome(Pipeline):
         )
         # fmt: on
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline.
 
         Notes:

--- a/clinica/pipelines/dwi_connectome/dwi_connectome_pipeline.py
+++ b/clinica/pipelines/dwi_connectome/dwi_connectome_pipeline.py
@@ -1,37 +1,40 @@
 # Use hash instead of parameters for iterables folder names
+from typing import List
+
 from nipype import config
 
-import clinica.pipelines.engine as cpe
+from clinica.pipelines.engine import Pipeline
 
 cfg = dict(execution={"parameterize_dirs": False})
 config.update_config(cfg)
 
 
-class DwiConnectome(cpe.Pipeline):
+class DwiConnectome(Pipeline):
     """Connectome-based processing of corrected DWI datasets.
 
     Returns:
         A clinica pipeline object containing the DwiConnectome pipeline.
     """
 
-    def check_pipeline_parameters(self):
+    def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
         if self.parameters["n_tracks"] < 0:
             raise ValueError(
                 f"The n_tracks parameter ({self.parameters['n_tracks']}) should be positive."
             )
 
-    def check_custom_dependencies(self):
+    def _check_custom_dependencies(self) -> None:
         """Check dependencies that can not be listed in the `info.json` file."""
         pass
 
-    def get_input_fields(self):
+    def get_input_fields(self) -> List[str]:
         """Specify the list of possible inputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) input fields name.
         """
-
         return [
             "t1_brain_file",
             "wm_mask_file",
@@ -41,18 +44,18 @@ class DwiConnectome(cpe.Pipeline):
             "atlas_files",
         ]
 
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Specify the list of possible outputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) output fields name.
         """
-
         return ["response", "fod", "tracts", "nodes", "connectomes"]
 
     def build_input_node(self):
         """Build and connect an input node to the pipeline."""
-        import os
         import re
 
         import nipype.interfaces.utility as nutil
@@ -111,9 +114,8 @@ class DwiConnectome(cpe.Pipeline):
         ]
 
         # Save subjects to process in <WD>/<Pipeline.name>/participants.tsv
-        folder_participants_tsv = os.path.join(self.base_dir, self.name)
         save_participants_sessions(
-            self.subjects, self.sessions, folder_participants_tsv
+            self.subjects, self.sessions, self.base_dir / self.name
         )
 
         if len(self.subjects):

--- a/clinica/pipelines/dwi_dti/dwi_dti_pipeline.py
+++ b/clinica/pipelines/dwi_dti/dwi_dti_pipeline.py
@@ -1,6 +1,8 @@
+from typing import List
+
 from nipype import config
 
-import clinica.pipelines.engine as cpe
+from clinica.pipelines.engine import Pipeline
 
 # Use hash instead of parameters for iterables folder names
 # Otherwise path will be too long and generate OSError
@@ -8,7 +10,7 @@ cfg = dict(execution={"parameterize_dirs": False})
 config.update_config(cfg)
 
 
-class DwiDti(cpe.Pipeline):
+class DwiDti(Pipeline):
     """DTI-based processing of DWI datasets.
 
     Returns:
@@ -16,27 +18,32 @@ class DwiDti(cpe.Pipeline):
 
     """
 
-    def check_pipeline_parameters(self):
+    def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
-
-    def check_custom_dependencies(self):
         pass
 
-    def get_input_fields(self):
+    def _check_custom_dependencies(self) -> None:
+        pass
+
+    def get_input_fields(self) -> List[str]:
         """Specify the list of possible inputs of this pipelines.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) input fields name.
         """
         return ["preproc_dwi", "preproc_bvec", "preproc_bval", "b0_mask"]
 
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Specify the list of possible outputs of this pipelines.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) output fields name.
         """
-        output_list_dti = [
+        return [
             "dti",
             "fa",
             "md",
@@ -55,12 +62,8 @@ class DwiDti(cpe.Pipeline):
             "affine_matrix",
         ]
 
-        return output_list_dti
-
     def build_input_node(self):
         """Build and connect an input node to the pipeline."""
-        import os
-
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
 
@@ -84,15 +87,14 @@ class DwiDti(cpe.Pipeline):
         )
 
         # Save subjects to process in <WD>/<Pipeline.name>/participants.tsv
-        folder_participants_tsv = os.path.join(self.base_dir, self.name)
         save_participants_sessions(
-            self.subjects, self.sessions, folder_participants_tsv
+            self.subjects, self.sessions, self.base_dir / self.name
         )
 
         if len(self.subjects):
             print_images_to_process(self.subjects, self.sessions)
             cprint(
-                f"List available in {os.path.join(folder_participants_tsv, 'participants.tsv')}"
+                f"List available in {self.base_dir / self.name / 'participants.tsv'}"
             )
             cprint("The pipeline will last approximately 20 minutes per image.")
 

--- a/clinica/pipelines/dwi_dti/dwi_dti_pipeline.py
+++ b/clinica/pipelines/dwi_dti/dwi_dti_pipeline.py
@@ -62,7 +62,7 @@ class DwiDti(Pipeline):
             "affine_matrix",
         ]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -121,7 +121,7 @@ class DwiDti(Pipeline):
             ]
         )
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         import nipype.interfaces.io as nio
         import nipype.interfaces.utility as nutil
@@ -206,7 +206,7 @@ class DwiDti(Pipeline):
         )
         # fmt: on
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import os
 

--- a/clinica/pipelines/dwi_dti/dwi_dti_pipeline.py
+++ b/clinica/pipelines/dwi_dti/dwi_dti_pipeline.py
@@ -165,46 +165,79 @@ class DwiDti(Pipeline):
             name="rename_into_caps",
         )
 
-        # Writing results into CAPS
         write_results = npe.Node(name="write_results", interface=nio.DataSink())
-        write_results.inputs.base_directory = self.caps_directory
+        write_results.inputs.base_directory = str(self.caps_directory)
         write_results.inputs.parameterization = False
 
-        # fmt: off
         self.connect(
             [
-                (self.input_node, container_path, [("preproc_dwi", "bids_or_caps_filename")]),
-
-                (container_path, write_results, [(("container", fix_join, "dwi", "dti_based_processing"), "container")]),
+                (
+                    self.input_node,
+                    container_path,
+                    [("preproc_dwi", "bids_or_caps_filename")],
+                ),
+                (
+                    container_path,
+                    write_results,
+                    [
+                        (
+                            ("container", fix_join, "dwi", "dti_based_processing"),
+                            "container",
+                        )
+                    ],
+                ),
                 (self.output_node, write_results, [("dti", "native_space.@dti")]),
-                (self.output_node, write_results, [("fa", "native_space.@fa"),
-                                                   ("md", "native_space.@md"),
-                                                   ("ad", "native_space.@ad"),
-                                                   ("rd", "native_space.@rd"),
-                                                   ("decfa", "native_space.@decfa")]),
-
+                (
+                    self.output_node,
+                    write_results,
+                    [
+                        ("fa", "native_space.@fa"),
+                        ("md", "native_space.@md"),
+                        ("ad", "native_space.@ad"),
+                        ("rd", "native_space.@rd"),
+                        ("decfa", "native_space.@decfa"),
+                    ],
+                ),
                 (self.input_node, rename_into_caps, [("preproc_dwi", "in_caps_dwi")]),
-                (self.output_node, rename_into_caps, [("registered_fa", "in_norm_fa"),
-                                                      ("registered_md", "in_norm_md"),
-                                                      ("registered_ad", "in_norm_ad"),
-                                                      ("registered_rd", "in_norm_rd"),
-                                                      ("affine_matrix", "in_affine_matrix"),
-                                                      ("b_spline_transform", "in_b_spline_transform")]),
-
-                (rename_into_caps, write_results, [("out_caps_fa", "normalized_space.@registered_fa"),
-                                                   ("out_caps_md", "normalized_space.@registered_md"),
-                                                   ("out_caps_ad", "normalized_space.@registered_ad"),
-                                                   ("out_caps_rd", "normalized_space.@registered_rd"),
-                                                   ("out_caps_affine_matrix", "normalized_space.@affine_matrix"),
-                                                   ("out_caps_b_spline_transform", "normalized_space.@b_spline_transform")]),
-
-                (self.output_node, write_results, [("statistics_fa", "atlas_statistics.@statistics_fa"),
-                                                   ("statistics_md", "atlas_statistics.@statistics_md"),
-                                                   ("statistics_ad", "atlas_statistics.@statistics_ad"),
-                                                   ("statistics_rd", "atlas_statistics.@statistics_rd")])
+                (
+                    self.output_node,
+                    rename_into_caps,
+                    [
+                        ("registered_fa", "in_norm_fa"),
+                        ("registered_md", "in_norm_md"),
+                        ("registered_ad", "in_norm_ad"),
+                        ("registered_rd", "in_norm_rd"),
+                        ("affine_matrix", "in_affine_matrix"),
+                        ("b_spline_transform", "in_b_spline_transform"),
+                    ],
+                ),
+                (
+                    rename_into_caps,
+                    write_results,
+                    [
+                        ("out_caps_fa", "normalized_space.@registered_fa"),
+                        ("out_caps_md", "normalized_space.@registered_md"),
+                        ("out_caps_ad", "normalized_space.@registered_ad"),
+                        ("out_caps_rd", "normalized_space.@registered_rd"),
+                        ("out_caps_affine_matrix", "normalized_space.@affine_matrix"),
+                        (
+                            "out_caps_b_spline_transform",
+                            "normalized_space.@b_spline_transform",
+                        ),
+                    ],
+                ),
+                (
+                    self.output_node,
+                    write_results,
+                    [
+                        ("statistics_fa", "atlas_statistics.@statistics_fa"),
+                        ("statistics_md", "atlas_statistics.@statistics_md"),
+                        ("statistics_ad", "atlas_statistics.@statistics_ad"),
+                        ("statistics_rd", "atlas_statistics.@statistics_rd"),
+                    ],
+                ),
             ]
         )
-        # fmt: on
 
     def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
@@ -347,22 +380,37 @@ class DwiDti(Pipeline):
             name="Write-End_Message",
         )
 
-        # Connection
-        # ==========
-        # fmt: off
         self.connect(
             [
-                (self.input_node, get_caps_filenames, [("preproc_dwi", "caps_dwi_filename")]),
+                (
+                    self.input_node,
+                    get_caps_filenames,
+                    [("preproc_dwi", "caps_dwi_filename")],
+                ),
                 # Print begin message
-                (self.input_node, print_begin_message, [("preproc_dwi", "in_bids_or_caps_file")]),
+                (
+                    self.input_node,
+                    print_begin_message,
+                    [("preproc_dwi", "in_bids_or_caps_file")],
+                ),
                 # Get BIDS/CAPS identifier from filename
-                (self.input_node, get_bids_identifier, [("preproc_dwi", "dwi_filename")]),
+                (
+                    self.input_node,
+                    get_bids_identifier,
+                    [("preproc_dwi", "caps_dwi_filename")],
+                ),
                 # Convert FSL gradient files (bval/bvec) to MRtrix format
-                (self.input_node, convert_gradients, [("preproc_bval", "bval_file"),
-                                                      ("preproc_bvec", "bvec_file")]),
+                (
+                    self.input_node,
+                    convert_gradients,
+                    [("preproc_bval", "bval_file"), ("preproc_bvec", "bvec_file")],
+                ),
                 # Computation of the DTI model
-                (self.input_node, dwi_to_dti, [("b0_mask", "mask"),
-                                               ("preproc_dwi", "in_file")]),
+                (
+                    self.input_node,
+                    dwi_to_dti,
+                    [("b0_mask", "mask"), ("preproc_dwi", "in_file")],
+                ),
                 (convert_gradients, dwi_to_dti, [("encoding_file", "encoding_file")]),
                 (get_caps_filenames, dwi_to_dti, [("out_dti", "out_filename")]),
                 # Computation of the different metrics from the DTI
@@ -376,44 +424,113 @@ class DwiDti(Pipeline):
                 # Registration of FA-map onto the atlas:
                 (dti_to_metrics, register_fa, [("out_fa", "moving_image")]),
                 # Apply deformation field on MD, AD & RD:
-                (register_fa, ants_transforms, [("out_matrix", "in_affine_transformation")]),
-                (register_fa, ants_transforms, [("forward_warp_field", "in_bspline_transformation")]),
-
-                (dti_to_metrics, apply_ants_registration_for_md, [("out_adc", "input_image")]),
-                (ants_transforms, apply_ants_registration_for_md, [("transforms", "transforms")]),
-
-                (dti_to_metrics, apply_ants_registration_for_ad, [("out_ad", "input_image")]),
-                (ants_transforms, apply_ants_registration_for_ad, [("transforms", "transforms")]),
-
-                (dti_to_metrics, apply_ants_registration_for_rd, [("out_rd", "input_image")]),
-                (ants_transforms, apply_ants_registration_for_rd, [("transforms", "transforms")]),
+                (
+                    register_fa,
+                    ants_transforms,
+                    [("out_matrix", "in_affine_transformation")],
+                ),
+                (
+                    register_fa,
+                    ants_transforms,
+                    [("forward_warp_field", "in_bspline_transformation")],
+                ),
+                (
+                    dti_to_metrics,
+                    apply_ants_registration_for_md,
+                    [("out_adc", "input_image")],
+                ),
+                (
+                    ants_transforms,
+                    apply_ants_registration_for_md,
+                    [("transforms", "transforms")],
+                ),
+                (
+                    dti_to_metrics,
+                    apply_ants_registration_for_ad,
+                    [("out_ad", "input_image")],
+                ),
+                (
+                    ants_transforms,
+                    apply_ants_registration_for_ad,
+                    [("transforms", "transforms")],
+                ),
+                (
+                    dti_to_metrics,
+                    apply_ants_registration_for_rd,
+                    [("out_rd", "input_image")],
+                ),
+                (
+                    ants_transforms,
+                    apply_ants_registration_for_rd,
+                    [("transforms", "transforms")],
+                ),
                 # Remove negative values from the DTI maps:
                 (register_fa, thres_norm_fa, [("warped_image", "in_file")]),
-                (apply_ants_registration_for_md, thres_norm_md, [("output_image", "in_file")]),
-                (apply_ants_registration_for_rd, thres_norm_rd, [("output_image", "in_file")]),
-                (apply_ants_registration_for_ad, thres_norm_ad, [("output_image", "in_file")]),
+                (
+                    apply_ants_registration_for_md,
+                    thres_norm_md,
+                    [("output_image", "in_file")],
+                ),
+                (
+                    apply_ants_registration_for_rd,
+                    thres_norm_rd,
+                    [("output_image", "in_file")],
+                ),
+                (
+                    apply_ants_registration_for_ad,
+                    thres_norm_ad,
+                    [("output_image", "in_file")],
+                ),
                 # Generate regional TSV files
-                (get_bids_identifier, scalar_analysis_fa, [("bids_identifier", "prefix_file")]),
-                (thres_norm_fa, scalar_analysis_fa, [("out_file", "in_registered_map")]),
-                (get_bids_identifier, scalar_analysis_md, [("bids_identifier", "prefix_file")]),
-                (thres_norm_md, scalar_analysis_md, [("out_file", "in_registered_map")]),
-                (get_bids_identifier, scalar_analysis_ad, [("bids_identifier", "prefix_file")]),
-                (thres_norm_ad, scalar_analysis_ad, [("out_file", "in_registered_map")]),
-                (get_bids_identifier, scalar_analysis_rd, [("bids_identifier", "prefix_file")]),
-                (thres_norm_rd, scalar_analysis_rd, [("out_file", "in_registered_map")]),
+                (
+                    get_bids_identifier,
+                    scalar_analysis_fa,
+                    [("bids_identifier", "prefix_file")],
+                ),
+                (
+                    thres_norm_fa,
+                    scalar_analysis_fa,
+                    [("out_file", "in_registered_map")],
+                ),
+                (
+                    get_bids_identifier,
+                    scalar_analysis_md,
+                    [("bids_identifier", "prefix_file")],
+                ),
+                (
+                    thres_norm_md,
+                    scalar_analysis_md,
+                    [("out_file", "in_registered_map")],
+                ),
+                (
+                    get_bids_identifier,
+                    scalar_analysis_ad,
+                    [("bids_identifier", "prefix_file")],
+                ),
+                (
+                    thres_norm_ad,
+                    scalar_analysis_ad,
+                    [("out_file", "in_registered_map")],
+                ),
+                (
+                    get_bids_identifier,
+                    scalar_analysis_rd,
+                    [("bids_identifier", "prefix_file")],
+                ),
+                (
+                    thres_norm_rd,
+                    scalar_analysis_rd,
+                    [("out_file", "in_registered_map")],
+                ),
                 # Remove negative values from the DTI maps:
                 (get_caps_filenames, thres_fa, [("out_fa", "out_file")]),
                 (dti_to_metrics, thres_fa, [("out_fa", "in_file")]),
-
                 (get_caps_filenames, thres_md, [("out_md", "out_file")]),
                 (dti_to_metrics, thres_md, [("out_adc", "in_file")]),
-
                 (get_caps_filenames, thres_ad, [("out_ad", "out_file")]),
                 (dti_to_metrics, thres_ad, [("out_ad", "in_file")]),
-
                 (get_caps_filenames, thres_rd, [("out_rd", "out_file")]),
                 (dti_to_metrics, thres_rd, [("out_rd", "in_file")]),
-
                 # Outputnode
                 (dwi_to_dti, self.output_node, [("tensor", "dti")]),
                 (thres_fa, self.output_node, [("out_file", "fa")]),
@@ -421,23 +538,47 @@ class DwiDti(Pipeline):
                 (thres_ad, self.output_node, [("out_file", "ad")]),
                 (thres_rd, self.output_node, [("out_file", "rd")]),
                 (dti_to_metrics, self.output_node, [("out_evec", "decfa")]),
-
                 (register_fa, self.output_node, [("out_matrix", "affine_matrix")]),
-                (register_fa, self.output_node, [("forward_warp_field", "b_spline_transform")]),
-
+                (
+                    register_fa,
+                    self.output_node,
+                    [("forward_warp_field", "b_spline_transform")],
+                ),
                 (thres_norm_fa, self.output_node, [("out_file", "registered_fa")]),
                 (thres_norm_md, self.output_node, [("out_file", "registered_md")]),
                 (thres_norm_ad, self.output_node, [("out_file", "registered_ad")]),
                 (thres_norm_rd, self.output_node, [("out_file", "registered_rd")]),
-
-                (scalar_analysis_fa, self.output_node, [("atlas_statistics_list", "statistics_fa")]),
-                (scalar_analysis_md, self.output_node, [("atlas_statistics_list", "statistics_md")]),
-                (scalar_analysis_ad, self.output_node, [("atlas_statistics_list", "statistics_ad")]),
-                (scalar_analysis_rd, self.output_node, [("atlas_statistics_list", "statistics_rd")]),
+                (
+                    scalar_analysis_fa,
+                    self.output_node,
+                    [("atlas_statistics_list", "statistics_fa")],
+                ),
+                (
+                    scalar_analysis_md,
+                    self.output_node,
+                    [("atlas_statistics_list", "statistics_md")],
+                ),
+                (
+                    scalar_analysis_ad,
+                    self.output_node,
+                    [("atlas_statistics_list", "statistics_ad")],
+                ),
+                (
+                    scalar_analysis_rd,
+                    self.output_node,
+                    [("atlas_statistics_list", "statistics_rd")],
+                ),
                 # Print end message
-                (self.input_node, print_end_message, [("preproc_dwi", "in_bids_or_caps_file")]),
+                (
+                    self.input_node,
+                    print_end_message,
+                    [("preproc_dwi", "in_bids_or_caps_file")],
+                ),
                 (thres_rd, print_end_message, [("out_file", "final_file_1")]),
-                (scalar_analysis_rd, print_end_message, [("atlas_statistics_list", "final_file_2")]),
+                (
+                    scalar_analysis_rd,
+                    print_end_message,
+                    [("atlas_statistics_list", "final_file_2")],
+                ),
             ]
         )
-        # fmt: on

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
@@ -89,7 +89,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(DWIPreprocessingPipeline):
             "smoothed_fmap_on_b0",
         ]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -166,7 +166,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(DWIPreprocessingPipeline):
         )
         # fmt: on
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         import nipype.interfaces.io as nio
         import nipype.interfaces.utility as nutil
@@ -243,7 +243,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(DWIPreprocessingPipeline):
         )
         # fmt: on
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.fsl as fsl
         import nipype.interfaces.mrtrix3 as mrtrix3

--- a/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_fmap/dwi_preprocessing_using_phasediff_fmap_pipeline.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+from typing import List
+
 from nipype import config
 
-import clinica.pipelines.engine as cpe
+from clinica.pipelines.engine import DWIPreprocessingPipeline
 
 # Use hash instead of parameters for iterables folder names
 # Otherwise path will be too long and generate OSError
@@ -8,7 +11,7 @@ cfg = dict(execution={"parameterize_dirs": False})
 config.update_config(cfg)
 
 
-class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
+class DwiPreprocessingUsingPhaseDiffFMap(DWIPreprocessingPipeline):
     """DWI Preprocessing using phase difference fieldmap.
 
     Ideas for improvement:
@@ -23,53 +26,22 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
     """
 
     @staticmethod
-    def get_processed_images(caps_directory, subjects, sessions):
-        import os
-
+    def get_processed_images(
+        caps_directory: Path, subjects: List[str], sessions: List[str]
+    ) -> List[str]:
         from clinica.utils.filemanip import extract_image_ids
         from clinica.utils.input_files import DWI_PREPROC_NII
         from clinica.utils.inputs import clinica_file_reader
 
-        image_ids = []
-        if os.path.isdir(caps_directory):
+        image_ids: List[str] = []
+        if caps_directory.is_dir():
             preproc_files, _ = clinica_file_reader(
                 subjects, sessions, caps_directory, DWI_PREPROC_NII, False
             )
             image_ids = extract_image_ids(preproc_files)
         return image_ids
 
-    def check_pipeline_parameters(self):
-        """Check pipeline parameters."""
-        from clinica.utils.stream import cprint
-
-        self.parameters.setdefault("low_bval", 5)
-        low_bval = self.parameters["low_bval"]
-        if low_bval < 0:
-            raise ValueError(
-                f"The low_bval is negative ({low_bval}): it should be zero or close to zero."
-            )
-        if self.parameters["low_bval"] > 100:
-            cprint(
-                f"The low_bval parameter is {low_bval}: it should be close to zero.",
-                lvl="warning",
-            )
-
-        self.parameters.setdefault("use_cuda", False)
-        self.parameters.setdefault("initrand", False)
-
-    def check_custom_dependencies(self):
-        """Check dependencies that can not be listed in the `info.json` file."""
-        from clinica.utils.check_dependency import is_binary_present
-        from clinica.utils.exceptions import ClinicaMissingDependencyError
-
-        if self.parameters["use_cuda"]:
-            if not is_binary_present("eddy_cuda"):
-                raise ClinicaMissingDependencyError(
-                    "[Error] FSL eddy with CUDA was set but Clinica could not find eddy_cuda in your PATH environment. "
-                    "Check that  https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/eddy/UsersGuide#The_eddy_executables is correctly set."
-                )
-
-    def get_input_fields(self):
+    def get_input_fields(self) -> List[str]:
         """Specify the list of possible inputs of this pipeline.
 
         Returns:
@@ -94,7 +66,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
             "fmap_phasediff_json",
         ]
 
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Specify the list of possible outputs of this pipeline.
 
         Returns:
@@ -119,8 +91,6 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
 
     def build_input_node(self):
         """Build and connect an input node to the pipeline."""
-        import os
-
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
 
@@ -155,15 +125,14 @@ class DwiPreprocessingUsingPhaseDiffFMap(cpe.Pipeline):
         )
 
         # Save subjects to process in <WD>/<Pipeline.name>/participants.tsv
-        folder_participants_tsv = os.path.join(self.base_dir, self.name)
         save_participants_sessions(
-            self.subjects, self.sessions, folder_participants_tsv
+            self.subjects, self.sessions, self.base_dir / self.name
         )
 
         if len(self.subjects):
             print_images_to_process(self.subjects, self.sessions)
             cprint(
-                f"List available in {os.path.join(folder_participants_tsv, 'participants.tsv')}"
+                f"List available in {self.base_dir / self.name / 'participants.tsv'}"
             )
             cprint(
                 "Computational time will depend of the number of volumes in your DWI dataset and the use of CUDA."

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_pipeline.py
@@ -150,8 +150,6 @@ class DwiPreprocessingUsingT1(DWIPreprocessingPipeline):
 
         from .dwi_preprocessing_using_t1_utils import rename_into_caps
 
-        # Find container path from DWI filename
-        # =====================================
         container_path = npe.Node(
             nutil.Function(
                 input_names=["bids_or_caps_filename"],
@@ -181,10 +179,8 @@ class DwiPreprocessingUsingT1(DWIPreprocessingPipeline):
             name="rename_into_caps",
         )
 
-        # Writing results into CAPS
-        # =========================
         write_results = npe.Node(name="write_results", interface=nio.DataSink())
-        write_results.inputs.base_directory = self.caps_directory
+        write_results.inputs.base_directory = str(self.caps_directory)
         write_results.inputs.parameterization = False
 
         # fmt: off
@@ -265,7 +261,7 @@ class DwiPreprocessingUsingT1(DWIPreprocessingPipeline):
             ),
         )
         prepare_b0.inputs.b_value_threshold = self.parameters["low_bval"]
-        prepare_b0.inputs.working_directory = self.base_dir
+        prepare_b0.inputs.working_directory = str(self.base_dir)
 
         # Head-motion correction + Eddy-currents correction
         eddy_fsl = eddy_fsl_pipeline(
@@ -275,7 +271,7 @@ class DwiPreprocessingUsingT1(DWIPreprocessingPipeline):
         )
         # Susceptibility distortion correction using T1w image
         sdc = epi_pipeline(
-            self.base_dir,
+            str(self.base_dir),
             self.parameters["delete_cache"],
             name="SusceptibilityDistortionCorrection",
             ants_random_seed=self.parameters["random_seed"],

--- a/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_pipeline.py
+++ b/clinica/pipelines/dwi_preprocessing_using_t1/dwi_preprocessing_using_t1_pipeline.py
@@ -78,7 +78,7 @@ class DwiPreprocessingUsingT1(DWIPreprocessingPipeline):
         """
         return ["preproc_dwi", "preproc_bvec", "preproc_bval", "b0_mask"]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -140,7 +140,7 @@ class DwiPreprocessingUsingT1(DWIPreprocessingPipeline):
         )
         # fmt: on
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         import nipype.interfaces.io as nio
         import nipype.interfaces.utility as nutil
@@ -205,7 +205,7 @@ class DwiPreprocessingUsingT1(DWIPreprocessingPipeline):
         )
         # fmt: on
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.fsl as fsl
         import nipype.interfaces.mrtrix3 as mrtrix3

--- a/clinica/pipelines/engine.py
+++ b/clinica/pipelines/engine.py
@@ -4,10 +4,12 @@ Subclasses are located in clinica/pipeline/<pipeline_name>/<pipeline_name>_pipel
 """
 
 import abc
-from typing import Tuple
+from pathlib import Path
+from typing import List, Optional, Tuple
 
 import click
-from nipype.pipeline.engine import Workflow
+from nipype.interfaces.utility import IdentityInterface
+from nipype.pipeline.engine import Node, Workflow
 
 
 def clinica_pipeline(func):
@@ -46,26 +48,26 @@ def postset(attribute, value):
     return postset_decorator
 
 
-def detect_cross_sectional_and_longitudinal_subjects(
-    all_subs: list, bids_dir: str
-) -> Tuple[list, list]:
+def _detect_cross_sectional_and_longitudinal_subjects(
+    all_subs: List[str], bids_dir: Path
+) -> Tuple[List[str], List[str]]:
     """This function detects whether a subject has a longitudinal or cross sectional structure.
     If it has a mixed structure, it will be considered cross sectionnal.
 
     Parameters
     ----------
-    all_subs: list
+    all_subs: list of str
         List containing all the names of the subjects.
 
-    bids_dir: str
-        Path to the bids directory.
+    bids_dir: Path
+        The path to the bids directory.
 
     Returns
     -------
-    cross_subj: list
+    cross_subj: list of str
         List of all the subject detected with a cross_sectional organisation.
 
-    long_subj: list
+    long_subj: list of str
         List of all the subject detected with a longitudinal organisation.
 
     Examples
@@ -75,7 +77,7 @@ def detect_cross_sectional_and_longitudinal_subjects(
     │   └── anat
     └── sub-02
         └── ses-M000
-    >>> detect_cross_sectional_and_longitudinal_subjects(["sub-01", "sub-02"], /Users/name.surname/BIDS)
+    >>> _detect_cross_sectional_and_longitudinal_subjects(["sub-01", "sub-02"], /Users/name.surname/BIDS)
     (["sub-01"], ["sub-02])
     """
     from os import listdir
@@ -93,6 +95,235 @@ def detect_cross_sectional_and_longitudinal_subjects(
         else:
             long_subj.append(sub)
     return cross_subj, long_subj
+
+
+SYMBOLS = {
+    "customary": ("B", "K", "M", "G", "T", "P", "E", "Z", "Y"),
+    "customary_ext": (
+        "byte",
+        "kilo",
+        "mega",
+        "giga",
+        "tera",
+        "peta",
+        "exa",
+        "zetta",
+        "iotta",
+    ),
+    "iec": ("Bi", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"),
+    "iec_ext": (
+        "byte",
+        "kibi",
+        "mebi",
+        "gibi",
+        "tebi",
+        "pebi",
+        "exbi",
+        "zebi",
+        "yobi",
+    ),
+}
+
+
+def _bytes2human(
+    n: int, format: str = "%(value).1f %(symbol)s", symbols: str = "customary"
+) -> str:
+    """Convert n bytes into a human readable string based on format.
+
+    Symbols can be either "customary", "customary_ext", "iec" or "iec_ext", see: http://goo.gl/kTQMs
+
+    License:
+    Bytes-to-human / human-to-bytes converter.
+    Based on: http://goo.gl/kTQMs
+    Author: Giampaolo Rodola' <g.rodola [AT] gmail [DOT] com>
+    License: MIT
+    """
+    n = int(n)
+    if n < 0:
+        raise ValueError("n < 0")
+    symbols = SYMBOLS[symbols]
+    prefix = {}
+    for i, s in enumerate(symbols[1:]):
+        prefix[s] = 1 << (i + 1) * 10
+    for symbol in reversed(symbols[1:]):
+        if n >= prefix[symbol]:
+            value = float(n) / prefix[symbol]
+            return format % locals()
+    return format % dict(symbol=symbols[0], value=n)
+
+
+def _human2bytes(s: str) -> int:
+    """Attempts to guess the string format based on default symbols
+    set and return the corresponding bytes as an integer.
+
+    When unable to recognize the format ValueError is raised.
+
+    License:
+    Bytes-to-human / human-to-bytes converter.
+    Based on: http://goo.gl/kTQMs
+    Author: Giampaolo Rodola' <g.rodola [AT] gmail [DOT] com>
+    License: MIT
+    """
+    init = s
+    num = ""
+    while s and s[0:1].isdigit() or s[0:1] == ".":
+        num += s[0]
+        s = s[1:]
+    num = float(num)
+    letter = s.strip()
+    for name, sset in SYMBOLS.items():
+        if letter in sset:
+            break
+    else:
+        if letter == "k":
+            # treat 'k' as an alias for 'K' as per: http://goo.gl/kTQMs
+            sset = SYMBOLS["customary"]
+            letter = letter.upper()
+        else:
+            raise ValueError("can't interpret %r" % init)
+    prefix = {sset[0]: 1}
+    for i, s in enumerate(sset[1:]):
+        prefix[s] = 1 << (i + 1) * 10
+    return int(num * prefix[letter])
+
+
+def _add_session_label(filename: str) -> str:
+    """Transform a cross-sectional filename into a longitudinal one.
+
+    Examples
+    --------
+    >>> _add_ses("sub-ADNI001_scans.tsv")
+    sub-ADNI001_ses-M000_scans.tsv
+
+    No modification done if filename already has a session:
+
+    >>> _add_ses("sub-023a_ses-M012_T1w.nii.gz")
+    sub-023a_ses-M012_T1w.nii.gz
+
+    Parameters
+    ----------
+    filename : str
+
+    Returns
+    -------
+    str :
+        filename with '_ses-M000_ added just after participant_id
+    """
+    import re
+
+    # If filename contains ses-..., returns the original filename
+    # Regex explication:
+    # ^ start of string
+    # ([a-zA-Z0-9]*) matches any number of characters from a to z,
+    #       A to Z, 0 to 9, and store it in group(1)
+    # (?!ses-[a-zA-Z0-9]) do not match if there is already a 'ses-'
+    # (.*) catches the rest of the string
+    m = re.search(r"(^sub-[a-zA-Z0-9]*)_(?!ses-[a-zA-Z0-9])(.*)", filename)
+    try:
+        return m.group(1) + "_ses-M000_" + m.group(2)
+    except AttributeError:
+        return filename
+
+
+def _copy2_add_session_label(src: Path, dst: Path) -> Path:
+    """Calls copy2 function from shutil, but modifies the filename of the
+    copied files if they match the regex template described in the
+    _add_session_label() function
+
+    Parameters
+    ----------
+    src : Path
+        The path to the file that needs to be copied.
+
+    dst : Path
+        The original destination for the copied file.
+
+    Returns
+    -------
+    Path :
+        copy2 with modified filename.
+    """
+    from shutil import copy2
+
+    return copy2(src, dst / _add_session_label(src.name))
+
+
+def _convert_cross_sectional(
+    bids_in: Path,
+    bids_out: Path,
+    cross_subjects: List[str],
+    long_subjects: List[str],
+) -> None:
+    """
+    This function converts a cross-sectional-bids dataset into a
+    longitudinal clinica-compliant dataset
+
+    Parameters
+    ----------
+    bids_in : Path
+        The path to the cross-sectional bids dataset you want to convert.
+
+    bids_out : Path
+        The path to the converted longitudinal bids dataset.
+
+    cross_subjects : list of str
+        List of subjects in cross-sectional form (they need some adjustment).
+
+    long_subjects : list of str
+        List of subjects in longitudinal form (they just need to be copied).
+    """
+    if not bids_out.exists():
+        bids_out.mkdir()
+    _convert(bids_in, bids_out, cross_subjects, cross_sectional=True)
+    _convert(bids_in, bids_out, long_subjects, cross_sectional=False)
+
+
+def _convert(
+    bids_in: Path, bids_out: Path, subjects: List[str], cross_sectional: bool
+) -> None:
+    for subject in subjects:
+        output_folder = (
+            bids_out / subject / "ses-M000" if cross_sectional else bids_out / subject
+        )
+        if not output_folder.exists():
+            output_folder.mkdir(parents=True)
+        for file_to_copy in [
+            f for f in (bids_in / subject).iterdir() if not f.name.startswith(".")
+        ]:
+            copy_func = _copy_cross_sectional if cross_sectional else _copy_longitudinal
+            copy_func(bids_in / subject / file_to_copy, output_folder)
+
+
+def _copy_cross_sectional(file_to_copy: Path, output_folder: Path) -> None:
+    from shutil import copy2, copytree
+
+    if not (output_folder / file_to_copy.name).exists():
+        if file_to_copy.is_dir():
+            copytree(
+                file_to_copy,
+                output_folder / file_to_copy.name,
+                copy_function=_copy2_add_session_label,
+            )
+        elif file_to_copy.is_file():
+            new_filename_wo_ses = _add_session_label(file_to_copy.name)
+            copy2(file_to_copy, output_folder / new_filename_wo_ses)
+
+
+def _copy_longitudinal(file_to_copy: Path, output_folder: Path) -> None:
+    from shutil import copy2, copytree
+
+    if not (output_folder / file_to_copy.name).exists():
+        if file_to_copy.is_dir():
+            copytree(file_to_copy, output_folder / file_to_copy.name)
+        elif file_to_copy.is_file():
+            copy2(file_to_copy, output_folder)
+
+
+def _check_cross_subj(cross_subj: list) -> None:
+    from clinica.utils.exceptions import ClinicaInconsistentDatasetError
+
+    if len(cross_subj) > 0:
+        raise ClinicaInconsistentDatasetError(cross_subj)
 
 
 class Pipeline(Workflow):
@@ -113,76 +344,113 @@ class Pipeline(Workflow):
                 |
         [ Data Output Stream ]
 
-    Attributes:
-        is_built (bool): Informs if the pipelines has been built or not.
-        parameters (dict): Parameters of the pipelines.
-        info (dict): Information presented in the associated `info.json` file.
-        input_node (:obj:`npe.Node`): Identity interface connecting inputs.
-        output_node (:obj:`npe.Node`): Identity interface connecting outputs.
-        bids_directory (str): Directory used to read the data from, in BIDS.
-        caps_directory (str): Directory used to read/write the data from/to,
-            in CAPS.
-        subjects (list): List of subjects defined in the `subjects.tsv` file.
-            # TODO(@jguillon): Check the subjects-sessions file name.
-        sessions (list): List of sessions defined in the `subjects.tsv` file.
-        tsv_file (str): Path to the subjects-sessions `.tsv` file.
-        info_file (str): Path to the associated `info.json` file.
+    Attributes
+    ----------
+    is_built : bool
+        Informs if the pipelines has been built or not.
+
+    parameters : dict
+        Parameters of the pipelines.
+
+    info : dict
+        Information presented in the associated `info.json` file.
+
+    input_node : :obj:`npe.Node`
+        Identity interface connecting inputs.
+
+    output_node : :obj:`npe.Node`
+        Identity interface connecting outputs.
+
+    bids_directory : Path
+        Directory used to read the data from, in BIDS.
+
+    caps_directory : Path
+        Directory used to read/write the data from/to in CAPS.
+
+    subjects : list
+        List of subjects defined in the `subjects.tsv` file.
+        TODO(@jguillon): Check the subjects-sessions file name.
+
+    sessions : list
+        List of sessions defined in the `subjects.tsv` file.
+
+    tsv_file : str
+        Path to the subjects-sessions `.tsv` file.
+
+    info_file : str
+        Path to the associated `info.json` file.
     """
 
     __metaclass__ = abc.ABCMeta
 
     def __init__(
         self,
-        bids_directory=None,
-        caps_directory=None,
-        tsv_file=None,
-        overwrite_caps=False,
-        base_dir=None,
-        parameters={},
-        name=None,
+        bids_directory: Optional[str] = None,
+        caps_directory: Optional[str] = None,
+        tsv_file: Optional[str] = None,
+        overwrite_caps: Optional[bool] = False,
+        base_dir: Optional[str] = None,
+        parameters: Optional[dict] = None,
+        name: Optional[str] = None,
     ):
         """Init a Pipeline object.
 
-        Args:
-            bids_directory (str, optional): Path to a BIDS directory. Defaults to None.
-            caps_directory (str, optional): Path to a CAPS directory. Defaults to None.
-            tsv_file (str, optional): Path to a subjects-sessions `.tsv` file. Defaults to None.
-            overwrite_caps (bool, optional): Overwrite or not output directory.. Defaults to False.
-            base_dir (str, optional): Working directory (attribute of Nipype::Workflow class). Defaults to None.
-            parameters (dict, optional): Pipeline parameters. Defaults to {}.
-            name (str, optional): Pipeline name. Defaults to None.
+        Parameters
+        ----------
+        bids_directory : str, optional
+            Path to a BIDS directory. Defaults to None.
 
-        Raises:
-            RuntimeError: [description]
+        caps_directory : str, optional
+            Path to a CAPS directory. Defaults to None.
+
+        tsv_file : str, optional
+            Path to a subjects-sessions `.tsv` file. Defaults to None.
+
+        overwrite_caps : bool, optional
+            Overwrite or not output directory. Defaults to False.
+
+        base_dir : str, optional
+            Working directory (attribute of Nipype::Workflow class). Defaults to None.
+
+        parameters : dict, optional
+            Pipeline parameters. Defaults to {}.
+
+        name : str, optional
+            Pipeline name. Defaults to None.
+
+        Raises
+        ------
+        RuntimeError: [description]
         """
         import inspect
         import os
+        from pathlib import Path
         from tempfile import mkdtemp
 
         from clinica.utils.inputs import check_bids_folder, check_caps_folder
         from clinica.utils.participant import get_subject_session_list
 
-        self._is_built = False
-        self._overwrite_caps = overwrite_caps
-        self._bids_directory = bids_directory
-        self._caps_directory = caps_directory
-        self._verbosity = "debug"
-        self._tsv_file = tsv_file
-        self._info_file = os.path.join(
-            os.path.dirname(os.path.abspath(inspect.getfile(self.__class__))),
-            "info.json",
+        self._is_built: bool = False
+        self._overwrite_caps: bool = overwrite_caps
+        self._bids_directory: Path = Path(bids_directory).absolute()
+        self._caps_directory: Path = Path(caps_directory).absolute()
+        self._verbosity: str = "debug"
+        self._tsv_file = Path(tsv_file).absolute()
+        self._info_file: Path = (
+            Path(os.path.dirname(os.path.abspath(inspect.getfile(self.__class__))))
+            / "info.json"
         )
-        self._info = {}
+        self._info: dict = {}
 
         if base_dir:
-            self.base_dir = base_dir
+            self.base_dir = Path(base_dir).absolute()
             self._base_dir_was_specified = True
         else:
-            self.base_dir = mkdtemp()
+            self.base_dir = Path(mkdtemp())
             self._base_dir_was_specified = False
 
         self._name = name or self.__class__.__name__
-        self._parameters = parameters
+        self._parameters = parameters or {}
 
         if not self._bids_directory:
             if not self._caps_directory:
@@ -205,11 +473,91 @@ class Pipeline(Workflow):
             use_session_tsv=False,
             tsv_dir=base_dir,
         )
+        self._input_node = None
+        self._output_node = None
+        self._init_nodes()
 
+    @property
+    def base_dir_was_specified(self) -> bool:
+        return self._base_dir_was_specified
+
+    @property
+    def is_built(self) -> bool:
+        return self._is_built
+
+    @is_built.setter
+    def is_built(self, value: bool):
+        self._is_built = value
+
+    @property
+    def overwrite_caps(self) -> bool:
+        return self._overwrite_caps
+
+    @property
+    def parameters(self) -> dict:
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, value: dict):
+        self._parameters = value
+        # Need to rebuild input, output and core nodes
+        self.is_built = False
         self.init_nodes()
 
+    @property
+    def info(self) -> dict:
+        return self._info
+
+    @info.setter
+    def info(self, value: dict):
+        self._info = value
+
+    @property
+    def input_node(self) -> Node:
+        return self._input_node
+
+    @property
+    def output_node(self) -> Node:
+        return self._output_node
+
+    @property
+    def bids_directory(self) -> Path:
+        return self._bids_directory
+
+    @property
+    def caps_directory(self) -> Path:
+        return self._caps_directory
+
+    @property
+    def subjects(self) -> List[str]:
+        return self._subjects
+
+    @subjects.setter
+    def subjects(self, value: List[str]):
+        self._subjects = value
+        self.is_built = False
+
+    @property
+    def sessions(self) -> List[str]:
+        return self._sessions
+
+    @sessions.setter
+    def sessions(self, value: List[str]):
+        self._sessions = value
+        self.is_built = False
+
+    @property
+    def tsv_file(self) -> Path:
+        return self._tsv_file
+
+    @property
+    def info_file(self) -> Path:
+        return self._info_file
+
     @staticmethod
-    def get_processed_images(caps_directory, subjects, sessions):
+    def get_processed_images(
+        caps_directory: Path, subjects: List[str], sessions: List[str]
+    ) -> List[str]:
         """Extract processed image IDs in `caps_directory` based on `subjects`_`sessions`.
 
         Todo:
@@ -225,58 +573,57 @@ class Pipeline(Workflow):
             "Implementation on which image(s) failed will appear soon."
         )
 
-    def init_nodes(self):
+    def _init_nodes(self) -> None:
         """Init the basic workflow and I/O nodes necessary before build."""
-        import nipype.interfaces.utility as nutil
-        import nipype.pipeline.engine as npe
-
-        if self.get_input_fields():
-            self._input_node = npe.Node(
-                name="Input",
-                interface=nutil.IdentityInterface(
-                    fields=self.get_input_fields(), mandatory_inputs=False
-                ),
-            )
-        else:
-            self._input_node = None
-
-        if self.get_output_fields():
-            self._output_node = npe.Node(
-                name="Output",
-                interface=nutil.IdentityInterface(
-                    fields=self.get_output_fields(), mandatory_inputs=False
-                ),
-            )
-        else:
-            self._output_node = None
-
+        self._init_input_node()
+        self._init_output_node()
         Workflow.__init__(self, self._name, self.base_dir)
         if self.input_node:
             self.add_nodes([self.input_node])
         if self.output_node:
             self.add_nodes([self.output_node])
 
-    def has_input_connections(self):
+    def _init_input_node(self) -> None:
+        if self.get_input_fields():
+            self._input_node = Node(
+                name="Input",
+                interface=IdentityInterface(
+                    fields=self.get_input_fields(), mandatory_inputs=False
+                ),
+            )
+
+    def _init_output_node(self) -> None:
+        if self.get_output_fields():
+            self._output_node = Node(
+                name="Output",
+                interface=IdentityInterface(
+                    fields=self.get_output_fields(), mandatory_inputs=False
+                ),
+            )
+
+    def has_input_connections(self) -> bool:
         """Checks if the Pipeline's input node has been connected.
 
-        Returns:
+        Returns
+        -------
+        bool :
             True if the input node is connected, False otherwise.
         """
         if self.input_node:
             return self._graph.in_degree(self.input_node) > 0
-        else:
-            return False
+        return False
 
-    def has_output_connections(self):
+    def has_output_connections(self) -> bool:
         """Checks if the Pipeline's output node has been connected.
 
-        Returns:
+        Returns
+        -------
+        bool :
             True if the output node is connected, False otherwise.
         """
         if self.output_node:
             return self._graph.out_degree(self.output_node) > 0
-        else:
-            return False
+        return False
 
     @postset("is_built", True)
     def build(self):
@@ -289,20 +636,27 @@ class Pipeline(Workflow):
         Since this method returns the concerned object, it can be chained to
         any other method of the Pipeline class.
 
-        Returns:
-            self: A Pipeline object.
+        Returns
+        -------
+        self: A Pipeline object.
         """
         if not self.is_built:
-            self.check_dependencies()
-            self.check_pipeline_parameters()
+            self._check_dependencies()
+            self._check_pipeline_parameters()
             if not self.has_input_connections():
-                self.build_input_node()
+                self._build_input_node()
             self.build_core_nodes()
             if not self.has_output_connections():
-                self.build_output_node()
+                self._build_output_node()
         return self
 
-    def run(self, plugin=None, plugin_args=None, update_hash=False, bypass_check=False):
+    def run(
+        self,
+        plugin=None,
+        plugin_args=None,
+        update_hash: bool = False,
+        bypass_check: bool = False,
+    ):
         """Executes the Pipeline.
 
         It overwrites the default Workflow method to check if the
@@ -327,11 +681,11 @@ class Pipeline(Workflow):
 
         if not self.is_built:
             self.build()
-        self.check_not_cross_sectional()
+        self._check_not_cross_sectional()
 
         if not bypass_check:
-            self.check_size()
-            plugin_args = self.update_parallelize_info(plugin_args)
+            self._check_size()
+            plugin_args = self._update_parallelize_info(plugin_args)
             plugin = "MultiProc"
         exec_graph = []
         try:
@@ -366,7 +720,7 @@ class Pipeline(Workflow):
             exec_graph = Graph()
         return exec_graph
 
-    def load_info(self):
+    def _load_info(self):
         """Loads the associated info.json file.
 
         Todo:
@@ -384,7 +738,7 @@ class Pipeline(Workflow):
             self.info = json.load(info_file)
         return self
 
-    def check_dependencies(self):
+    def _check_dependencies(self):
         """Checks if listed dependencies are present.
 
         Loads the pipelines related `info.json` file and check each one of the
@@ -425,7 +779,7 @@ class Pipeline(Workflow):
 
         # Load the info.json file
         if not self.info:
-            self.load_info()
+            self._load_info()
 
         # Dependencies checking
         for d in self.info["dependencies"]:
@@ -442,110 +796,18 @@ class Pipeline(Workflow):
                     f"Pipeline.check_dependencies() Unknown dependency type: '{d['type']}'."
                 )
 
-        self.check_custom_dependencies()
+        self._check_custom_dependencies()
 
         return self
 
-    def check_size(self):
+    def _check_size(self):
         """Check if the pipeline has enough space on the disk for both working directory and CAPS."""
-        import select
         import sys
         from os import statvfs
         from os.path import dirname
 
         from clinica.utils.stream import cprint
 
-        SYMBOLS = {
-            "customary": ("B", "K", "M", "G", "T", "P", "E", "Z", "Y"),
-            "customary_ext": (
-                "byte",
-                "kilo",
-                "mega",
-                "giga",
-                "tera",
-                "peta",
-                "exa",
-                "zetta",
-                "iotta",
-            ),
-            "iec": ("Bi", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"),
-            "iec_ext": (
-                "byte",
-                "kibi",
-                "mebi",
-                "gibi",
-                "tebi",
-                "pebi",
-                "exbi",
-                "zebi",
-                "yobi",
-            ),
-        }
-
-        def bytes2human(n, format="%(value).1f %(symbol)s", symbols="customary"):
-            """
-            Convert n bytes into a human readable string based on format.
-            Symbols can be either "customary", "customary_ext", "iec" or "iec_ext",
-            see: http://goo.gl/kTQMs
-
-            License:
-            Bytes-to-human / human-to-bytes converter.
-            Based on: http://goo.gl/kTQMs
-            Working with Python 2.x and 3.x.
-            Author: Giampaolo Rodola' <g.rodola [AT] gmail [DOT] com>
-            License: MIT
-            """
-            n = int(n)
-            if n < 0:
-                raise ValueError("n < 0")
-            symbols = SYMBOLS[symbols]
-            prefix = {}
-            for i, s in enumerate(symbols[1:]):
-                prefix[s] = 1 << (i + 1) * 10
-            for symbol in reversed(symbols[1:]):
-                if n >= prefix[symbol]:
-                    value = float(n) / prefix[symbol]
-                    return format % locals()
-            return format % dict(symbol=symbols[0], value=n)
-
-        def human2bytes(s):
-            """
-            Attempts to guess the string format based on default symbols
-            set and return the corresponding bytes as an integer.
-            When unable to recognize the format ValueError is raised.
-
-            License:
-            Bytes-to-human / human-to-bytes converter.
-            Based on: http://goo.gl/kTQMs
-            Working with Python 2.x and 3.x.
-            Author: Giampaolo Rodola' <g.rodola [AT] gmail [DOT] com>
-            License: MIT
-            """
-            init = s
-            num = ""
-            while s and s[0:1].isdigit() or s[0:1] == ".":
-                num += s[0]
-                s = s[1:]
-            num = float(num)
-            letter = s.strip()
-            for name, sset in SYMBOLS.items():
-                if letter in sset:
-                    break
-            else:
-                if letter == "k":
-                    # treat 'k' as an alias for 'K' as per: http://goo.gl/kTQMs
-                    sset = SYMBOLS["customary"]
-                    letter = letter.upper()
-                else:
-                    raise ValueError("can't interpret %r" % init)
-            prefix = {sset[0]: 1}
-            for i, s in enumerate(sset[1:]):
-                prefix[s] = 1 << (i + 1) * 10
-            return int(num * prefix[letter])
-
-        timeout = 15
-
-        # Get the number of sessions
         n_sessions = len(self.subjects)
         try:
             caps_stat = statvfs(self.caps_directory)
@@ -561,32 +823,32 @@ class Pipeline(Workflow):
         try:
             space_needed_caps_1_session = self.info["space_caps"]
             space_needed_wd_1_session = self.info["space_wd"]
-            space_needed_caps = n_sessions * human2bytes(space_needed_caps_1_session)
-            space_needed_wd = n_sessions * human2bytes(space_needed_wd_1_session)
+            space_needed_caps = n_sessions * _human2bytes(space_needed_caps_1_session)
+            space_needed_wd = n_sessions * _human2bytes(space_needed_wd_1_session)
             error = ""
             if free_space_caps == free_space_wd:
                 if space_needed_caps + space_needed_wd > free_space_wd:
                     # We assume this is the same disk
                     error = (
                         f"{error}Space needed for CAPS and working directory ("
-                        f"{bytes2human(space_needed_caps + space_needed_wd)}"
+                        f"{_bytes2human(space_needed_caps + space_needed_wd)}"
                         f") is greater than what is left on your hard drive ("
-                        f"{bytes2human(free_space_wd)})"
+                        f"{_bytes2human(free_space_wd)})"
                     )
             else:
                 if space_needed_caps > free_space_caps:
                     error = (
                         f"{error} Space needed for CAPS ("
-                        f"{bytes2human(space_needed_caps)}"
+                        f"{_bytes2human(space_needed_caps)}"
                         f") is greater than what is left on your hard drive ("
-                        f"{bytes2human(free_space_caps)})\n"
+                        f"{_bytes2human(free_space_caps)})\n"
                     )
                 if space_needed_wd > free_space_wd:
                     error = (
                         f"{error}Space needed for working_directory ("
-                        f"{bytes2human(space_needed_wd)}"
+                        f"{_bytes2human(space_needed_wd)}"
                         f") is greater than what is left on your hard drive ("
-                        f"{bytes2human(free_space_wd)})\n"
+                        f"{_bytes2human(free_space_wd)})\n"
                     )
             if error:
                 cprint(msg=f"[SpaceError] {error}", lvl="error")
@@ -599,26 +861,18 @@ class Pipeline(Workflow):
         except KeyError:
             cprint("No info on how much size the pipeline takes. Running anyway...")
 
-    def update_parallelize_info(self, plugin_args):
+    def _update_parallelize_info(self, plugin_args: Optional[dict]) -> dict:
         """Performs some checks of the number of threads given in parameters,
         given the number of CPUs of the machine in which clinica is running.
         We force the use of plugin MultiProc
 
-        Author: Arnaud Marcoux"""
-        import select
-        import sys
+        Author: Arnaud Marcoux
+        """
         from multiprocessing import cpu_count
 
         from clinica.utils.stream import cprint
 
-        # count number of CPUs
         n_cpu = cpu_count()
-        # timeout value: max time allowed to decide how many thread
-        # to run in parallel (sec)
-        timeout = 15
-
-        # Use this var to know in the end if we need to ask the user
-        # an other number
         ask_user = False
 
         try:
@@ -665,267 +919,51 @@ class Pipeline(Workflow):
 
         return plugin_args
 
-    def check_not_cross_sectional(self):
+    def _check_not_cross_sectional(self):
         """
-        This function checks if the dataset is longitudinal. If it is cross
-        sectional, clinica proposes to convert it in a clinica compliant form.
+        This function checks if the dataset is longitudinal.
+
+        If it is cross-sectional, clinica proposes to convert it in a clinica compliant form.
 
         author: Arnaud Marcoux
         """
         import sys
-        from os import listdir
-        from os.path import abspath, basename, dirname, isdir, join
 
         from clinica.utils.exceptions import ClinicaInconsistentDatasetError
         from clinica.utils.stream import cprint
 
-        def _check_cross_subj(cross_subj: list) -> None:
-            if len(cross_subj) > 0:
-                raise ClinicaInconsistentDatasetError(cross_subj)
-
-        def convert_cross_sectional(bids_in, bids_out, cross_subjects, long_subjects):
-            """
-            This function converts a cross-sectional-bids dataset into a
-            longitudinal clinica-compliant dataset
-
-            Args:
-                bids_in: cross sectional bids dataset you want to convert
-                bids_out: converted longitudinal bids dataset
-                cross_subjects: list of subjects in cross sectional form
-                (they need some adjustment)
-                long_subjects: list of subjects in longitudinal form (they
-                just need to be copied)
-
-            Returns:
-                nothing
-            """
-            from os import mkdir
-            from os.path import exists, isfile
-            from shutil import copy2, copytree
-
-            def add_ses(f):
-                """
-                Use this function to transform a cross sectional filename into
-                a longitudinal one.
-                Examples:
-                sub-ADNI001_scans.tsv -> sub-ADNI001_ses-M000_scans.tsv
-                sub-023a_ses-M012_T1w.nii.gz -> sub-023a_ses-M012_T1w.nii.gz (no
-                    modification done if filename already has a session)
-
-                Args:
-                    f: filename
-
-                Returns:
-                    filename with '_ses-M000_ added just after participant_id
-                """
-                import re
-
-                # If filename contains ses-..., returns the original filename
-                # Regex explication:
-                # ^ start of string
-                # ([a-zA-Z0-9]*) matches any number of characters from a to z,
-                #       A to Z, 0 to 9, and store it in group(1)
-                # (?!ses-[a-zA-Z0-9]) do not match if there is already a 'ses-'
-                # (.*) catches the rest of the string
-                m = re.search(r"(^sub-[a-zA-Z0-9]*)_(?!ses-[a-zA-Z0-9])(.*)", f)
-                try:
-                    return m.group(1) + "_ses-M000_" + m.group(2)
-                except AttributeError:
-                    # If something goes wrong, we return the original filename
-                    return f
-
-            def copy2_add_ses(src, dst):
-                """
-                copy2_add_ses calls copy2 function from shutil, but modifies
-                the filename of the copied files if they match the regex
-                template described in add_ses() function
-
-                Args:
-                    src: path to the file that needs to be copied
-                    dst: original destination for the copied file
-
-                Returns:
-                    copy2 with modified filename
-                """
-                from os.path import basename, dirname, join
-                from shutil import copy2
-
-                dst_modified = join(dirname(dst), add_ses(basename(src)))
-                return copy2(src, dst_modified)
-
-            if not exists(bids_out):
-                # Create the output folder if it does not exists yet
-                mkdir(bids_out)
-
-            # First part of the algorithm: deal with subjects that does not
-            # have longitudinal (session) information
-            for subj in cross_subjects:
-                # Get list of of files/folders to copy. Remove hidden element
-                # ( if they start with a dot '.')
-                to_copy = [
-                    f for f in listdir(join(bids_in, subj)) if not f.startswith(".")
-                ]
-                # Always check that folder are existing, otherwise an exception
-                # is raised even though that does not prevent the function from
-                # working
-                if not exists(join(bids_out, subj)):
-                    mkdir(join(bids_out, subj))
-                if not exists(join(bids_out, subj, "ses-M000")):
-                    mkdir(join(bids_out, subj, "ses-M000"))
-                for el in to_copy:
-                    path_el = join(bids_in, subj, el)
-                    if not exists(join(bids_out, subj, "ses-M000", el)):
-                        # If the element to copy is a folder...
-                        if isdir(path_el):
-                            # Copytree is used with a 'custom' copy function,
-                            # to give a correct filemename to the files inside
-                            # the copied folders
-                            copytree(
-                                path_el,
-                                join(bids_out, subj, "ses-M000", basename(path_el)),
-                                copy_function=copy2_add_ses,
-                            )
-                        # If the element to copy is a file...
-                        elif isfile(path_el):
-                            # Modify the filename with add_ses function
-                            new_filename_wo_ses = add_ses(el)
-                            copy2(
-                                path_el,
-                                join(bids_out, subj, "ses-M000", new_filename_wo_ses),
-                            )
-            # Second part of the algorithm: deal with subjects that do not
-            # have the problem. We only xopy the content of the folder, and no
-            # filename needs to be changed
-            for su in long_subjects:
-                # Do not copy hidden files
-                to_copy = [
-                    f for f in listdir(join(bids_in, su)) if not f.startswith(".")
-                ]
-                if not exists(join(bids_out, su)):
-                    mkdir(join(bids_out, su))
-                for el in to_copy:
-                    path_el = join(bids_in, su, el)
-                    if not exists(join(bids_out, su, el)):
-                        # 2 possible cases: element to pcopy is a folder or a
-                        # file
-                        if isdir(path_el):
-                            copytree(path_el, join(bids_out, su, basename(path_el)))
-                        elif isfile(path_el):
-                            copy2(path_el, join(bids_out, su))
-
-        if self.bids_directory is not None:
-            bids_dir = abspath(self.bids_directory)
-            # Extract all subjects in BIDS directory: element must be a folder and
-            # a name starting with 'sub-'
-            all_subs = [
-                f
-                for f in listdir(bids_dir)
-                if isdir(join(bids_dir, f)) and f.startswith("sub-")
-            ]
-
-            cross_subj, long_subj = detect_cross_sectional_and_longitudinal_subjects(
-                all_subs, bids_dir
+        if self.bids_directory is None:
+            return
+        all_subs = [
+            f.name
+            for f in self.bids_directory.iterdir()
+            if (self.bids_directory / f).is_dir() and f.name.startswith("sub-")
+        ]
+        cross_subj, long_subj = _detect_cross_sectional_and_longitudinal_subjects(
+            all_subs, self.bids_directory
+        )
+        try:
+            _check_cross_subj(cross_subj)
+        except ClinicaInconsistentDatasetError as e:
+            cprint(e, lvl="warning")
+            proposed_bids = (
+                self.bids_directory / f"{self.bids_directory.name}_clinica_compliant"
             )
-            try:
-                _check_cross_subj(cross_subj)
-            except ClinicaInconsistentDatasetError as e:
-                cprint(e, lvl="warning")
-                proposed_bids = join(
-                    dirname(bids_dir), basename(bids_dir) + "_clinica_compliant"
+            if not click.confirm(
+                "Do you want to proceed with the conversion in another folder? "
+                "(Your original BIDS folder will not be modified "
+                f"and the folder {proposed_bids} will be created.)"
+            ):
+                click.echo("Clinica will now exit...")
+                sys.exit()
+            else:
+                cprint("Converting cross-sectional dataset into longitudinal...")
+                _convert_cross_sectional(
+                    self.bids_directory, proposed_bids, cross_subj, long_subj
                 )
-
-                if not click.confirm(
-                    "Do you want to proceed with the conversion in another "
-                    "folder? (Your original BIDS folder will not be modified "
-                    f"and the folder {proposed_bids} will be created.)"
-                ):
-                    click.echo("Clinica will now exit...")
-                    sys.exit()
-                else:
-                    cprint("Converting cross-sectional dataset into longitudinal...")
-                    convert_cross_sectional(
-                        bids_dir, proposed_bids, cross_subj, long_subj
-                    )
-                    cprint(
-                        f"Conversion succeeded. Your clinica-compliant dataset is located here: {proposed_bids}"
-                    )
-
-    @property
-    def base_dir_was_specified(self):
-        return self._base_dir_was_specified
-
-    @property
-    def is_built(self):
-        return self._is_built
-
-    @is_built.setter
-    def is_built(self, value):
-        self._is_built = value
-
-    @property
-    def overwrite_caps(self):
-        return self._overwrite_caps
-
-    @property
-    def parameters(self):
-        return self._parameters
-
-    @parameters.setter
-    def parameters(self, value):
-        self._parameters = value
-        # Need to rebuild input, output and core nodes
-        self.is_built = False
-        self.init_nodes()
-
-    @property
-    def info(self):
-        return self._info
-
-    @info.setter
-    def info(self, value):
-        self._info = value
-
-    @property
-    def input_node(self):
-        return self._input_node
-
-    @property
-    def output_node(self):
-        return self._output_node
-
-    @property
-    def bids_directory(self):
-        return self._bids_directory
-
-    @property
-    def caps_directory(self):
-        return self._caps_directory
-
-    @property
-    def subjects(self):
-        return self._subjects
-
-    @subjects.setter
-    def subjects(self, value):
-        self._subjects = value
-        self.is_built = False
-
-    @property
-    def sessions(self):
-        return self._sessions
-
-    @sessions.setter
-    def sessions(self, value):
-        self._sessions = value
-        self.is_built = False
-
-    @property
-    def tsv_file(self):
-        return self._tsv_file
-
-    @property
-    def info_file(self):
-        return self._info_file
+                cprint(
+                    f"Conversion succeeded. Your clinica-compliant dataset is located here: {proposed_bids}"
+                )
 
     @abc.abstractmethod
     def build_core_nodes(self):
@@ -955,7 +993,7 @@ class Pipeline(Workflow):
         """
 
     @abc.abstractmethod
-    def get_input_fields(self):
+    def get_input_fields(self) -> List[str]:
         """Lists the input fields of the Pipeline.
 
         Returns:
@@ -964,7 +1002,7 @@ class Pipeline(Workflow):
         """
 
     @abc.abstractmethod
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Lists the output fields of the Pipeline.
 
         Returns:
@@ -973,16 +1011,16 @@ class Pipeline(Workflow):
         """
 
     @abc.abstractmethod
-    def check_custom_dependencies(self):
+    def _check_custom_dependencies(self) -> None:
         """Check dependencies provided by the developer."""
 
     @abc.abstractmethod
-    def check_pipeline_parameters(self):
+    def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
 
 
 class PETPipeline(Pipeline):
-    def check_pipeline_parameters(self):
+    def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
         if "acq_label" not in self.parameters.keys():
             raise KeyError("Missing compulsory acq_label key in pipeline parameter.")
@@ -1004,3 +1042,37 @@ class PETPipeline(Pipeline):
             )
 
         return bids_pet_nii(pet_tracer, reconstruction_method)
+
+
+class DWIPreprocessingPipeline(Pipeline):
+    def _check_pipeline_parameters(self) -> None:
+        """Check pipeline parameters."""
+        from clinica.utils.stream import cprint
+
+        self.parameters.setdefault("low_bval", 5)
+        low_bval = self.parameters["low_bval"]
+        if low_bval < 0:
+            raise ValueError(
+                f"The low_bval is negative ({low_bval}): it should be zero or close to zero."
+            )
+        if self.parameters["low_bval"] > 100:
+            cprint(
+                f"The low_bval parameter is {low_bval}: it should be close to zero.",
+                lvl="warning",
+            )
+        self.parameters.setdefault("use_cuda", False)
+        self.parameters.setdefault("initrand", False)
+
+    def _check_custom_dependencies(self) -> None:
+        """Check dependencies that can not be listed in the `info.json` file."""
+        from clinica.utils.check_dependency import is_binary_present
+        from clinica.utils.exceptions import ClinicaMissingDependencyError
+
+        if self.parameters["use_cuda"]:
+            if not is_binary_present("eddy_cuda"):
+                raise ClinicaMissingDependencyError(
+                    "[Error] FSL eddy with CUDA was set but Clinica could "
+                    "not find eddy_cuda in your PATH environment. Check that "
+                    "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/eddy/UsersGuide#The_eddy_executables "
+                    "is correctly set."
+                )

--- a/clinica/pipelines/engine.py
+++ b/clinica/pipelines/engine.py
@@ -432,10 +432,14 @@ class Pipeline(Workflow):
 
         self._is_built: bool = False
         self._overwrite_caps: bool = overwrite_caps
-        self._bids_directory: Path = Path(bids_directory).absolute()
-        self._caps_directory: Path = Path(caps_directory).absolute()
+        self._bids_directory: Optional[Path] = (
+            Path(bids_directory).absolute() if bids_directory else None
+        )
+        self._caps_directory: Optional[Path] = (
+            Path(caps_directory).absolute() if caps_directory else None
+        )
         self._verbosity: str = "debug"
-        self._tsv_file = Path(tsv_file).absolute()
+        self._tsv_file: Optional[Path] = Path(tsv_file).absolute() if tsv_file else None
         self._info_file: Path = (
             Path(os.path.dirname(os.path.abspath(inspect.getfile(self.__class__))))
             / "info.json"
@@ -521,11 +525,11 @@ class Pipeline(Workflow):
         return self._output_node
 
     @property
-    def bids_directory(self) -> Path:
+    def bids_directory(self) -> Optional[Path]:
         return self._bids_directory
 
     @property
-    def caps_directory(self) -> Path:
+    def caps_directory(self) -> Optional[Path]:
         return self._caps_directory
 
     @property
@@ -547,7 +551,7 @@ class Pipeline(Workflow):
         self.is_built = False
 
     @property
-    def tsv_file(self) -> Path:
+    def tsv_file(self) -> Optional[Path]:
         return self._tsv_file
 
     @property

--- a/clinica/pipelines/engine.py
+++ b/clinica/pipelines/engine.py
@@ -966,7 +966,7 @@ class Pipeline(Workflow):
                 )
 
     @abc.abstractmethod
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Builds the Pipeline's core nodes.
 
         This method should use and connect to the `Pipeline.input_node` one
@@ -975,7 +975,7 @@ class Pipeline(Workflow):
         """
 
     @abc.abstractmethod
-    def build_input_node(self):
+    def _build_input_node(self):
         """Builds the Pipeline's input data stream node.
 
         Warnings:
@@ -984,7 +984,7 @@ class Pipeline(Workflow):
         """
 
     @abc.abstractmethod
-    def build_output_node(self):
+    def _build_output_node(self):
         """Builds the Pipeline's output data stream node.
 
         Warnings:

--- a/clinica/pipelines/engine.py
+++ b/clinica/pipelines/engine.py
@@ -645,7 +645,7 @@ class Pipeline(Workflow):
             self._check_pipeline_parameters()
             if not self.has_input_connections():
                 self._build_input_node()
-            self.build_core_nodes()
+            self._build_core_nodes()
             if not self.has_output_connections():
                 self._build_output_node()
         return self

--- a/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
+++ b/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
@@ -146,14 +146,20 @@ class SpatialSVM(Pipeline):
         read_parameters_node.inputs.dartel_input = dartel_input
         read_parameters_node.inputs.input_image = input_image
 
-        # fmt: off
         self.connect(
             [
-                (read_parameters_node, self.input_node, [("dartel_input", "dartel_input")]),
-                (read_parameters_node, self.input_node, [("input_image", "input_image")]),
+                (
+                    read_parameters_node,
+                    self.input_node,
+                    [("dartel_input", "dartel_input")],
+                ),
+                (
+                    read_parameters_node,
+                    self.input_node,
+                    [("input_image", "input_image")],
+                ),
             ]
         )
-        # fmt: on
 
     def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
@@ -199,7 +205,7 @@ class SpatialSVM(Pipeline):
         heat_solver_equation.inputs.FWHM = self.parameters["fwhm"]
 
         datasink = npe.Node(nio.DataSink(), name="sinker")
-        datasink.inputs.base_directory = self.caps_directory
+        datasink.inputs.base_directory = str(self.caps_directory)
         datasink.inputs.parameterization = True
         if self.parameters["orig_input_data_ml"] == "t1-volume":
             datasink.inputs.regexp_substitutions = [
@@ -252,21 +258,49 @@ class SpatialSVM(Pipeline):
                     + r"_space-Ixi549Space_gram.npy",
                 ),
             ]
-        # Connection
-        # ==========
-        # fmt: off
         self.connect(
             [
-                (self.input_node, fisher_tensor_generation, [("dartel_input", "dartel_input")]),
-                (fisher_tensor_generation, time_step_generation, [("fisher_tensor", "g")]),
-                (self.input_node, time_step_generation, [("dartel_input", "dartel_input")]),
-                (self.input_node, heat_solver_equation, [("input_image", "input_image")]),
-                (fisher_tensor_generation, heat_solver_equation, [("fisher_tensor", "g")]),
+                (
+                    self.input_node,
+                    fisher_tensor_generation,
+                    [("dartel_input", "dartel_input")],
+                ),
+                (
+                    fisher_tensor_generation,
+                    time_step_generation,
+                    [("fisher_tensor", "g")],
+                ),
+                (
+                    self.input_node,
+                    time_step_generation,
+                    [("dartel_input", "dartel_input")],
+                ),
+                (
+                    self.input_node,
+                    heat_solver_equation,
+                    [("input_image", "input_image")],
+                ),
+                (
+                    fisher_tensor_generation,
+                    heat_solver_equation,
+                    [("fisher_tensor", "g")],
+                ),
                 (time_step_generation, heat_solver_equation, [("t_step", "t_step")]),
-                (self.input_node, heat_solver_equation, [("dartel_input", "dartel_input")]),
-                (fisher_tensor_generation, datasink, [("fisher_tensor_path", "fisher_tensor_path")]),
+                (
+                    self.input_node,
+                    heat_solver_equation,
+                    [("dartel_input", "dartel_input")],
+                ),
+                (
+                    fisher_tensor_generation,
+                    datasink,
+                    [("fisher_tensor_path", "fisher_tensor_path")],
+                ),
                 (time_step_generation, datasink, [("json_file", "json_file")]),
-                (heat_solver_equation, datasink, [("regularized_image", "regularized_image")]),
+                (
+                    heat_solver_equation,
+                    datasink,
+                    [("regularized_image", "regularized_image")],
+                ),
             ]
         )
-        # fmt: on

--- a/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
+++ b/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
@@ -1,49 +1,52 @@
-import clinica.pipelines.engine as cpe
+from typing import List
+
+from clinica.pipelines.engine import Pipeline
 
 
-class SpatialSVM(cpe.Pipeline):
+class SpatialSVM(Pipeline):
     """SpatialSVM - Prepare input data for SVM with spatial and anatomical regularization.
 
     Returns:
         A clinica pipeline object containing the SpatialSVM pipeline.
     """
 
-    def check_pipeline_parameters(self):
+    def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
         from clinica.utils.group import check_group_label
 
-        # Clinica compulsory parameters
         self.parameters.setdefault("group_label", None)
         check_group_label(self.parameters["group_label"])
-
         if "orig_input_data_ml" not in self.parameters.keys():
             raise KeyError(
                 "Missing compulsory orig_input_data key in pipeline parameter."
             )
-
         # Optional parameters for inputs from pet-volume pipeline
         self.parameters.setdefault("acq_label", None)
         self.parameters.setdefault("suvr_reference_region", None)
         self.parameters.setdefault("use_pvc_data", False)
-
         # Advanced parameters
         self.parameters.setdefault("fwhm", 4)
 
-    def check_custom_dependencies(self):
+    def _check_custom_dependencies(self) -> None:
         """Check dependencies that can not be listed in the `info.json` file."""
+        pass
 
-    def get_input_fields(self):
+    def get_input_fields(self) -> List[str]:
         """Specify the list of possible inputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) input fields name.
         """
         return ["dartel_input", "input_image"]
 
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Specify the list of possible outputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list fo str :
             A list of (string) output fields name.
         """
         return ["regularized_image"]
@@ -63,12 +66,9 @@ class SpatialSVM(cpe.Pipeline):
         from clinica.utils.inputs import clinica_file_reader, clinica_group_reader
         from clinica.utils.ux import print_groups_in_caps_directory
 
-        # Check that group already exists
-        if not os.path.exists(
-            os.path.join(
-                self.caps_directory, "groups", "group-" + self.parameters["group_label"]
-            )
-        ):
+        if not (
+            self.caps_directory / "groups" / f"group-{self.parameters['group_label']}"
+        ).exists():
             print_groups_in_caps_directory(self.caps_directory)
             raise ClinicaException(
                 f"Group {self.parameters['group_label']} does not exist. "
@@ -157,6 +157,7 @@ class SpatialSVM(cpe.Pipeline):
 
     def build_output_node(self):
         """Build and connect an output node to the pipeline."""
+        pass
 
     def build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""

--- a/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
+++ b/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
@@ -51,7 +51,7 @@ class SpatialSVM(Pipeline):
         """
         return ["regularized_image"]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         import os
 
@@ -155,11 +155,11 @@ class SpatialSVM(Pipeline):
         )
         # fmt: on
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         pass
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.io as nio
         import nipype.interfaces.utility as nutil

--- a/clinica/pipelines/pet_linear/pet_linear_pipeline.py
+++ b/clinica/pipelines/pet_linear/pet_linear_pipeline.py
@@ -167,7 +167,6 @@ class PETLinear(PETPipeline):
             synchronize=True,
             interface=nutil.IdentityInterface(fields=self.get_input_fields()),
         )
-        # fmt: off
         self.connect(
             [
                 (read_input_node, self.input_node, [("t1w", "t1w")]),
@@ -175,7 +174,6 @@ class PETLinear(PETPipeline):
                 (read_input_node, self.input_node, [("t1w_to_mni", "t1w_to_mni")]),
             ]
         )
-        # fmt: on
 
     def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
@@ -187,12 +185,10 @@ class PETLinear(PETPipeline):
 
         from .pet_linear_utils import rename_into_caps
 
-        # Writing node
         write_node = npe.Node(name="WriteCaps", interface=DataSink())
-        write_node.inputs.base_directory = self.caps_directory
+        write_node.inputs.base_directory = str(self.caps_directory)
         write_node.inputs.parameterization = False
 
-        # Other nodes
         rename_file_node_inputs = [
             "pet_filename_bids",
             "pet_filename_raw",
@@ -228,38 +224,72 @@ class PETLinear(PETPipeline):
             ),
             name="containerPath",
         )
-        # fmt: off
         self.connect(
             [
                 (self.input_node, container_path, [("pet", "bids_or_caps_filename")]),
-                (container_path, write_node, [(("container", fix_join, "pet_linear"), "container")]),
+                (
+                    container_path,
+                    write_node,
+                    [(("container", fix_join, "pet_linear"), "container")],
+                ),
                 (self.input_node, rename_files, [("pet", "pet_filename_bids")]),
-                (self.output_node, rename_files, [("affine_mat", "transformation_filename_raw")]),
-                (rename_files, write_node, [("transformation_filename_caps", "@transform_mat")]),
+                (
+                    self.output_node,
+                    rename_files,
+                    [("affine_mat", "transformation_filename_raw")],
+                ),
+                (
+                    rename_files,
+                    write_node,
+                    [("transformation_filename_caps", "@transform_mat")],
+                ),
             ]
         )
         if not (self.parameters.get("uncropped_image")):
             self.connect(
                 [
-                    (self.output_node, rename_files, [("outfile_crop", "pet_filename_raw")]),
-                    (rename_files, write_node, [("pet_filename_caps", "@registered_pet")]),
+                    (
+                        self.output_node,
+                        rename_files,
+                        [("outfile_crop", "pet_filename_raw")],
+                    ),
+                    (
+                        rename_files,
+                        write_node,
+                        [("pet_filename_caps", "@registered_pet")],
+                    ),
                 ]
             )
         else:
             self.connect(
                 [
-                    (self.output_node, rename_files, [("suvr_pet", "pet_filename_raw")]),
-                    (rename_files, write_node, [("pet_filename_caps", "@registered_pet")]),
+                    (
+                        self.output_node,
+                        rename_files,
+                        [("suvr_pet", "pet_filename_raw")],
+                    ),
+                    (
+                        rename_files,
+                        write_node,
+                        [("pet_filename_caps", "@registered_pet")],
+                    ),
                 ]
             )
         if self.parameters.get("save_PETinT1w"):
             self.connect(
                 [
-                    (self.output_node, rename_files, [("PETinT1w", "pet_filename_in_t1w_raw")]),
-                    (rename_files, write_node, [("pet_filename_in_t1w_caps", "@registered_pet_in_t1w")]),
+                    (
+                        self.output_node,
+                        rename_files,
+                        [("PETinT1w", "pet_filename_in_t1w_raw")],
+                    ),
+                    (
+                        rename_files,
+                        write_node,
+                        [("pet_filename_in_t1w_caps", "@registered_pet_in_t1w")],
+                    ),
                 ]
             )
-        # fmt: on
 
     def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
@@ -370,9 +400,6 @@ class PETLinear(PETPipeline):
         )
         ants_applytransform_optional_node.inputs.dimension = 3
 
-        # Connection
-        # ==========
-        # fmt: off
         self.connect(
             [
                 (self.input_node, init_node, [("pet", "pet")]),
@@ -380,20 +407,59 @@ class PETLinear(PETPipeline):
                 (self.input_node, ants_registration_node, [("t1w", "fixed_image")]),
                 (init_node, ants_registration_node, [("pet", "moving_image")]),
                 # STEP 2
-                (ants_registration_node, concatenate_node, [("out_matrix", "pet_to_t1w_transform")]),
-                (self.input_node, concatenate_node, [("t1w_to_mni", "t1w_to_mni_transform")]),
+                (
+                    ants_registration_node,
+                    concatenate_node,
+                    [("out_matrix", "pet_to_t1w_transform")],
+                ),
+                (
+                    self.input_node,
+                    concatenate_node,
+                    [("t1w_to_mni", "t1w_to_mni_transform")],
+                ),
                 (self.input_node, ants_applytransform_node, [("pet", "input_image")]),
-                (concatenate_node, ants_applytransform_node, [("transforms_list", "transforms")]),
+                (
+                    concatenate_node,
+                    ants_applytransform_node,
+                    [("transforms_list", "transforms")],
+                ),
                 # STEP 3
-                (self.input_node, ants_registration_nonlinear_node, [("t1w", "moving_image")]),
-                (ants_registration_nonlinear_node, ants_applytransform_nonlinear_node,
-                 [("reverse_forward_transforms", "transforms")]),
-                (ants_applytransform_node, ants_applytransform_nonlinear_node, [("output_image", "input_image")]),
-                (ants_applytransform_node, normalize_intensity_node, [("output_image", "input_img")]),
-                (ants_applytransform_nonlinear_node, normalize_intensity_node, [("output_image", "norm_img")]),
+                (
+                    self.input_node,
+                    ants_registration_nonlinear_node,
+                    [("t1w", "moving_image")],
+                ),
+                (
+                    ants_registration_nonlinear_node,
+                    ants_applytransform_nonlinear_node,
+                    [("reverse_forward_transforms", "transforms")],
+                ),
+                (
+                    ants_applytransform_node,
+                    ants_applytransform_nonlinear_node,
+                    [("output_image", "input_image")],
+                ),
+                (
+                    ants_applytransform_node,
+                    normalize_intensity_node,
+                    [("output_image", "input_img")],
+                ),
+                (
+                    ants_applytransform_nonlinear_node,
+                    normalize_intensity_node,
+                    [("output_image", "norm_img")],
+                ),
                 # Connect to DataSink
-                (ants_registration_node, self.output_node, [("out_matrix", "affine_mat")]),
-                (normalize_intensity_node, self.output_node, [("output_img", "suvr_pet")]),
+                (
+                    ants_registration_node,
+                    self.output_node,
+                    [("out_matrix", "affine_mat")],
+                ),
+                (
+                    normalize_intensity_node,
+                    self.output_node,
+                    [("output_img", "suvr_pet")],
+                ),
                 (self.input_node, print_end_message, [("pet", "pet")]),
             ]
         )
@@ -401,25 +467,51 @@ class PETLinear(PETPipeline):
         if not (self.parameters.get("uncropped_image")):
             self.connect(
                 [
-                    (normalize_intensity_node, crop_nifti_node, [("output_img", "input_img")]),
-                    (crop_nifti_node, self.output_node, [("output_img", "outfile_crop")]),
-                    (crop_nifti_node, print_end_message, [("output_img", "final_file")]),
+                    (
+                        normalize_intensity_node,
+                        crop_nifti_node,
+                        [("output_img", "input_img")],
+                    ),
+                    (
+                        crop_nifti_node,
+                        self.output_node,
+                        [("output_img", "outfile_crop")],
+                    ),
+                    (
+                        crop_nifti_node,
+                        print_end_message,
+                        [("output_img", "final_file")],
+                    ),
                 ]
             )
         else:
             self.connect(
                 [
-                    (normalize_intensity_node, print_end_message, [("output_img", "final_file")]),
+                    (
+                        normalize_intensity_node,
+                        print_end_message,
+                        [("output_img", "final_file")],
+                    ),
                 ]
             )
         # STEP 6: Optional argument
         if self.parameters.get("save_PETinT1w"):
             self.connect(
                 [
-                    (self.input_node, ants_applytransform_optional_node, [("pet", "input_image"),
-                                                                          ("t1w", "reference_image")]),
-                    (ants_registration_node, ants_applytransform_optional_node, [("out_matrix", "transforms")]),
-                    (ants_applytransform_optional_node, self.output_node, [("output_image", "PETinT1w")]),
+                    (
+                        self.input_node,
+                        ants_applytransform_optional_node,
+                        [("pet", "input_image"), ("t1w", "reference_image")],
+                    ),
+                    (
+                        ants_registration_node,
+                        ants_applytransform_optional_node,
+                        [("out_matrix", "transforms")],
+                    ),
+                    (
+                        ants_applytransform_optional_node,
+                        self.output_node,
+                        [("output_image", "PETinT1w")],
+                    ),
                 ]
             )
-        # fmt: on

--- a/clinica/pipelines/pet_linear/pet_linear_pipeline.py
+++ b/clinica/pipelines/pet_linear/pet_linear_pipeline.py
@@ -54,7 +54,7 @@ class PETLinear(PETPipeline):
             "registered_pet_in_t1w",
         ]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         from os import pardir
         from os.path import abspath, dirname, exists, join
@@ -177,7 +177,7 @@ class PETLinear(PETPipeline):
         )
         # fmt: on
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -261,7 +261,7 @@ class PETLinear(PETPipeline):
             )
         # fmt: on
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe

--- a/clinica/pipelines/pet_linear/pet_linear_pipeline.py
+++ b/clinica/pipelines/pet_linear/pet_linear_pipeline.py
@@ -1,14 +1,16 @@
 # Use hash instead of parameters for iterables folder names
 # Otherwise path will be too long and generate OSError
+from typing import List
+
 from nipype import config
 
-import clinica.pipelines.engine as cpe
+from clinica.pipelines.engine import PETPipeline
 
 cfg = dict(execution={"parameterize_dirs": False})
 config.update_config(cfg)
 
 
-class PETLinear(cpe.PETPipeline):
+class PETLinear(PETPipeline):
     """PET Linear - Affine registration of PET images to standard space.
     This preprocessing pipeline uses T1w MRI transformation into standard
     space computed in clinica t1-linear pipeline.
@@ -24,29 +26,33 @@ class PETLinear(cpe.PETPipeline):
         A clinica pipeline object containing the pet_linear pipeline.
     """
 
-    def check_custom_dependencies(self):
+    def _check_custom_dependencies(self) -> None:
         """Check dependencies that can not be listed in the `info.json` file."""
         pass
 
-    def get_input_fields(self):
+    def get_input_fields(self) -> List[str]:
         """Specify the list of possible inputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) input fields name.
         """
         return ["pet", "t1w", "t1w_to_mni"]
 
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Specify the list of possible outputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) output fields name.
         """
         return [
             "registered_pet",
             "transform_mat",
             "registered_pet_in_t1w",
-        ]  # Fill here the list
+        ]
 
     def build_input_node(self):
         """Build and connect an input node to the pipeline."""
@@ -173,7 +179,6 @@ class PETLinear(cpe.PETPipeline):
 
     def build_output_node(self):
         """Build and connect an output node to the pipeline."""
-
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
         from nipype.interfaces.io import DataSink
@@ -258,7 +263,6 @@ class PETLinear(cpe.PETPipeline):
 
     def build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
-
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
         from nipype.interfaces import ants

--- a/clinica/pipelines/pet_surface/pet_surface_pipeline.py
+++ b/clinica/pipelines/pet_surface/pet_surface_pipeline.py
@@ -46,16 +46,16 @@ class PetSurface(PETPipeline):
         """Specify the list of possible outputs of this pipeline."""
         return []
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         from clinica.utils.filemanip import save_participants_sessions
         from clinica.utils.stream import cprint
         from clinica.utils.ux import print_images_to_process
 
         if self.parameters["longitudinal"]:
-            self.build_input_node_longitudinal()
+            self._build_input_node_longitudinal()
         else:
-            self.build_input_node_cross_sectional()
+            self._build_input_node_cross_sectional()
 
         # Save subjects to process in <WD>/<Pipeline.name>/participants.tsv
         folder_participants_tsv = self.base_dir / self.name
@@ -68,7 +68,7 @@ class PetSurface(PETPipeline):
             cprint(f"List available in {folder_participants_tsv / 'participants.tsv'}")
             cprint("The pipeline will last approximately a few hours per image.")
 
-    def build_input_node_longitudinal(self):
+    def _build_input_node_longitudinal(self):
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
 
@@ -205,7 +205,7 @@ class PetSurface(PETPipeline):
         )
         # fmt: on
 
-    def build_input_node_cross_sectional(self):
+    def _build_input_node_cross_sectional(self):
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
 
@@ -336,10 +336,10 @@ class PetSurface(PETPipeline):
         )
         # fmt: on
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline.
 
         The function get_wf constructs a pipeline for one subject (in pet_surface_utils.py) and runs it.

--- a/clinica/pipelines/pet_surface/pet_surface_pipeline.py
+++ b/clinica/pipelines/pet_surface/pet_surface_pipeline.py
@@ -1,30 +1,34 @@
-import clinica.pipelines.engine as cpe
+from typing import List
+
+from clinica.pipelines.engine import PETPipeline
 
 
-class PetSurface(cpe.PETPipeline):
+class PetSurface(PETPipeline):
     """PetSurface - Surface-based processing of PET images.
 
     Returns:
         A clinica pipeline object containing the PetSurface pipeline.
     """
 
-    def check_pipeline_parameters(self):
+    def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
-        super().check_pipeline_parameters()
-        if "suvr_reference_region" not in self.parameters.keys():
-            raise KeyError(
-                "Missing compulsory suvr_reference_region key in pipeline parameter."
-            )
-        if "pvc_psf_tsv" not in self.parameters.keys():
-            raise KeyError("Missing compulsory pvc_psf_tsv key in pipeline parameter.")
+        super()._check_pipeline_parameters()
+        for mandatory in ("suvr_reference_region", "pvc_psf_tsv"):
+            if mandatory not in self.parameters:
+                raise KeyError(
+                    f"Missing compulsory {mandatory} key in pipeline parameter."
+                )
 
-    def check_custom_dependencies(self):
+    def _check_custom_dependencies(self) -> None:
         """Check dependencies that can not be listed in the `info.json` file."""
+        pass
 
-    def get_input_fields(self):
+    def get_input_fields(self) -> List[str]:
         """Specify the list of possible inputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) input fields name.
         """
         return [
@@ -38,14 +42,12 @@ class PetSurface(cpe.PETPipeline):
             "desikan_right",
         ]
 
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Specify the list of possible outputs of this pipeline."""
         return []
 
     def build_input_node(self):
         """Build and connect an input node to the pipeline."""
-        import os
-
         from clinica.utils.filemanip import save_participants_sessions
         from clinica.utils.stream import cprint
         from clinica.utils.ux import print_images_to_process
@@ -56,17 +58,14 @@ class PetSurface(cpe.PETPipeline):
             self.build_input_node_cross_sectional()
 
         # Save subjects to process in <WD>/<Pipeline.name>/participants.tsv
-        folder_participants_tsv = os.path.join(self.base_dir, self.name)
+        folder_participants_tsv = self.base_dir / self.name
         save_participants_sessions(
             self.subjects, self.sessions, folder_participants_tsv
         )
 
         if len(self.subjects):
             print_images_to_process(self.subjects, self.sessions)
-            cprint(
-                "List available in %s"
-                % os.path.join(folder_participants_tsv, "participants.tsv")
-            )
+            cprint(f"List available in {folder_participants_tsv / 'participants.tsv'}")
             cprint("The pipeline will last approximately a few hours per image.")
 
     def build_input_node_longitudinal(self):

--- a/clinica/pipelines/pet_volume/pet_volume_pipeline.py
+++ b/clinica/pipelines/pet_volume/pet_volume_pipeline.py
@@ -79,7 +79,7 @@ class PETVolume(PETPipeline):
             "pvc_atlas_statistics",
         ]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -280,7 +280,7 @@ class PETVolume(PETPipeline):
         )
         # fmt: on
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         import re
 
@@ -409,7 +409,7 @@ class PETVolume(PETPipeline):
         )
         # fmt: on
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect an output node to the pipeline."""
         import nipype.interfaces.spm as spm
         import nipype.interfaces.spm.utils as spmutils

--- a/clinica/pipelines/statistics_surface/pipeline.py
+++ b/clinica/pipelines/statistics_surface/pipeline.py
@@ -1,7 +1,9 @@
-import clinica.pipelines.engine as cpe
+from typing import List
+
+from clinica.pipelines.engine import Pipeline
 
 
-class StatisticsSurface(cpe.Pipeline):
+class StatisticsSurface(Pipeline):
     """StatisticsSurface - Surface-based mass-univariate analysis with BrainStat.
 
     See documentation at https://aramislab.paris.inria.fr/clinica/docs/public/latest/Pipelines/Stats_Surface/
@@ -14,7 +16,7 @@ class StatisticsSurface(cpe.Pipeline):
     Pipeline parameters are explained in StatisticsSurfaceCLI.define_options()
     """
 
-    def check_pipeline_parameters(self):
+    def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
         from clinica.utils.exceptions import ClinicaException
         from clinica.utils.group import check_group_label
@@ -85,21 +87,26 @@ class StatisticsSurface(cpe.Pipeline):
                     "and a custom file (use the --custom_file option)."
                 )
 
-    def check_custom_dependencies(self):
+    def _check_custom_dependencies(self) -> None:
         """Check dependencies that can not be listed in the `info.json` file."""
+        pass
 
-    def get_input_fields(self):
+    def get_input_fields(self) -> List[str]:
         """Specify the list of possible inputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) input fields name.
         """
         return []
 
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Specify the list of possible outputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) output fields name.
         """
         return ["output_dir"]

--- a/clinica/pipelines/statistics_surface/pipeline.py
+++ b/clinica/pipelines/statistics_surface/pipeline.py
@@ -111,7 +111,7 @@ class StatisticsSurface(Pipeline):
         """
         return ["output_dir"]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         from clinica.utils.exceptions import ClinicaException
         from clinica.utils.inputs import clinica_file_reader
@@ -162,7 +162,7 @@ class StatisticsSurface(Pipeline):
                 error_message += str(msg)
             raise RuntimeError(error_message)
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -193,7 +193,7 @@ class StatisticsSurface(Pipeline):
             ]
         )
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe

--- a/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
+++ b/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
@@ -83,7 +83,7 @@ class StatisticsVolume(Pipeline):
             "contrast",
         ]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -177,7 +177,7 @@ class StatisticsVolume(Pipeline):
             [(read_parameters_node, self.input_node, [("input_files", "input_files")])]
         )
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         from os.path import pardir
 
@@ -265,7 +265,7 @@ class StatisticsVolume(Pipeline):
         )
         # fmt: on
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         from os.path import dirname, join
 

--- a/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
+++ b/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
@@ -193,7 +193,7 @@ class StatisticsVolume(Pipeline):
         )
 
         datasink = npe.Node(nio.DataSink(), name="sinker")
-        datasink.inputs.base_directory = base_dir
+        datasink.inputs.base_directory = str(base_dir)
 
         datasink.inputs.parameterization = True
         if self.parameters["full_width_at_half_maximum"]:
@@ -248,22 +248,32 @@ class StatisticsVolume(Pipeline):
                 ),
             ]
 
-        datasink.inputs.tsv_file = self.tsv_file
+        datasink.inputs.tsv_file = str(self.tsv_file)
 
-        # fmt: off
         self.connect(
             [
                 (self.output_node, datasink, [("spmT_0001", "spm_results_analysis_1")]),
                 (self.output_node, datasink, [("spmT_0002", "spm_results_analysis_2")]),
                 (self.output_node, datasink, [("spm_figures", "figures")]),
-                (self.output_node, datasink, [("variance_of_error", "variance_of_error")]),
-                (self.output_node, datasink, [("resels_per_voxels", "resels_per_voxels")]),
+                (
+                    self.output_node,
+                    datasink,
+                    [("variance_of_error", "variance_of_error")],
+                ),
+                (
+                    self.output_node,
+                    datasink,
+                    [("resels_per_voxels", "resels_per_voxels")],
+                ),
                 (self.output_node, datasink, [("mask", "mask")]),
-                (self.output_node, datasink, [("regression_coeff", "regression_coeff")]),
+                (
+                    self.output_node,
+                    datasink,
+                    [("regression_coeff", "regression_coeff")],
+                ),
                 (self.output_node, datasink, [("contrasts", "contrasts")]),
             ]
         )
-        # fmt: on
 
     def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""

--- a/clinica/pipelines/statistics_volume_correction/statistics_volume_correction_pipeline.py
+++ b/clinica/pipelines/statistics_volume_correction/statistics_volume_correction_pipeline.py
@@ -38,7 +38,7 @@ class StatisticsVolumeCorrection(Pipeline):
         """
         return []
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -64,11 +64,11 @@ class StatisticsVolumeCorrection(Pipeline):
 
         self.connect([(read_parameters_node, self.input_node, [("t_map", "t_map")])])
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         pass
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         from os.path import abspath, dirname, exists, join, pardir
 

--- a/clinica/pipelines/statistics_volume_correction/statistics_volume_correction_pipeline.py
+++ b/clinica/pipelines/statistics_volume_correction/statistics_volume_correction_pipeline.py
@@ -1,28 +1,39 @@
-import clinica.pipelines.engine as cpe
+from typing import List
+
+from clinica.pipelines.engine import Pipeline
 
 
-class StatisticsVolumeCorrection(cpe.Pipeline):
+class StatisticsVolumeCorrection(Pipeline):
     """StatisticsVolumeCorrection - Statistical correction of StatisticsVolume pipeline.
 
     Returns:
         A clinica pipeline object containing the StatisticsVolumeCorrection pipeline.
     """
 
-    def check_custom_dependencies(self):
+    def _check_custom_dependencies(self) -> None:
         """Check dependencies that can not be listed in the `info.json` file."""
+        pass
 
-    def get_input_fields(self):
+    def _check_pipeline_parameters(self) -> None:
+        """Check pipeline parameters."""
+        pass
+
+    def get_input_fields(self) -> List[str]:
         """Specify the list of possible inputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) input fields name.
         """
         return ["t_map"]
 
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Specify the list of possible outputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) output fields name.
         """
         return []
@@ -55,6 +66,7 @@ class StatisticsVolumeCorrection(cpe.Pipeline):
 
     def build_output_node(self):
         """Build and connect an output node to the pipeline."""
+        pass
 
     def build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""

--- a/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer/t1_freesurfer_pipeline.py
@@ -79,7 +79,7 @@ class T1FreeSurfer(Pipeline):
         """
         return ["image_id"]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline.
 
         Raise:
@@ -179,7 +179,7 @@ class T1FreeSurfer(Pipeline):
             ]
         )
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -204,7 +204,7 @@ class T1FreeSurfer(Pipeline):
             ]
         )
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe

--- a/clinica/pipelines/t1_freesurfer_atlas/t1_freeesurfer_atlas_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer_atlas/t1_freeesurfer_atlas_pipeline.py
@@ -127,7 +127,7 @@ class T1FreeSurferAtlas(Pipeline):
         """
         return ["image_id"]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
 
@@ -155,10 +155,10 @@ class T1FreeSurferAtlas(Pipeline):
             ]
         )
 
-    def build_output_node(self):
+    def _build_output_node(self):
         return super().build_output_node()
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
 

--- a/clinica/pipelines/t1_freesurfer_longitudinal/longitudinal_utils.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/longitudinal_utils.py
@@ -5,6 +5,8 @@ where we need to manipulate longitudinal IDs.
 
 When a new longitudinal pipeline will be developed into Clinica, refactoring will be needed.
 """
+from pathlib import Path
+from typing import List, Tuple
 
 
 def extract_subject_session_longitudinal_ids_from_filename(bids_or_caps_files):
@@ -30,27 +32,27 @@ def extract_subject_session_longitudinal_ids_from_filename(bids_or_caps_files):
     return part_ids, sess_ids, long_ids
 
 
-def read_part_sess_long_ids_from_tsv(tsv_file):
+def read_part_sess_long_ids_from_tsv(
+    tsv_file: Path,
+) -> Tuple[List[str], List[str], List[str]]:
     """Extract participant, session and longitudinal from TSV file.
 
     TODO: Find a way to merge with utils/filemanip.py::read_participant_tsv into one util
     """
-    import os
-
-    import pandas
+    import pandas as pd
 
     from clinica.utils.exceptions import ClinicaException
 
-    if not os.path.isfile(tsv_file):
+    if not tsv_file.is_file():
         raise ClinicaException(
             "The TSV file you gave is not a file.\n"
             "Error explanations:\n"
             f" - Clinica expected the following path to be a file: {tsv_file}\n"
             " - If you gave relative path, did you run Clinica on the good folder?"
         )
-    df = pandas.read_csv(tsv_file, sep="\t")
+    df = pd.read_csv(tsv_file, sep="\t")
 
-    def check_key_in_data_frame(file, data_frame, key):
+    def check_key_in_data_frame(file: Path, data_frame: pd.DataFrame, key: str) -> None:
         if key not in list(data_frame.columns.values):
             raise ClinicaException(
                 f"The TSV file does not contain {key} column (path: {file})"
@@ -120,7 +122,9 @@ def extract_participant_long_ids_from_filename(caps_files):
     return part_ids, long_ids
 
 
-def grab_image_ids_from_caps_directory(caps_dir):
+def grab_image_ids_from_caps_directory(
+    caps_dir: Path,
+) -> Tuple[List[str], List[str], List[str]]:
     """Parse CAPS directory to extract participants, sessions and longitudinal IDs.
 
     Note:
@@ -151,7 +155,7 @@ def grab_image_ids_from_caps_directory(caps_dir):
     import os
     from glob import glob
 
-    participants_paths = glob(os.path.join(caps_dir, "subjects", "*sub-*"))
+    participants_paths = glob(str(caps_dir / "subjects" / "*sub-*"))
 
     participants_paths.sort()
     if len(participants_paths) == 0:

--- a/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_correction_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_correction_pipeline.py
@@ -51,10 +51,8 @@ class T1FreeSurferLongitudinalCorrection(Pipeline):
         """
         return ["subject_id"]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
-        import os
-
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
 
@@ -187,7 +185,7 @@ class T1FreeSurferLongitudinalCorrection(Pipeline):
             ]
         )
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -212,7 +210,7 @@ class T1FreeSurferLongitudinalCorrection(Pipeline):
             ]
         )
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe

--- a/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_correction_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_correction_pipeline.py
@@ -1,42 +1,52 @@
-import clinica.pipelines.engine as cpe
+from typing import List
+
+from clinica.pipelines.engine import Pipeline
 
 
-class T1FreeSurferLongitudinalCorrection(cpe.Pipeline):
+class T1FreeSurferLongitudinalCorrection(Pipeline):
     """FreeSurfer Longitudinal correction class.
 
     Returns:
         A clinica pipeline object containing the T1FreeSurferLongitudinalCorrection pipeline
     """
 
-    def check_pipeline_parameters(self):
+    def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
+        pass
 
-    def check_custom_dependencies(self):
+    def _check_custom_dependencies(self) -> None:
         """Check dependencies that cannot be listed in `info.json`."""
+        pass
 
-    def get_input_fields(self):
+    def get_input_fields(self) -> List[str]:
         """Specify the list of possible inputs of this pipeline.
 
-        Note:
-            The list of inputs of the T1FreeSurferLongitudinalCorrection pipeline is:
-                * participant_id (str): Participant ID (e.g. "sub-CLNC01")
-                * session_id (str): Session ID associated to `participant_id` (e.g. "ses-M000")
-                * long_id (str): Longitudinal ID associated to `participant_id` (e.g. "long-M000" or "long-M000M018")
+        Notes
+        -----
+        The list of inputs of the T1FreeSurferLongitudinalCorrection pipeline is:
+            * participant_id (str): Participant ID (e.g. "sub-CLNC01")
+            * session_id (str): Session ID associated to `participant_id` (e.g. "ses-M000")
+            * long_id (str): Longitudinal ID associated to `participant_id` (e.g. "long-M000" or "long-M000M018")
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) input fields name.
         """
         return ["participant_id", "session_id", "long_id"]
 
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Specify the list of possible outputs of this pipeline.
 
-        Note:
-            The list of inputs of the T1FreeSurferLongitudinalCorrection pipeline is:
-                * subject_id (str): FreeSurfer ID
-                    (e.g. "sub-CLNC01_ses-M000.long.sub-CLNC01_long-M000M018")
+        Notes
+        -----
+        The list of inputs of the T1FreeSurferLongitudinalCorrection pipeline is:
+            * subject_id (str): FreeSurfer ID
+                (e.g. "sub-CLNC01_ses-M000.long.sub-CLNC01_long-M000M018")
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) output fields name.
         """
         return ["subject_id"]
@@ -97,7 +107,7 @@ class T1FreeSurferLongitudinalCorrection(cpe.Pipeline):
             else:
                 cprint("Image(s) will be ignored by Clinica.", lvl="warning")
                 input_ids = [
-                    p_id + "_" + s_id + "_" + l_id
+                    f"{p_id}_{s_id}_{l_id}"
                     for p_id, s_id, l_id in zip(
                         self.subjects, self.sessions, list_long_id
                     )
@@ -134,14 +144,14 @@ class T1FreeSurferLongitudinalCorrection(cpe.Pipeline):
                 error_message += str(msg)
             raise ClinicaException(error_message)
 
-        # Save subjects to process in <WD>/<Pipeline.name>/participants.tsv
-        folder_participants_tsv = os.path.join(self.base_dir, self.name)
         save_part_sess_long_ids_to_tsv(
-            self.subjects, self.sessions, list_long_id, folder_participants_tsv
+            self.subjects, self.sessions, list_long_id, self.base_dir / self.name
         )
 
         def print_images_to_process(
-            list_participant_id, list_session_id, list_longitudinal_id
+            list_participant_id: List[str],
+            list_session_id: List[str],
+            list_longitudinal_id: List[str],
         ):
             cprint(
                 f"The pipeline will be run on the following {len(list_participant_id)} image(s):"
@@ -155,8 +165,7 @@ class T1FreeSurferLongitudinalCorrection(cpe.Pipeline):
             # TODO: Generalize long IDs to the message display
             print_images_to_process(self.subjects, self.sessions, list_long_id)
             cprint(
-                "List available in %s"
-                % os.path.join(folder_participants_tsv, "participants.tsv")
+                f"List available in {self.base_dir / self.name / 'participants.tsv'}"
             )
             cprint("The pipeline will last approximately 10 hours per participant.")
 
@@ -180,8 +189,6 @@ class T1FreeSurferLongitudinalCorrection(cpe.Pipeline):
 
     def build_output_node(self):
         """Build and connect an output node to the pipeline."""
-        import os
-
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
 
@@ -195,9 +202,7 @@ class T1FreeSurferLongitudinalCorrection(cpe.Pipeline):
             ),
             name="SaveToCaps",
         )
-        save_to_caps.inputs.source_dir = os.path.join(
-            self.base_dir, self.name, "ReconAll"
-        )
+        save_to_caps.inputs.source_dir = self.base_dir / self.name / "ReconAll"
         save_to_caps.inputs.caps_dir = self.caps_directory
         save_to_caps.inputs.overwrite_caps = self.overwrite_caps
 
@@ -209,8 +214,6 @@ class T1FreeSurferLongitudinalCorrection(cpe.Pipeline):
 
     def build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
-        import os
-
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
 
@@ -239,9 +242,7 @@ class T1FreeSurferLongitudinalCorrection(cpe.Pipeline):
             name="0-InitPipeline",
         )
         init_input.inputs.caps_dir = self.caps_directory
-        init_input.inputs.output_dir = os.path.join(
-            self.base_dir, self.name, "ReconAll"
-        )
+        init_input.inputs.output_dir = self.base_dir / self.name / "ReconAll"
 
         # Run recon-all command
         recon_all = npe.Node(
@@ -279,9 +280,7 @@ class T1FreeSurferLongitudinalCorrection(cpe.Pipeline):
             ),
             name="3-MoveSubjectsDir",
         )
-        move_subjects_dir.inputs.source_dir = os.path.join(
-            self.base_dir, self.name, "ReconAll"
-        )
+        move_subjects_dir.inputs.source_dir = self.base_dir / self.name / "ReconAll"
 
         # Connections
         # ===========

--- a/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_template_pipeline.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_template_pipeline.py
@@ -84,7 +84,7 @@ class T1FreeSurferTemplate(Pipeline):
         """
         return ["image_id"]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -223,7 +223,7 @@ class T1FreeSurferTemplate(Pipeline):
             ]
         )
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -259,7 +259,7 @@ class T1FreeSurferTemplate(Pipeline):
             ]
         )
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -311,18 +311,25 @@ class T1FreeSurferTemplate(Pipeline):
         )
         move_subjects_dir.inputs.source_dir = self.base_dir / self.name / "ReconAll"
 
-        # Connections
-        # ===========
-        # fmt: off
         self.connect(
             [
                 # Initialize the pipeline
                 (self.input_node, init_input, [("participant_id", "participant_id")]),
-                (self.input_node, init_input, [("list_session_ids", "list_session_ids")]),
+                (
+                    self.input_node,
+                    init_input,
+                    [("list_session_ids", "list_session_ids")],
+                ),
                 # Run recon-all command
-                (init_input, recon_all, [("subjects_dir", "subjects_dir"),
-                                         ("image_id", "subject_id"),
-                                         ("flags", "flags")]),
+                (
+                    init_input,
+                    recon_all,
+                    [
+                        ("subjects_dir", "subjects_dir"),
+                        ("image_id", "subject_id"),
+                        ("flags", "flags"),
+                    ],
+                ),
                 # Move $SUBJECT_DIR to source_dir (1 time point case)
                 (init_input, move_subjects_dir, [("subjects_dir", "subjects_dir")]),
                 (recon_all, move_subjects_dir, [("subject_id", "subject_id")]),
@@ -330,4 +337,3 @@ class T1FreeSurferTemplate(Pipeline):
                 (move_subjects_dir, self.output_node, [("subject_id", "image_id")]),
             ]
         )
-        # fmt: on

--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -204,7 +204,7 @@ class AnatLinear(Pipeline):
 
         # Writing node
         write_node = npe.Node(name="WriteCaps", interface=DataSink())
-        write_node.inputs.base_directory = self.caps_directory
+        write_node.inputs.base_directory = str(self.caps_directory)
         write_node.inputs.parameterization = False
 
         # Other nodes

--- a/clinica/pipelines/t1_volume_create_dartel/t1_volume_create_dartel_pipeline.py
+++ b/clinica/pipelines/t1_volume_create_dartel/t1_volume_create_dartel_pipeline.py
@@ -43,7 +43,7 @@ class T1VolumeCreateDartel(Pipeline):
         """
         return ["final_template_file", "template_files", "dartel_flow_fields"]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         import sys
 
@@ -133,7 +133,7 @@ class T1VolumeCreateDartel(Pipeline):
             ]
         )
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         import os.path as op
         import re
@@ -221,7 +221,7 @@ class T1VolumeCreateDartel(Pipeline):
             ]
         )
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.spm as spm
         import nipype.interfaces.utility as nutil

--- a/clinica/pipelines/t1_volume_create_dartel/t1_volume_create_dartel_pipeline.py
+++ b/clinica/pipelines/t1_volume_create_dartel/t1_volume_create_dartel_pipeline.py
@@ -143,14 +143,12 @@ class T1VolumeCreateDartel(Pipeline):
 
         from clinica.utils.filemanip import zip_nii
 
-        # Writing flowfields into CAPS
-        # ============================
         write_flowfields_node = npe.MapNode(
             name="write_flowfields_node",
             iterfield=["container", "flow_fields"],
             interface=nio.DataSink(infields=["flow_fields"]),
         )
-        write_flowfields_node.inputs.base_directory = self.caps_directory
+        write_flowfields_node.inputs.base_directory = str(self.caps_directory)
         write_flowfields_node.inputs.parameterization = False
         write_flowfields_node.inputs.container = [
             "subjects/"
@@ -180,11 +178,9 @@ class T1VolumeCreateDartel(Pipeline):
             (r"trait_added", r""),
         ]
 
-        # Writing templates into CAPS
-        # ===========================
         write_template_node = npe.Node(nio.DataSink(), name="write_template_node")
         write_template_node.inputs.parameterization = False
-        write_template_node.inputs.base_directory = self.caps_directory
+        write_template_node.inputs.base_directory = str(self.caps_directory)
         write_template_node.inputs.container = op.join(
             "groups", f"group-{self.parameters['group_label']}", "t1"
         )
@@ -233,8 +229,6 @@ class T1VolumeCreateDartel(Pipeline):
         if spm_standalone_is_available():
             use_spm_standalone()
 
-        # Unzipping
-        # =========
         unzip_node = npe.MapNode(
             nutil.Function(
                 input_names=["in_file"], output_names=["out_file"], function=unzip_nii
@@ -243,8 +237,6 @@ class T1VolumeCreateDartel(Pipeline):
             iterfield=["in_file"],
         )
 
-        # DARTEL template
-        # ===============
         dartel_template = npe.Node(spm.DARTEL(), name="dartel_template")
 
         self.connect(

--- a/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
+++ b/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
@@ -157,8 +157,6 @@ class T1VolumeDartel2MNI(Pipeline):
 
         from clinica.utils.filemanip import zip_nii
 
-        # Writing normalized images (and smoothed) into CAPS
-        # ==================================================
         write_normalized_node = npe.MapNode(
             name="write_normalized_node",
             iterfield=["container", "normalized_files", "smoothed_normalized_files"],
@@ -166,7 +164,7 @@ class T1VolumeDartel2MNI(Pipeline):
                 infields=["normalized_files", "smoothed_normalized_files"]
             ),
         )
-        write_normalized_node.inputs.base_directory = self.caps_directory
+        write_normalized_node.inputs.base_directory = str(self.caps_directory)
         write_normalized_node.inputs.parameterization = False
         write_normalized_node.inputs.container = [
             "subjects/"
@@ -232,8 +230,6 @@ class T1VolumeDartel2MNI(Pipeline):
         if spm_standalone_is_available():
             use_spm_standalone()
 
-        # Unzipping
-        # =========
         unzip_tissues_node = npe.MapNode(
             nutil.Function(
                 input_names=["in_file"], output_names=["out_file"], function=unzip_nii
@@ -267,8 +263,6 @@ class T1VolumeDartel2MNI(Pipeline):
         dartel2mni_node.inputs.modulate = self.parameters["modulate"]
         dartel2mni_node.inputs.fwhm = 0
 
-        # Smoothing
-        # =========
         if self.parameters["smooth"] is not None and len(self.parameters["smooth"]) > 0:
             smoothing_node = npe.MapNode(
                 spm.Smooth(), name="smoothing_node", iterfield=["in_files"]

--- a/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
+++ b/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
@@ -46,10 +46,8 @@ class T1VolumeDartel2MNI(Pipeline):
         """
         return ["normalized_files", "smoothed_normalized_files", "atlas_statistics"]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
-        import os
-
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
 
@@ -152,7 +150,7 @@ class T1VolumeDartel2MNI(Pipeline):
             ]
         )
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         import nipype.interfaces.io as nio
         import nipype.pipeline.engine as npe
@@ -218,7 +216,7 @@ class T1VolumeDartel2MNI(Pipeline):
             ]
         )
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.spm as spm
         import nipype.interfaces.utility as nutil

--- a/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
+++ b/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
@@ -1,42 +1,47 @@
-import clinica.pipelines.engine as cpe
+from typing import List
+
+from clinica.pipelines.engine import Pipeline
 
 
-class T1VolumeDartel2MNI(cpe.Pipeline):
+class T1VolumeDartel2MNI(Pipeline):
     """T1VolumeDartel2MNI - Dartel template to MNI.
 
     Returns:
         A clinica pipeline object containing the T1VolumeDartel2MNI pipeline.
     """
 
-    def check_pipeline_parameters(self):
+    def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
         from clinica.utils.group import check_group_label
 
         if "group_label" not in self.parameters.keys():
             raise KeyError("Missing compulsory group_label key in pipeline parameter.")
-
         self.parameters.setdefault("tissues", [1, 2, 3])
         self.parameters.setdefault("voxel_size", None)
         self.parameters.setdefault("modulate", True)
         self.parameters.setdefault("smooth", [8])
-
         check_group_label(self.parameters["group_label"])
 
-    def check_custom_dependencies(self):
+    def _check_custom_dependencies(self) -> None:
         """Check dependencies that can not be listed in the `info.json` file."""
+        pass
 
-    def get_input_fields(self):
+    def get_input_fields(self) -> List[str]:
         """Specify the list of possible inputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) input fields name.
         """
         return ["native_segmentations", "flowfield_files", "template_file"]
 
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Specify the list of possible outputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) output fields name.
         """
         return ["normalized_files", "smoothed_normalized_files", "atlas_statistics"]
@@ -61,12 +66,9 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
             print_images_to_process,
         )
 
-        # Check that group already exists
-        if not os.path.exists(
-            os.path.join(
-                self.caps_directory, "groups", "group-" + self.parameters["group_label"]
-            )
-        ):
+        if not (
+            self.caps_directory / "groups" / f"group-{self.parameters['group_label']}"
+        ).exists():
             print_groups_in_caps_directory(self.caps_directory)
             raise ClinicaException(
                 f"Group {self.parameters['group_label']} does not exist. "
@@ -136,15 +138,19 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
             print_images_to_process(self.subjects, self.sessions)
             cprint("The pipeline will last a few minutes per image.")
 
-        # fmt: off
         self.connect(
             [
-                (read_input_node, self.input_node, [("native_segmentations", "native_segmentations"),
-                                                    ("flowfield_files", "flowfield_files"),
-                                                    ("template_file", "template_file")]),
+                (
+                    read_input_node,
+                    self.input_node,
+                    [
+                        ("native_segmentations", "native_segmentations"),
+                        ("flowfield_files", "flowfield_files"),
+                        ("template_file", "template_file"),
+                    ],
+                ),
             ]
         )
-        # fmt: on
 
     def build_output_node(self):
         """Build and connect an output node to the pipeline."""
@@ -196,7 +202,6 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
             (r"trait_added", r""),
         ]
 
-        # fmt: off
         self.connect(
             [
                 (
@@ -204,12 +209,14 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
                     write_normalized_node,
                     [
                         (("normalized_files", zip_nii, True), "normalized_files"),
-                        (("smoothed_normalized_files", zip_nii, True), "smoothed_normalized_files"),
+                        (
+                            ("smoothed_normalized_files", zip_nii, True),
+                            "smoothed_normalized_files",
+                        ),
                     ],
                 )
             ]
         )
-        # fmt: on
 
     def build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
@@ -288,31 +295,61 @@ class T1VolumeDartel2MNI(cpe.Pipeline):
                 joinfield="smoothed_normalized_files",
                 name="join_smoothing_node",
             )
-            # fmt: off
             self.connect(
                 [
-                    (dartel2mni_node, smoothing_node, [("normalized_files", "in_files")]),
-                    (smoothing_node, join_smoothing_node, [("smoothed_files", "smoothed_normalized_files")]),
-                    (join_smoothing_node, self.output_node, [("smoothed_normalized_files", "smoothed_normalized_files")]),
+                    (
+                        dartel2mni_node,
+                        smoothing_node,
+                        [("normalized_files", "in_files")],
+                    ),
+                    (
+                        smoothing_node,
+                        join_smoothing_node,
+                        [("smoothed_files", "smoothed_normalized_files")],
+                    ),
+                    (
+                        join_smoothing_node,
+                        self.output_node,
+                        [("smoothed_normalized_files", "smoothed_normalized_files")],
+                    ),
                 ]
             )
-            # fmt: on
         else:
             self.output_node.inputs.smoothed_normalized_files = []
 
-        # Connection
-        # ==========
-        # fmt: off
         self.connect(
             [
-                (self.input_node, unzip_tissues_node, [("native_segmentations", "in_file")]),
-                (self.input_node, unzip_flowfields_node, [("flowfield_files", "in_file")]),
+                (
+                    self.input_node,
+                    unzip_tissues_node,
+                    [("native_segmentations", "in_file")],
+                ),
+                (
+                    self.input_node,
+                    unzip_flowfields_node,
+                    [("flowfield_files", "in_file")],
+                ),
                 (self.input_node, unzip_template_node, [("template_file", "in_file")]),
                 (unzip_tissues_node, dartel2mni_node, [("out_file", "apply_to_files")]),
-                (unzip_flowfields_node, dartel2mni_node, [
-                    (("out_file", dartel2mni_utils.prepare_flowfields, self.parameters["tissues"]), "flowfield_files")]),
+                (
+                    unzip_flowfields_node,
+                    dartel2mni_node,
+                    [
+                        (
+                            (
+                                "out_file",
+                                dartel2mni_utils.prepare_flowfields,
+                                self.parameters["tissues"],
+                            ),
+                            "flowfield_files",
+                        )
+                    ],
+                ),
                 (unzip_template_node, dartel2mni_node, [("out_file", "template_file")]),
-                (dartel2mni_node, self.output_node, [("normalized_files", "normalized_files")]),
+                (
+                    dartel2mni_node,
+                    self.output_node,
+                    [("normalized_files", "normalized_files")],
+                ),
             ]
         )
-        # fmt: on

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
@@ -134,7 +134,7 @@ class T1VolumeParcellation(Pipeline):
 
         datasink = npe.Node(nio.DataSink(), name="datasink")
 
-        datasink.inputs.base_directory = self.caps_directory
+        datasink.inputs.base_directory = str(self.caps_directory)
         datasink.inputs.parameterization = True
         datasink.inputs.regexp_substitutions = [
             (

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
@@ -1,46 +1,51 @@
-import clinica.pipelines.engine as cpe
+from typing import List
+
+from clinica.pipelines.engine import Pipeline
 
 
-class T1VolumeParcellation(cpe.Pipeline):
+class T1VolumeParcellation(Pipeline):
     """T1VolumeParcellation - Computation of mean GM concentration for a set of regions.
 
     Returns:
         A clinica pipeline object containing the T1VolumeParcellation pipeline.
     """
 
-    def check_custom_dependencies(self):
+    def _check_custom_dependencies(self) -> None:
         """Check dependencies that can not be listed in the `info.json` file."""
+        pass
 
-    def check_pipeline_parameters(self):
+    def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
         from clinica.utils.atlas import T1_VOLUME_ATLASES
         from clinica.utils.group import check_group_label
 
         self.parameters.setdefault("group_label", None)
         check_group_label(self.parameters["group_label"])
-
         self.parameters.setdefault("atlases", T1_VOLUME_ATLASES)
         self.parameters.setdefault("modulate", True)
 
-    def get_input_fields(self):
+    def get_input_fields(self) -> List[str]:
         """Specify the list of possible inputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) input fields name.
         """
         return ["file_list", "atlas_list"]
 
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Specify the list of possible outputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) output fields name.
         """
+        return []
 
     def build_input_node(self):
         """Build and connect an input node to the pipeline."""
-        import os
-
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
 
@@ -53,12 +58,9 @@ class T1VolumeParcellation(cpe.Pipeline):
             print_images_to_process,
         )
 
-        # Check that group already exists
-        if not os.path.exists(
-            os.path.join(
-                self.caps_directory, "groups", f"group-{self.parameters['group_label']}"
-            )
-        ):
+        if not (
+            self.caps_directory / "groups" / f"group-{self.parameters['group_label']}"
+        ).exists():
             print_groups_in_caps_directory(self.caps_directory)
             raise ClinicaException(
                 f"Group {self.parameters['group_label']} does not exist. "
@@ -103,6 +105,7 @@ class T1VolumeParcellation(cpe.Pipeline):
 
     def build_output_node(self):
         """Build and connect an output node to the pipeline."""
+        pass
 
     def build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
@@ -141,16 +144,15 @@ class T1VolumeParcellation(cpe.Pipeline):
                 + r"/\2/\3",
             )
         ]
-
-        # Connection
-        # ==========
-        # fmt: off
         self.connect(
             [
                 (self.input_node, atlas_stats_node, [("file_list", "in_image")]),
                 (self.input_node, atlas_stats_node, [("atlas_list", "atlas_list")]),
-                (atlas_stats_node, outputnode, [("atlas_statistics", "atlas_statistics")]),
+                (
+                    atlas_stats_node,
+                    outputnode,
+                    [("atlas_statistics", "atlas_statistics")],
+                ),
                 (outputnode, datasink, [("atlas_statistics", "atlas_statistics")]),
             ]
         )
-        # fmt: on

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
@@ -44,7 +44,7 @@ class T1VolumeParcellation(Pipeline):
         """
         return []
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -103,11 +103,11 @@ class T1VolumeParcellation(Pipeline):
             ]
         )
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         pass
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.io as nio
         import nipype.interfaces.utility as nutil

--- a/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_pipeline.py
+++ b/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_pipeline.py
@@ -132,14 +132,12 @@ class T1VolumeRegisterDartel(Pipeline):
 
         from clinica.utils.filemanip import zip_nii
 
-        # Writing flowfields into CAPS
-        # ============================
         write_flowfields_node = npe.MapNode(
             name="write_flowfields_node",
             iterfield=["container", "flow_fields"],
             interface=nio.DataSink(infields=["flow_fields"]),
         )
-        write_flowfields_node.inputs.base_directory = self.caps_directory
+        write_flowfields_node.inputs.base_directory = str(self.caps_directory)
         write_flowfields_node.inputs.parameterization = False
         write_flowfields_node.inputs.container = [
             "subjects/"
@@ -187,8 +185,6 @@ class T1VolumeRegisterDartel(Pipeline):
         import clinica.pipelines.t1_volume_register_dartel.t1_volume_register_dartel_utils as utils
         from clinica.utils.filemanip import unzip_nii
 
-        # Unzipping
-        # =========
         unzip_dartel_input_node = npe.MapNode(
             nutil.Function(
                 input_names=["in_file"], output_names=["out_file"], function=unzip_nii

--- a/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_pipeline.py
+++ b/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_pipeline.py
@@ -1,38 +1,44 @@
-import clinica.pipelines.engine as cpe
+from typing import List
+
+from clinica.pipelines.engine import Pipeline
 
 
-class T1VolumeRegisterDartel(cpe.Pipeline):
+class T1VolumeRegisterDartel(Pipeline):
     """T1VolumeExistingDartel - Reuse existing Dartel template.
 
     Returns:
         A clinica pipeline object containing the T1VolumeExistingDartel pipeline.
     """
 
-    def check_custom_dependencies(self):
+    def _check_custom_dependencies(self) -> None:
         """Check dependencies that can not be listed in the `info.json` file."""
+        pass
 
-    def check_pipeline_parameters(self):
+    def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
         from clinica.utils.group import check_group_label
 
         if "group_label" not in self.parameters.keys():
             raise KeyError("Missing compulsory group_label key in pipeline parameter.")
         self.parameters.setdefault("tissues", [1, 2, 3])
-
         check_group_label(self.parameters["group_label"])
 
-    def get_input_fields(self):
+    def get_input_fields(self) -> List[str]:
         """Specify the list of possible inputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) input fields name.
         """
         return ["dartel_input_images", "dartel_iteration_templates"]
 
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Specify the list of possible outputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) output fields name.
         """
         return ["dartel_flow_fields"]
@@ -102,14 +108,20 @@ class T1VolumeRegisterDartel(cpe.Pipeline):
         if len(self.subjects):
             print_images_to_process(self.subjects, self.sessions)
 
-        # fmt: off
         self.connect(
             [
-                (read_input_node, self.input_node, [("dartel_input_images", "dartel_input_images")]),
-                (read_input_node, self.input_node, [("dartel_iteration_templates", "dartel_iteration_templates")]),
+                (
+                    read_input_node,
+                    self.input_node,
+                    [("dartel_input_images", "dartel_input_images")],
+                ),
+                (
+                    read_input_node,
+                    self.input_node,
+                    [("dartel_iteration_templates", "dartel_iteration_templates")],
+                ),
             ]
         )
-        # fmt: on
 
     def build_output_node(self):
         """Build and connect an output node to the pipeline."""
@@ -157,13 +169,15 @@ class T1VolumeRegisterDartel(cpe.Pipeline):
             (r"trait_added", r""),
         ]
 
-        # fmt: off
         self.connect(
             [
-                (self.output_node, write_flowfields_node, [(("dartel_flow_fields", zip_nii, True), "flow_fields")])
+                (
+                    self.output_node,
+                    write_flowfields_node,
+                    [(("dartel_flow_fields", zip_nii, True), "flow_fields")],
+                )
             ]
         )
-        # fmt: on
 
     def build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
@@ -196,16 +210,37 @@ class T1VolumeRegisterDartel(cpe.Pipeline):
             iterfield=["image_files"],
         )
 
-        # Connection
-        # ==========
-        # fmt: off
         self.connect(
             [
-                (self.input_node, unzip_dartel_input_node, [("dartel_input_images", "in_file")]),
-                (self.input_node, unzip_templates_node, [("dartel_iteration_templates", "in_file")]),
-                (unzip_dartel_input_node, dartel_existing_template, [(("out_file", utils.prepare_dartel_input_images), "image_files")]),
-                (unzip_templates_node, dartel_existing_template, [(("out_file", utils.create_iteration_parameters, None), "iteration_parameters")]),
-                (dartel_existing_template, self.output_node, [("dartel_flow_fields", "dartel_flow_fields")]),
+                (
+                    self.input_node,
+                    unzip_dartel_input_node,
+                    [("dartel_input_images", "in_file")],
+                ),
+                (
+                    self.input_node,
+                    unzip_templates_node,
+                    [("dartel_iteration_templates", "in_file")],
+                ),
+                (
+                    unzip_dartel_input_node,
+                    dartel_existing_template,
+                    [(("out_file", utils.prepare_dartel_input_images), "image_files")],
+                ),
+                (
+                    unzip_templates_node,
+                    dartel_existing_template,
+                    [
+                        (
+                            ("out_file", utils.create_iteration_parameters, None),
+                            "iteration_parameters",
+                        )
+                    ],
+                ),
+                (
+                    dartel_existing_template,
+                    self.output_node,
+                    [("dartel_flow_fields", "dartel_flow_fields")],
+                ),
             ]
         )
-        # fmt: on

--- a/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_pipeline.py
+++ b/clinica/pipelines/t1_volume_register_dartel/t1_volume_register_dartel_pipeline.py
@@ -43,7 +43,7 @@ class T1VolumeRegisterDartel(Pipeline):
         """
         return ["dartel_flow_fields"]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -123,7 +123,7 @@ class T1VolumeRegisterDartel(Pipeline):
             ]
         )
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         import re
 
@@ -179,7 +179,7 @@ class T1VolumeRegisterDartel(Pipeline):
             ]
         )
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe

--- a/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
+++ b/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
@@ -154,8 +154,6 @@ class T1VolumeTissueSegmentation(Pipeline):
             name="0-InitNode",
         )
 
-        # Unzipping
-        # =========
         unzip_node = npe.Node(
             nutil.Function(
                 input_names=["in_file"], output_names=["out_file"], function=unzip_nii
@@ -234,7 +232,7 @@ class T1VolumeTissueSegmentation(Pipeline):
         # Writing CAPS
         # ============
         write_node = npe.Node(name="WriteCAPS", interface=nio.DataSink())
-        write_node.inputs.base_directory = self.caps_directory
+        write_node.inputs.base_directory = str(self.caps_directory)
         write_node.inputs.parameterization = False
         write_node.inputs.regexp_substitutions = [
             (r"(.*)c1(sub-.*)(\.nii(\.gz)?)$", r"\1\2_segm-graymatter\3"),

--- a/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
+++ b/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
@@ -63,7 +63,7 @@ class T1VolumeTissueSegmentation(Pipeline):
             "t1_mni",
         ]
 
-    def build_input_node(self):
+    def _build_input_node(self):
         """Build and connect an input node to the pipeline.
 
         Raise:
@@ -116,11 +116,11 @@ class T1VolumeTissueSegmentation(Pipeline):
             ]
         )
 
-    def build_output_node(self):
+    def _build_output_node(self):
         """Build and connect an output node to the pipeline."""
         pass
 
-    def build_core_nodes(self):
+    def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import nipype.interfaces.io as nio
         import nipype.interfaces.spm as spm

--- a/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
+++ b/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
@@ -1,24 +1,25 @@
-# Use hash instead of parameters for iterables folder names
-# Otherwise path will be too long and generate OSError
+from typing import List
+
 from nipype import config
 
-import clinica.pipelines.engine as cpe
+from clinica.pipelines.engine import Pipeline
 
 cfg = dict(execution={"parameterize_dirs": False})
 config.update_config(cfg)
 
 
-class T1VolumeTissueSegmentation(cpe.Pipeline):
+class T1VolumeTissueSegmentation(Pipeline):
     """T1VolumeTissueSegmentation - Tissue segmentation, bias correction and spatial normalization to MNI space.
 
     Returns:
         A clinica pipeline object containing the T1VolumeTissueSegmentation pipeline.
     """
 
-    def check_custom_dependencies(self):
+    def _check_custom_dependencies(self) -> None:
         """Check dependencies that can not be listed in the `info.json` file."""
+        pass
 
-    def check_pipeline_parameters(self):
+    def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
         from clinica.utils.spm import get_tpm
 
@@ -27,23 +28,26 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
         self.parameters.setdefault("save_warped_unmodulated", True)
         self.parameters.setdefault("save_warped_modulated", False)
         self.parameters.setdefault("tissue_probability_maps", None)
-
         # Fetch the TPM in case none was passed explicitly.
         if not self.parameters["tissue_probability_maps"]:
             self.parameters["tissue_probability_maps"] = get_tpm()
 
-    def get_input_fields(self):
+    def get_input_fields(self) -> List[str]:
         """Specify the list of possible inputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) input fields name.
         """
         return ["t1w"]
 
-    def get_output_fields(self):
+    def get_output_fields(self) -> List[str]:
         """Specify the list of possible outputs of this pipeline.
 
-        Returns:
+        Returns
+        -------
+        list of str :
             A list of (string) output fields name.
         """
         return [
@@ -114,6 +118,7 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
 
     def build_output_node(self):
         """Build and connect an output node to the pipeline."""
+        pass
 
     def build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
@@ -183,10 +188,6 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
             ),
             name="WriteEndMessage",
         )
-
-        # Connection
-        # ==========
-        # fmt: off
         self.connect(
             [
                 (self.input_node, init_node, [("t1w", "t1w")]),
@@ -194,21 +195,30 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
                 (unzip_node, new_segment, [("out_file", "channel_files")]),
                 (init_node, print_end_message, [("subject_id", "subject_id")]),
                 (unzip_node, t1_to_mni, [("out_file", "in_files")]),
-                (new_segment, t1_to_mni, [("forward_deformation_field", "deformation_field")]),
-                (new_segment, self.output_node, [("bias_corrected_images", "bias_corrected_images"),
-                                                 ("bias_field_images", "bias_field_images"),
-                                                 ("dartel_input_images", "dartel_input_images"),
-                                                 ("forward_deformation_field", "forward_deformation_field"),
-                                                 ("inverse_deformation_field", "inverse_deformation_field"),
-                                                 ("modulated_class_images", "modulated_class_images"),
-                                                 ("native_class_images", "native_class_images"),
-                                                 ("normalized_class_images", "normalized_class_images"),
-                                                 ("transformation_mat", "transformation_mat")]),
+                (
+                    new_segment,
+                    t1_to_mni,
+                    [("forward_deformation_field", "deformation_field")],
+                ),
+                (
+                    new_segment,
+                    self.output_node,
+                    [
+                        ("bias_corrected_images", "bias_corrected_images"),
+                        ("bias_field_images", "bias_field_images"),
+                        ("dartel_input_images", "dartel_input_images"),
+                        ("forward_deformation_field", "forward_deformation_field"),
+                        ("inverse_deformation_field", "inverse_deformation_field"),
+                        ("modulated_class_images", "modulated_class_images"),
+                        ("native_class_images", "native_class_images"),
+                        ("normalized_class_images", "normalized_class_images"),
+                        ("transformation_mat", "transformation_mat"),
+                    ],
+                ),
                 (t1_to_mni, self.output_node, [("out_files", "t1_mni")]),
                 (self.output_node, print_end_message, [("t1_mni", "final_file")]),
             ]
         )
-        # fmt: on
 
         # Find container path from t1w filename
         # =====================================
@@ -255,28 +265,77 @@ class T1VolumeTissueSegmentation(cpe.Pipeline):
             (r"trait_added", r""),
         ]
 
-        # fmt: off
         self.connect(
             [
                 (self.input_node, container_path, [("t1w", "bids_or_caps_filename")]),
-                (container_path, write_node, [(("container", fix_join, "t1", "spm", "segmentation"), "container")]),
-                (self.output_node, write_node, [(("native_class_images", zip_list_files, True), "native_space"),
-                                                (("dartel_input_images", zip_list_files, True), "dartel_input")]),
-                (self.output_node, write_node, [(("inverse_deformation_field", zip_nii, True), "inverse_deformation_field")]),
-                (self.output_node, write_node, [(("forward_deformation_field", zip_nii, True), "forward_deformation_field")]),
+                (
+                    container_path,
+                    write_node,
+                    [
+                        (
+                            ("container", fix_join, "t1", "spm", "segmentation"),
+                            "container",
+                        )
+                    ],
+                ),
+                (
+                    self.output_node,
+                    write_node,
+                    [
+                        (("native_class_images", zip_list_files, True), "native_space"),
+                        (("dartel_input_images", zip_list_files, True), "dartel_input"),
+                    ],
+                ),
+                (
+                    self.output_node,
+                    write_node,
+                    [
+                        (
+                            ("inverse_deformation_field", zip_nii, True),
+                            "inverse_deformation_field",
+                        )
+                    ],
+                ),
+                (
+                    self.output_node,
+                    write_node,
+                    [
+                        (
+                            ("forward_deformation_field", zip_nii, True),
+                            "forward_deformation_field",
+                        )
+                    ],
+                ),
                 (self.output_node, write_node, [(("t1_mni", zip_nii, True), "t1_mni")]),
             ]
         )
         if self.parameters["save_warped_unmodulated"]:
             self.connect(
                 [
-                    (self.output_node, write_node, [(("normalized_class_images", zip_list_files, True), "normalized")]),
+                    (
+                        self.output_node,
+                        write_node,
+                        [
+                            (
+                                ("normalized_class_images", zip_list_files, True),
+                                "normalized",
+                            )
+                        ],
+                    ),
                 ]
             )
         if self.parameters["save_warped_modulated"]:
             self.connect(
                 [
-                    (self.output_node, write_node, [(("modulated_class_images", zip_list_files, True), "modulated_normalized")]),
+                    (
+                        self.output_node,
+                        write_node,
+                        [
+                            (
+                                ("modulated_class_images", zip_list_files, True),
+                                "modulated_normalized",
+                            )
+                        ],
+                    ),
                 ]
             )
-        # fmt: on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ target-version = "py38"
 line-length = 88
 
 [tool.ruff.lint]
-select = ["E", "W", "I001"]
+select = ["E", "W", "I001", "PTH"]
 ignore = ["E203", "E501"]
 
 [tool.ruff.lint.isort]

--- a/test/unittests/pipelines/test_nipype_engine.py
+++ b/test/unittests/pipelines/test_nipype_engine.py
@@ -16,7 +16,7 @@ def test_detect_cross_sectional_and_longitudinal_subjects(
     tmp_path, subs, directory_content, expected
 ):
     from clinica.pipelines.engine import (
-        detect_cross_sectional_and_longitudinal_subjects,
+        _detect_cross_sectional_and_longitudinal_subjects,
     )
 
     bids_dir = tmp_path / Path("bids")
@@ -27,4 +27,4 @@ def test_detect_cross_sectional_and_longitudinal_subjects(
     for dir in dirs:
         if not dir.is_dir():
             os.makedirs(dir)
-    assert detect_cross_sectional_and_longitudinal_subjects(subs, bids_dir) == expected
+    assert _detect_cross_sectional_and_longitudinal_subjects(subs, bids_dir) == expected


### PR DESCRIPTION
This PR proposes to use Pathlib Path objects to represent paths in Pipeline classes instead of raw strings.

It does some refactoring of the pipeline engine first and propagate the changes to all Clinica pipelines.

This needs to be tested on the CI to check that pipelines were not broken.
