### PR TITLE
[CI] Load module Matlab 2019b on MacOS CI machines

### DIFF
--- a/.github/workflows/test_pipelines_anat.yml
+++ b/.github/workflows/test_pipelines_anat.yml
@@ -51,7 +51,7 @@ jobs:
           source ~/miniconda3/etc/profile.d/conda.sh
           conda activate "${{ github.workspace }}"/env
           source "$(brew --prefix)/opt/modules/init/bash"
-          module load clinica/matlab/2017a
+          module load clinica/matlab/2019b
           module load clinica/spm12/r7771
           make install
           cd test


### PR DESCRIPTION
Module Matlab 2017a is only available on Linux machines.