### PR TITLE
MAINT: Add hook to ensure consistency of Poetry files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,10 @@ repos:
       - id: codespell
         additional_dependencies:
           - tomli
+  - repo: https://github.com/python-poetry/poetry
+    rev: '1.7.1'
+    hooks:
+      - id: poetry-check
 
 default_language_version:
   python: python3


### PR DESCRIPTION
In case there is an inconsistency, then one would get:

```
poetry-check.............................................................Failed
- hook id: poetry-check
- exit code: 1

Error: poetry.lock is not consistent with pyproject.toml. Run `poetry lock [--no-update]` to fix it.
```