### PR TITLE
[CI] Run DWI non regression tests on GitHub actions

### DIFF
--- a/.github/workflows/test_pipelines_dwi.yml
+++ b/.github/workflows/test_pipelines_dwi.yml
@@ -1,0 +1,70 @@
+name: DWI Pipelines Tests
+
+on:
+  schedule:
+    - cron: 0 20 * * 5 # every friday at 8pm
+
+permissions:
+  contents: read
+
+env:
+  POETRY_VERSION: '1.6.1'
+  PYTHON_VERSION: '3.10'
+
+jobs:
+  test-dwi-MacOS:
+    runs-on:
+      - self-hosted
+      - macOS
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+      - name: Run tests for dwi pipelines
+        run: |
+          make env.conda
+          source ~/miniconda3/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          source "$(brew --prefix)/opt/modules/init/bash"
+          module load clinica.all
+          make install
+          cd test
+          poetry run pytest --verbose \
+          --working_directory=/Volumes/data/working_dir_mac \
+          --input_data_directory=/Volumes/data_ci \
+          --basetemp=/Volumes/data/tmp \
+          --junitxml=./test-reports/non_regression_dwi_mac.xml \
+          --disable-warnings \
+          ./nonregression/pipelines/dwi/test_pipelines.py
+
+  test-dwi-Linux:
+    runs-on:
+      - self-hosted
+      - Linux
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: poetry
+      - name: Run tests for dwi pipelines
+        run: |
+          make env.conda
+          source /builds/miniconda/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          source /usr/local/Modules/init/profile.sh
+          module load clinica.all
+          make install
+          cd test
+          poetry run pytest --verbose \
+          --working_directory=/mnt/data/ci/working_dir_linux \
+          --input_data_directory=/mnt/data_ci \
+          --basetemp=/mnt/data/ci/tmp \
+          --junitxml=./test-reports/non_regression_dwi_linux.xml \
+          --disable-warnings \
+          ./nonregression/pipelines/dwi/test_pipelines.py

--- a/.github/workflows/test_pipelines_dwi_preprocessing.yml
+++ b/.github/workflows/test_pipelines_dwi_preprocessing.yml
@@ -1,0 +1,127 @@
+name: DWI Preprocessing Pipelines Tests
+
+on:
+  schedule:
+    - cron: 0 20 * * 1 # every monday at 8pm
+
+permissions:
+  contents: read
+
+env:
+  POETRY_VERSION: '1.6.1'
+  PYTHON_VERSION: '3.10'
+
+jobs:
+  test-dwi-preproc-t1-MacOS:
+    runs-on:
+      - self-hosted
+      - macOS
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+      - name: Run tests for dwi pre-processing using t1 pipelines
+        run: |
+          make env.conda
+          source ~/miniconda3/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          source "$(brew --prefix)/opt/modules/init/bash"
+          module load clinica.all
+          make install
+          cd test
+          poetry run pytest --verbose \
+          --working_directory=/Volumes/data/working_dir_mac \
+          --input_data_directory=/Volumes/data_ci \
+          --basetemp=/Volumes/data/tmp \
+          --junitxml=./test-reports/non_regression_dwi_preproc_using_t1_mac.xml \
+          --disable-warnings \
+          ./nonregression/pipelines/dwi/preprocessing/test_t1.py
+
+  test-dwi-preproc-phasediff-MacOS:
+    runs-on:
+      - self-hosted
+      - macOS
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+      - name: Run tests for dwi pre-processing using phasediff pipelines
+        run: |
+          make env.conda
+          source ~/miniconda3/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          source "$(brew --prefix)/opt/modules/init/bash"
+          module load clinica.all
+          make install
+          cd test
+          poetry run pytest --verbose \
+          --working_directory=/Volumes/data/working_dir_mac \
+          --input_data_directory=/Volumes/data_ci \
+          --basetemp=/Volumes/data/tmp \
+          --junitxml=./test-reports/non_regression_dwi_preproc_using_phasediff_mac.xml \
+          --disable-warnings \
+          ./nonregression/pipelines/dwi/preprocessing/test_phase_diff.py
+
+  test-dwi-preproc-t1-Linux:
+    runs-on:
+      - self-hosted
+      - Linux
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: poetry
+      - name: Run tests for dwi pre-processing using t1 pipelines
+        run: |
+          make env.conda
+          source /builds/miniconda/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          source /usr/local/Modules/init/profile.sh
+          module load clinica.all
+          make install
+          cd test
+          poetry run pytest --verbose \
+          --working_directory=/mnt/data/ci/working_dir_linux \
+          --input_data_directory=/mnt/data_ci \
+          --basetemp=/mnt/data/ci/tmp \
+          --junitxml=./test-reports/non_regression_dwi_preproc_using_t1_linux.xml \
+          --disable-warnings \
+          ./nonregression/pipelines/dwi/preprocessing/test_t1.py
+
+  test-dwi-preproc-phasediff-Linux:
+    runs-on:
+      - self-hosted
+      - Linux
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+          virtualenvs-create: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: poetry
+      - name: Run tests for dwi pre-processing using phasediff pipelines
+        run: |
+          make env.conda
+          source /builds/miniconda/etc/profile.d/conda.sh
+          conda activate "${{ github.workspace }}"/env
+          source /usr/local/Modules/init/profile.sh
+          module load clinica.all
+          make install
+          cd test
+          poetry run pytest --verbose \
+          --working_directory=/mnt/data/ci/working_dir_linux \
+          --input_data_directory=/mnt/data_ci \
+          --basetemp=/mnt/data/ci/tmp \
+          --junitxml=./test-reports/non_regression_dwi_preproc_using_phasediff_linux.xml \
+          --disable-warnings \
+          ./nonregression/pipelines/dwi/preprocessing/test_phase_diff.py


### PR DESCRIPTION
Following #1066 this PR is a portion of #989 and only adds two new workflows running on Github actions as cron jobs for DWI pipelines. 

- Testing of DWI preprocessing pipelines will happen every Monday at 8pm
- Testing of DWI pipelines will happen every Friday at 8pm

It relies on the test splitting done in #1066 