### PR TITLE
[FIX] Update regexp dwi connectome utility function

### DIFF
--- a/clinica/pipelines/dwi_connectome/dwi_connectome_utils.py
+++ b/clinica/pipelines/dwi_connectome/dwi_connectome_utils.py
@@ -1,18 +1,21 @@
-def get_luts():
+from typing import List, Tuple
+
+
+def get_luts() -> list:
     import os
+    from pathlib import Path
 
     from clinica.utils.exceptions import ClinicaException
 
     try:
-        # For aparc+aseg.mgz file:
-        default = os.path.join(os.environ["FREESURFER_HOME"], "FreeSurferColorLUT.txt")
-        # For aparc.a2009s+aseg.mgz file:
-        a2009s = os.path.join(os.environ["FREESURFER_HOME"], "FreeSurferColorLUT.txt")
-
-        # TODO: Add custom Lausanne2008 LUTs here.
+        freesurfer_home = Path(os.environ["FREESURFER_HOME"])
     except KeyError:
         raise ClinicaException("Could not find FREESURFER_HOME environment variable.")
-    return [default, a2009s]
+
+    return [
+        str(freesurfer_home / "FreeSurferColorLUT.txt"),
+        str(freesurfer_home / "FreeSurferColorLUT.txt"),
+    ]
 
 
 def get_conversion_luts_offline():
@@ -20,36 +23,30 @@ def get_conversion_luts_offline():
     return
 
 
-def get_conversion_luts():
-    from os import pardir
-    from os.path import abspath, dirname, join
+def get_conversion_luts() -> list:
     from pathlib import Path
 
     from clinica.utils.inputs import RemoteFileStructure, fetch_file
     from clinica.utils.stream import cprint
 
-    root = dirname(abspath(join(abspath(__file__), pardir, pardir)))
-
-    path_to_mappings = Path(root) / "resources" / "mappings"
-
+    path_to_mappings = (
+        Path(__file__).resolve().parent.parent.parent / "resources" / "mappings"
+    )
     url_mrtrix = "https://raw.githubusercontent.com/MRtrix3/mrtrix3/master/share/mrtrix3/labelconvert/"
-
     fs_default = RemoteFileStructure(
         filename="fs_default.txt",
         url=url_mrtrix,
         checksum="6ee07088915fdbcf52b05147ddae86e5fcaf3efc63db5b0ba8f361637dfa11ef",
     )
-
     fs_a2009s = RemoteFileStructure(
         filename="fs_a2009s.txt",
         url=url_mrtrix,
         checksum="b472f09cfe92ac0b6694fb6b00a87baf15dd269566e4a92b8a151ff1080bf170",
     )
+    ref_fs_default = path_to_mappings / fs_default.filename
+    ref_fs_a2009 = path_to_mappings / fs_a2009s.filename
 
-    ref_fs_default = path_to_mappings / Path(fs_default.filename)
-    ref_fs_a2009 = path_to_mappings / Path(fs_a2009s.filename)
-
-    if not (ref_fs_default.is_file()):
+    if not ref_fs_default.is_file():
         try:
             ref_fs_default = fetch_file(fs_default, path_to_mappings)
         except IOError as err:
@@ -57,7 +54,7 @@ def get_conversion_luts():
                 msg=f"Unable to download required MRTRIX mapping (fs_default.txt) for processing: {err}",
                 lvl="error",
             )
-    if not (ref_fs_a2009.is_file()):
+    if not ref_fs_a2009.is_file():
         try:
             ref_fs_a2009 = fetch_file(fs_a2009s, path_to_mappings)
         except IOError as err:
@@ -69,45 +66,46 @@ def get_conversion_luts():
     return [ref_fs_default, ref_fs_a2009]
 
 
-def get_containers(subjects, sessions):
-    import os
+def get_containers(subjects: list, sessions: list) -> list:
+    from pathlib import Path
 
     return [
-        os.path.join("subjects", subjects[i], sessions[i], "dwi")
-        for i in range(len(subjects))
+        str(Path("subjects") / subject / session / "dwi")
+        for subject, session in zip(subjects, sessions)
     ]
 
 
-def get_caps_filenames(dwi_file: str):
+def get_caps_filenames(dwi_file: str) -> tuple:
     import re
 
