### PR TITLE
[BUG] Fix deprecation warning with SSL protocol

### DIFF
--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -927,7 +927,8 @@ def fetch_file(remote: RemoteFileStructure, dirname: Optional[str]) -> str:
 
     file_path = os.path.join(dirname, remote.filename)
     # Download the file from `url` and save it locally under `file_name`:
-    gcontext = ssl.SSLContext()
+    gcontext = ssl.SSLContext(protocol=ssl.PROTOCOL_TLS_CLIENT)
+    gcontext.load_default_certs()
     req = Request(remote.url + remote.filename)
     try:
         response = urlopen(req, context=gcontext)


### PR DESCRIPTION
Constructing a SSLContext object without setting a protocol explicitly triggers a deprecation warning since Python 3.10. This commits sets the protocol to `PROTOCOL_TLS_CLIENT` instead of `PROTOCOL_TLS`, since the latter is also deprecated.