### PR TITLE
Fix bad warning 

### DIFF
--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -75,7 +75,7 @@ def _list_subjects_sub_folders(
     subjects_sub_folders = [
         sub
         for sub in folder_content
-        if (sub.name.startswith("sub-") and (root_dir / sub).is_dir())
+        if (sub.name.startswith("sub-") and sub.is_dir())
     ]
     if len(subjects_sub_folders) == 0 and not groups_dir.is_dir():
         cprint(msg=warning_msg, lvl="warning")

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -73,9 +73,7 @@ def _list_subjects_sub_folders(
     )
     folder_content = [f for f in root_dir.iterdir()]
     subjects_sub_folders = [
-        sub
-        for sub in folder_content
-        if (sub.name.startswith("sub-") and sub.is_dir())
+        sub for sub in folder_content if (sub.name.startswith("sub-") and sub.is_dir())
     ]
     if len(subjects_sub_folders) == 0 and not groups_dir.is_dir():
         cprint(msg=warning_msg, lvl="warning")


### PR DESCRIPTION
There was a problem with the function `_list_subjects_sub_folders` that prints the sentence 'Could not determine if {folder} is a CAPS or BIDS directory. Clinica will assume this is a CAPS directory.' every time it is called.