### PR TITLE
[CI] Increase timeout of t1-Freesurfer test workflows from 12h to 24h...

### DIFF
--- a/.github/workflows/test_pipelines_anat_freesurfer.yml
+++ b/.github/workflows/test_pipelines_anat_freesurfer.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on:
       - self-hosted
       - macOS
-    timeout-minutes: 720
+    timeout-minutes: 1440
     steps:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1
@@ -41,7 +41,7 @@ jobs:
     runs-on:
       - self-hosted
       - Linux
-    timeout-minutes: 720
+    timeout-minutes: 1440
     steps:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1


### PR DESCRIPTION
This PR proposes to increase the timeout for the workflow testing the T1-freesurfer related pipelines.
The current limit of 12 hours seems to be insufficient:

https://github.com/aramis-lab/clinica/actions/runs/7631311178/job/20788979698

Let's try with 24h...