### PR TITLE
[INFRA] Update `isort` version in `pre-commit` config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: '5.10.1'
+    rev: '5.12.0'
     hooks:
       - id: isort
   - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
There seems to be an issue with the current pre-commit config, at least for some users.

This PR proposes to bump isort to 5.12.0 which solves the issue.