### PR TITLE
BUG: Use appropriate numpy dtype for objects

### DIFF
--- a/clinica/pipelines/statistics_surface/_utils.py
+++ b/clinica/pipelines/statistics_surface/_utils.py
@@ -146,7 +146,7 @@ def _convert_dtype_to_str_format(dtype) -> str:
         return "%d"
     if dtype == np.float64:
         return "%f"
-    if dtype == np.object:
+    if dtype == np.object_:
         return "%s"
     raise ValueError(f"Unknown dtype (given: {dtype})")
 


### PR DESCRIPTION
`np.object` is deprecated in favor of `np.object_`

Fixes one of the failures reported by the integration tests.