### PR TITLE
[CI] Run fast non regression tests on main

### DIFF
--- a/.github/workflows/test_converters.yml
+++ b/.github/workflows/test_converters.yml
@@ -42,6 +42,10 @@ jobs:
           --junitxml=./test-reports/run_converters_mac.xml \
           --disable-warnings \
           ./nonregression/iotools/test_run_converters.py
+      - name: Clean
+        run: |
+          rm -rf /Volumes/data/tmp
+          rm -rf /Volumes/data/working_dir_mac
 
   test-converters-Linux:
     runs-on:
@@ -71,3 +75,7 @@ jobs:
           --junitxml=./test-reports/run_converters_linux.xml \
           --disable-warnings \
           ./nonregression/iotools/test_run_converters.py
+      - name: Clean
+        run: |
+          rm -rf /mnt/data/ci/tmp
+          rm -rf /mnt/data/ci/working_dir_linux

--- a/.github/workflows/test_non_regression_fast.yml
+++ b/.github/workflows/test_non_regression_fast.yml
@@ -3,8 +3,6 @@ name: Fast Non Regression Tests
 on:
   push:
     branches: [dev]
-  pull_request:
-    branches: [dev]
 
 permissions:
   contents: read

--- a/.github/workflows/test_non_regression_fast.yml
+++ b/.github/workflows/test_non_regression_fast.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Clean
         run: |
           rm -rf /Volumes/data/tmp
+          rm -rf /Volumes/data/working_dir_mac
 
   test-non-regression-fast-Linux:
     runs-on:
@@ -83,3 +84,4 @@ jobs:
       - name: Clean
         run: |
           rm -rf /mnt/data/ci/tmp
+          rm -rf /mnt/data/ci/working_dir_linux


### PR DESCRIPTION
This PR proposes to:

- Clean working directories after test pipelines (seems to be causing some issues and we don't want tests to use cached results anyway).
- Run the fast non regression tests (which aren't so fast) on the dev branch instead of on pull requests. This should avoid jobs congestions on our self-hosted runners, especially when multiple PRs are updated at the same time.