### PR TITLE
[FIX] Fix calls to `get_subject_session_list`

### DIFF
--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -119,7 +119,9 @@ def _get_participants_and_subjects_sessions_df(
 
     index_cols = ["participant_id", "session_id"]
     subjects, sessions = get_subject_session_list(
-        bids_dir, ss_file=tsv_file, use_session_tsv=(not ignore_sessions_files)
+        bids_dir,
+        subject_session_file=tsv_file,
+        use_session_tsv=(not ignore_sessions_files),
     )
     if (bids_dir / "participants.tsv").is_file():
         participants_df = pd.read_csv(bids_dir / "participants.tsv", sep="\t")

--- a/clinica/pipelines/engine.py
+++ b/clinica/pipelines/engine.py
@@ -199,7 +199,11 @@ class Pipeline(Workflow):
             input_dir = self._bids_directory
             is_bids_dir = True
         self._subjects, self._sessions = get_subject_session_list(
-            input_dir, tsv_file, is_bids_dir, False, base_dir
+            input_dir,
+            subject_session_file=tsv_file,
+            is_bids_dir=is_bids_dir,
+            use_session_tsv=False,
+            tsv_dir=base_dir,
         )
 
         self.init_nodes()

--- a/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_cli.py
+++ b/clinica/pipelines/t1_freesurfer_longitudinal/t1_freesurfer_longitudinal_cli.py
@@ -50,7 +50,7 @@ def cli(
     )
 
     if not subjects_sessions_tsv:
-        l_part, l_sess = get_subject_session_list(caps_directory, None, False, False)
+        l_part, l_sess = get_subject_session_list(caps_directory, is_bids_dir=False)
         l_long = get_participants_long_id(l_part, l_sess)
         now = datetime.datetime.now().strftime("%H%M%S")
         subjects_sessions_tsv = now + "_participants.tsv"

--- a/clinica/pipelines/t1_volume/t1_volume_cli.py
+++ b/clinica/pipelines/t1_volume/t1_volume_cli.py
@@ -82,9 +82,7 @@ def cli(
     )
 
     if not subjects_sessions_tsv:
-        participant_ids, session_ids = get_subject_session_list(
-            bids_directory, None, True, False
-        )
+        participant_ids, session_ids = get_subject_session_list(bids_directory)
         now = datetime.datetime.now().strftime("%H%M%S")
         subjects_sessions_tsv = now + "_participants.tsv"
         save_participants_sessions(


### PR DESCRIPTION
Fix small bug introduced in #1052 (`ss_file` argument was changed to `subject_session_file` for clarity but one call was forgotten).
This PR also proposes to make all calls to `get_subject_session_list` less ambiguous by either using the default values or specifying the name of the named arguments.