### PR TITLE
[CI] Split `t1-linear` and `t1-volume` non regression tests

### DIFF
--- a/.github/workflows/test_pipelines_anat.yml
+++ b/.github/workflows/test_pipelines_anat.yml
@@ -12,15 +12,15 @@ env:
   PYTHON_VERSION: '3.10'
 
 jobs:
-  test-pipelines-anat-MacOS:
+  test-t1-linear-MacOS:
     runs-on:
       - self-hosted
       - macOS
-    timeout-minutes: 720
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1
-      - name: Run tests for anat t1 linear pipelines
+      - name: Run tests for t1 linear pipelines
         run: |
           make env.conda
           source ~/miniconda3/etc/profile.d/conda.sh
@@ -36,8 +36,24 @@ jobs:
           --junitxml=./test-reports/non_regression_anat_t1_linear_mac.xml \
           --disable-warnings \
           ./nonregression/pipelines/anat/test_t1_linear.py
-      - name: Run tests for anat t1 volume pipelines
+  
+  test-t1-volume-MacOS:
+    runs-on:
+      - self-hosted
+      - macOS
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+      - name: Run tests for t1 volume pipelines
         run: |
+          make env.conda
+          source ~/miniconda3/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          source "$(brew --prefix)/opt/modules/init/bash"
+          module load clinica.all
+          make install
+          cd test
           poetry run pytest --verbose \
           --working_directory=/Volumes/data/working_dir_mac \
           --input_data_directory=/Volumes/data_ci \
@@ -46,11 +62,11 @@ jobs:
           --disable-warnings \
           ./nonregression/pipelines/anat/test_t1_volume.py
 
-  test-pipelines-anat-Linux:
+  test-t1-linear-Linux:
     runs-on:
       - self-hosted
       - Linux
-    timeout-minutes: 720
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
       - uses: snok/install-poetry@v1
@@ -61,7 +77,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: poetry
-      - name: Run tests for anat t1 linear pipelines
+      - name: Run tests for t1 linear pipelines
         run: |
           make env.conda
           source /builds/miniconda/etc/profile.d/conda.sh
@@ -77,8 +93,31 @@ jobs:
           --junitxml=./test-reports/non_regression_anat_t1_linear_linux.xml \
           --disable-warnings \
           ./nonregression/pipelines/anat/test_t1_linear.py
-      - name: Run tests for anat t1 volume pipelines
+  
+  test-t1-volume-Linux:
+    runs-on:
+      - self-hosted
+      - Linux
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: poetry
+      - name: Run tests for t1 volume pipelines
         run: |
+          make env.conda
+          source /builds/miniconda/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          source /usr/local/Modules/init/profile.sh
+          module load clinica.all
+          make install
+          cd test
           poetry run pytest --verbose \
           --working_directory=/mnt/data/ci/working_dir_linux \
           --input_data_directory=/mnt/data_ci \


### PR DESCRIPTION
This PR proposes to split the non regression tests for `t1-linear` and `t1-volume` in distinct jobs with distinct timeouts.