### PR TITLE
[FIX] Fix linter on dev

### DIFF
--- a/clinica/pipelines/machine_learning/algorithm.py
+++ b/clinica/pipelines/machine_learning/algorithm.py
@@ -386,7 +386,7 @@ class RandomForest(base.MLAlgorithm):
             min_samples_split=min_samples_split,
             max_features="sqrt" if max_features == "auto" else max_features,
             class_weight="balanced" if self._algorithm_params["balanced"] else None,
-            n_jobs=self._algorithm_params["n_threads"]
+            n_jobs=self._algorithm_params["n_threads"],
         )
         classifier.fit(x_train, y_train)
         y_hat_train = classifier.predict(x_train)


### PR DESCRIPTION
Fix pep8 error introduced in #1090 which makes the linter fail on dev.

Wasn't captured by CI since the PR wasn't made from a fork.