### PR TITLE
[ENH] Set the random seed in DWI pipeline using ANTs

### DIFF
--- a/clinica/pipelines/dwi_dti/dwi_dti_cli.py
+++ b/clinica/pipelines/dwi_dti/dwi_dti_cli.py
@@ -15,6 +15,7 @@ pipeline_name = "dwi-dti"
 @cli_param.option_group.common_pipelines_options
 @cli_param.option.subjects_sessions_tsv
 @cli_param.option.working_directory
+@cli_param.option.random_seed
 @option.global_option_group
 @option.n_procs
 def cli(
@@ -22,6 +23,7 @@ def cli(
     subjects_sessions_tsv: Optional[str] = None,
     working_directory: Optional[str] = None,
     n_procs: Optional[int] = None,
+    random_seed: Optional[int] = None,
 ) -> None:
     """DTI-based processing of DWI datasets.
 
@@ -38,6 +40,7 @@ def cli(
         tsv_file=subjects_sessions_tsv,
         base_dir=working_directory,
         name=pipeline_name,
+        parameters={"random_seed": random_seed},
     )
 
     exec_pipeline = (

--- a/clinica/pipelines/dwi_dti/dwi_dti_pipeline.py
+++ b/clinica/pipelines/dwi_dti/dwi_dti_pipeline.py
@@ -20,7 +20,7 @@ class DwiDti(Pipeline):
 
     def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
-        pass
+        self.parameters.setdefault("random_seed", None)
 
     def _check_custom_dependencies(self) -> None:
         pass
@@ -242,6 +242,7 @@ class DwiDti(Pipeline):
     def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
         import os
+        from pathlib import Path
 
         import nipype.interfaces.fsl as fsl
         import nipype.interfaces.mrtrix as mrtrix
@@ -299,10 +300,10 @@ class DwiDti(Pipeline):
         dti_to_metrics = npe.Node(interface=TensorMetrics(), name="2-DTI-based_Metrics")
 
         register_fa = npe.Node(interface=RegistrationSynQuick(), name="3a-Register_FA")
-        fsl_dir = check_environment_variable("FSLDIR", "FSL")
-        fa_map = os.path.join(
-            fsl_dir, "data", "atlases", "JHU", "JHU-ICBM-FA-1mm.nii.gz"
-        )
+        if self.parameters["random_seed"] is not None:
+            register_fa.inputs.random_seed = self.parameters["random_seed"]
+        fsl_dir = Path(check_environment_variable("FSLDIR", "FSL"))
+        fa_map = str(fsl_dir / "data" / "atlases" / "JHU" / "JHU-ICBM-FA-1mm.nii.gz")
         register_fa.inputs.fixed_image = fa_map
 
         ants_transforms = npe.Node(

--- a/test/nonregression/pipelines/dwi/preprocessing/test_t1.py
+++ b/test/nonregression/pipelines/dwi/preprocessing/test_t1.py
@@ -247,6 +247,7 @@ def run_dwi_preprocessing_using_t1(
         "initrand": True,
         "low_bval": 5,
         "use_cuda": False,
+        "random_seed": 42,
     }
     pipeline = DwiPreprocessingUsingT1(
         bids_directory=str(input_dir / "bids"),

--- a/test/nonregression/pipelines/dwi/test_pipelines.py
+++ b/test/nonregression/pipelines/dwi/test_pipelines.py
@@ -41,6 +41,7 @@ def run_dwi_dti(
         caps_directory=str(caps_dir),
         tsv_file=str(input_dir / "subjects.tsv"),
         base_dir=str(working_dir),
+        parameters={"random_seed": 42},
     )
     pipeline.build()
     pipeline.run(plugin="MultiProc", plugin_args={"n_procs": 4}, bypass_check=True)


### PR DESCRIPTION
This is a portion of #989 dealing with adding a random seed option to the CLI of the `DWIDTI` pipeline in order to set the random seed of the `RegistrationSynQuick` interface.
This PR also sets the random seed in related non regression tests.