-    m = re.search(r"/(sub-[a-zA-Z0-9]+_ses-[a-zA-Z0-9]+.*)_preproc", dwi_file)
-    if not m:
-        raise ValueError(
-            f"Input filename {dwi_file} is not in a CAPS compliant format."
+    error_msg = f"Input filename {dwi_file} is not in a CAPS compliant format."
+    if (
+        m := re.search(
+            r"/(sub-[a-zA-Z0-9]+_ses-[a-zA-Z0-9]+.*_desc-preproc*)_dwi", dwi_file
         )
+    ) is None:
+        raise ValueError(error_msg)
     source_file_caps = m.group(1)
-
-    m = re.search(
-        r"/(sub-[a-zA-Z0-9]+_ses-[a-zA-Z0-9]+.*)_space-[a-zA-Z0-9]+_preproc", dwi_file
-    )
-    if not m:
-        raise ValueError(
-            f"Input filename {dwi_file} is not in a CAPS compliant format."
+    if (
+        m := re.search(
+            r"/(sub-[a-zA-Z0-9]+_ses-[a-zA-Z0-9]+.*)_space-[a-zA-Z0-9]+_desc-preproc_dwi",
+            dwi_file,
         )
+    ) is None:
+        raise ValueError(error_msg)
     source_file_bids = m.group(1)
 
     response = f"{source_file_caps}_model-CSD_responseFunction.txt"
     fod = f"{source_file_caps}_model-CSD_diffmodel.nii.gz"
     tracts = f"{source_file_caps}_model-CSD_tractography.tck"
     nodes = [
-        f"{source_file_caps}_atlas-desikan_parcellation.nii.gz",
-        f"{source_file_caps}_atlas-destrieux_parcellation.nii.gz",
+        f"{source_file_caps}_atlas-{atlas}_parcellation.nii.gz"
+        for atlas in ("desikan", "destrieux")
     ]
     # TODO: Add custom Lausanne2008 node files here.
     connectomes = [
-        f"{source_file_bids}_model-CSD_atlas-desikan_connectivity.tsv",
-        f"{source_file_bids}_model-CSD_atlas-destrieux_connectivity.tsv",
+        f"{source_file_bids}_model-CSD_atlas-{atlas}_connectivity.tsv"
+        for atlas in ("desikan", "destrieux")
     ]
     # TODO: Add custom Lausanne2008 connectome files here.
 

--- a/clinica/pipelines/dwi_connectome/dwi_connectome_utils.py
+++ b/clinica/pipelines/dwi_connectome/dwi_connectome_utils.py
@@ -92,12 +92,10 @@ def get_caps_filenames(dwi_file: str) -> tuple:
         f"{source_file_caps}_atlas-{atlas}_parcellation.nii.gz"
         for atlas in ("desikan", "destrieux")
     ]
-    # TODO: Add custom Lausanne2008 node files here.
     connectomes = [
         f"{source_file_bids}_model-CSD_atlas-{atlas}_connectivity.tsv"
         for atlas in ("desikan", "destrieux")
     ]
-    # TODO: Add custom Lausanne2008 connectome files here.
 
     return response, fod, tracts, nodes, connectomes
 

--- a/test/unittests/pipelines/dwi_connectome/test_dwi_connectome_utils.py
+++ b/test/unittests/pipelines/dwi_connectome/test_dwi_connectome_utils.py
@@ -134,3 +134,21 @@ def test_get_caps_filenames(tmp_path):
             "sub-01_ses-M000_model-CSD_atlas-destrieux_connectivity.tsv",
         ],
     )
+
+
+@pytest.mark.parametrize(
+    "subjects,sessions,expected",
+    [
+        ([], [], []),
+        (["foo"], ["bar"], ["subjects/foo/bar/dwi"]),
+        (
+            ["sub-01", "sub-02"],
+            ["ses-M000", "ses-M006"],
+            ["subjects/sub-01/ses-M000/dwi", "subjects/sub-02/ses-M006/dwi"],
+        ),
+    ],
+)
+def test_get_containers(subjects, sessions, expected):
+    from clinica.pipelines.dwi_connectome.dwi_connectome_utils import get_containers
+
+    assert get_containers(subjects, sessions) == expected

--- a/test/unittests/pipelines/dwi_connectome/test_dwi_connectome_utils.py
+++ b/test/unittests/pipelines/dwi_connectome/test_dwi_connectome_utils.py
@@ -1,0 +1,42 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "foo.txt",
+        "dwi.nii.gz",
+        "sub-01_ses-M000_dwi.nii.gz",
+        "sub-01_ses-M000_preproc.nii.gz",
+        "sub-01_ses-M000_space-T1w_preproc.nii.gz",
+        "sub-01_ses-M000_space-b0_preproc.nii.gz",
+    ],
+)
+def test_get_caps_filenames_error(tmp_path, filename):
+    from clinica.pipelines.dwi_connectome.dwi_connectome_utils import get_caps_filenames
+
+    with pytest.raises(ValueError, match="is not in a CAPS compliant format."):
+        get_caps_filenames(str(tmp_path / filename))
+
+
+def test_get_caps_filenames(tmp_path):
+    from clinica.pipelines.dwi_connectome.dwi_connectome_utils import get_caps_filenames
+
+    dwi_caps = tmp_path / "dwi" / "preprocessing"
+    dwi_caps.mkdir(parents=True)
+
+    assert get_caps_filenames(
+        str(dwi_caps / "sub-01_ses-M000_space-b0_desc-preproc_dwi.nii.gz")
+    ) == (
+        "sub-01_ses-M000_space-b0_desc-preproc_model-CSD_responseFunction.txt",
+        "sub-01_ses-M000_space-b0_desc-preproc_model-CSD_diffmodel.nii.gz",
+        "sub-01_ses-M000_space-b0_desc-preproc_model-CSD_tractography.tck",
+        [
+            "sub-01_ses-M000_space-b0_desc-preproc_atlas-desikan_parcellation.nii.gz",
+            "sub-01_ses-M000_space-b0_desc-preproc_atlas-destrieux_parcellation.nii.gz",
+        ],
+        [
+            "sub-01_ses-M000_model-CSD_atlas-desikan_connectivity.tsv",
+            "sub-01_ses-M000_model-CSD_atlas-destrieux_connectivity.tsv",
+        ],
+    )


### PR DESCRIPTION
Follow-up PR to #1050 

Updates a utility function from DWIConnectome pipeline to handle new format for DWI files.

Also uses pathlib instead of os.path in other utility functions.