### PR TITLE
Fix dwi positive direction in dwi-preprocessing

### DIFF
--- a/clinica/utils/dwi.py
+++ b/clinica/utils/dwi.py
@@ -575,7 +575,9 @@ def bids_dir_to_fsl_dir(bids_dir):
             f"Unknown PhaseEncodingDirection {fsl_dir}: it should be a value in (i, j, k, i-, j-, k-)"
         )
 
-    return fsl_dir.replace("i", "x").replace("j", "y").replace("k", "z")
+    return (
+        fsl_dir.replace("i", "x").replace("j", "y").replace("k", "z").replace("+", "")
+    )
 
 
 def extract_bids_identifier_from_filename(dwi_filename: str) -> str:


### PR DESCRIPTION
Closes #1034 

The current converters do not correct the PhaseEncodingDirection if it is not BIDS compliant leaving open the possibility of positive values (y+ instead of y for instance). This PR transforms these positive values so that the pipeline will not crash.