### PR TITLE
[DOC] Improve third-party software documentation page

### DIFF
--- a/docs/Pipelines/DWI_Connectome.md
+++ b/docs/Pipelines/DWI_Connectome.md
@@ -9,11 +9,7 @@ To aim that, it relies on the **MRtrix3** [[Tournier et al., 2019](https://doi.o
 You need to [preprocess your DWI data](../DWI_Preprocessing) and run the [`t1-freesurfer`](../T1_FreeSurfer) pipeline on your T1-weighted MRI images prior to running this pipeline.
 
 ## Dependencies
-<!-- If you installed the docker image of Clinica, nothing is required.-->
-
-If you only installed the core of Clinica, this pipeline needs the installation of **FSL 6.0** and **MRtrix3** on your computer.
-
-You can find how to install these software packages on the [third-party](../../Third-party) page.
+If you only installed the core of Clinica, this pipeline needs the installation of [FSL 6.0](../Third-party.md#fsl) and [MRtrix3](../Third-party.md#mrtrix3) on your computer.
 
 ## Running the pipeline
 

--- a/docs/Pipelines/DWI_DTI.md
+++ b/docs/Pipelines/DWI_DTI.md
@@ -12,11 +12,7 @@ To that aim, it mainly relies on the **MRtrix3** [[Tournier et al., 2019](https:
 You need [preprocessed DWI data](../DWI_Preprocessing) prior to running any of these pipelines.
 
 ## Dependencies
-<!-- If you installed the docker image of Clinica, nothing is required.-->
-
-If you only installed the core of Clinica, this pipeline needs the installation of
-**ANTs v2.3.1**, **FSL 6.0** and **MRtrix3** on your computer.
-You can find how to install these software packages on the [third-party](../../Third-party) page.
+If you only installed the core of Clinica, this pipeline needs the installation of [ANTs v2.5.0](../Third-party.md#ants), [FSL 6.0](../Third-party.md#fsl), and [MRtrix3](../Third-party.md#mrtrix3) on your computer.
 
 ## Running the pipeline
 

--- a/docs/Pipelines/DWI_Preprocessing.md
+++ b/docs/Pipelines/DWI_Preprocessing.md
@@ -22,11 +22,9 @@ computing a single multiplicative bias field from the corrected b0 image(s) as i
 
 ## Dependencies
 
-<!--If you installed the docker image of Clinica, nothing is required.-->
+If you only installed the core of Clinica, the `dwi-preprocessing-*` pipeline needs the installation of [ANTs](../Third-party.md#ants), [FSL](../Third-party.md#fsl), and [MRtrix3](../Third-party.md#mrtrix3) on your computer.
 
-If you only installed the core of Clinica, the `dwi-preprocessing-*` pipeline needs the installation of **ANTs**, **FSL**, and **MRtrix3** on your computer.
-Extra installation of **Convert3D** will be needed for the `dwi-preprocessing-using-t1` pipeline.
-You can find how to install these software packages on the [third-party](../../Third-party) page.
+Extra installation of [Convert3D](../Third-party.md#convert3d) will be needed for the `dwi-preprocessing-using-t1` pipeline.
 
 ## Running the pipeline
 

--- a/docs/Pipelines/FLAIR_Linear.md
+++ b/docs/Pipelines/FLAIR_Linear.md
@@ -15,9 +15,7 @@ cropping of the registered images to remove the background.
 
 ## Dependencies
 
-If you only installed the core of Clinica, this pipeline needs the installation of
-**ANTs** on your computer.
-You can find how to install this software package on the [third-party](../../Third-party) page.
+If you only installed the core of Clinica, this pipeline needs the installation of [ANTs](../Third-party.md#ants) on your computer.
 
 ## Running the pipeline
 

--- a/docs/Pipelines/PET_Linear.md
+++ b/docs/Pipelines/PET_Linear.md
@@ -26,9 +26,7 @@ T1-weighted MR images.
 
 ## Dependencies
 
-If you only installed the core of Clinica, this pipeline needs the installation
-of **ANTs** on your computer. You can find how to install this software package
-on the [third-party](../../Third-party) page.
+If you only installed the core of Clinica, this pipeline needs the installation of [ANTs](../Third-party.md#ants) on your computer.
 
 ## Running the pipeline
 

--- a/docs/Pipelines/PET_Surface.md
+++ b/docs/Pipelines/PET_Surface.md
@@ -22,11 +22,10 @@ This pipeline relies mainly on tools from **[FreeSurfer](https://surfer.nmr.mgh.
 You need to have performed the [`t1-freesurfer`](../T1_FreeSurfer) pipeline on your T1-weighted MR images.
 
 ## Dependencies
-<!-- If you installed the docker image of Clinica, nothing is required.-->
 
-If you only installed the core of Clinica, this pipeline needs the installation of
-**FreeSurfer 6.0**, **SPM12**, **FSL 6.0** and **PETPVC 1.2.4** (which depends on **ITK 4**) on your computer.
-You can find how to install these software packages on the [third-party](../../Third-party) page.
+If you only installed the core of Clinica, this pipeline needs the installation of [FreeSurfer 6.0](../Third-party.md#freesurfer), [FSL 6.0](../Third-party.md#fsl), and [PETPVC 1.2.4](../Third-party.md#petpvc) (which depends on [ITK 4](../Third-party.md#itk)) on your computer.
+
+In addition, you also need to either install [SPM12](../Third-party.md#spm12) and [Matlab](../Third-party.md#matlab), or [spm standalone](../Third-party.md#spm12-standalone).
 
 ## Running the pipeline
 

--- a/docs/Pipelines/PET_Surface_Longitudinal.md
+++ b/docs/Pipelines/PET_Surface_Longitudinal.md
@@ -26,11 +26,11 @@ not the [`t1-freesurfer`](../T1_FreeSurfer) pipeline.
 You need to have performed the [`t1-freesurfer-longitudinal`](../T1_FreeSurfer_Longitudinal) pipeline on your T1-weighted MR images.
 
 ## Dependencies
-<!-- If you installed the docker image of Clinica, nothing is required.-->
 
-If you only installed the core of Clinica, this pipeline needs the installation of
-**FreeSurfer 6.0**, **SPM12**, **FSL 6.0** and **PETPVC 1.2.4** (which depends on **ITK 4**) on your computer.
-You can find how to install these software packages on the [third-party](../../Third-party) page.
+If you only installed the core of Clinica, this pipeline needs the installation of [FreeSurfer 6.0](../Third-party.md#freesurfer), [FSL 6.0](../Third-party.md#fsl), and [PETPVC 1.2.4](../Third-party.md#petpvc) (which depends on [ITK 4](../Third-party.md#itk)) on your computer.
+
+In addition, you also need to either install [SPM12](../Third-party.md#spm12) and [Matlab](../Third-party.md#matlab), or [spm standalone](../Third-party.md#spm12-standalone).
+
 
 ## Running the pipeline
 

--- a/docs/Pipelines/PET_Volume.md
+++ b/docs/Pipelines/PET_Volume.md
@@ -19,14 +19,10 @@ The list of available atlases can be found [here](../../Atlases).
 You need to have performed the [`t1-volume`](../T1_Volume) pipeline on your T1-weighted MR images.
 
 ## Dependencies
-<!--- If you installed the docker image of Clinica, nothing is required.-->
 
-- If you only installed the core of Clinica, this pipeline needs the installation of **SPM12**.
-You can find how to install this software package on the [third-party](../../Third-party) page.
+If you only installed the core of Clinica, this pipeline needs the installation of either [SPM12](../Third-party.md#spm12) and [Matlab](../Third-party.md#matlab), or [spm standalone](../Third-party.md#spm12-standalone).
 
-- If you want to apply partial volume correction (PVC) on your PET data, you will need to install
-**PETPVC 1.2.4**, which depends on **ITK 4**.
-More information on the [third-party](../../Third-party) page.
+In addition, if you want to apply partial volume correction (PVC) on your PET data, you will need to install [PETPVC 1.2.4](../Third-party.md#petpvc), which depends on [ITK 4](../Third-party.md#itk).
 
 ## Running the pipeline
 

--- a/docs/Pipelines/Stats_Surface.md
+++ b/docs/Pipelines/Stats_Surface.md
@@ -19,7 +19,6 @@ You need to process your data with the [`t1-freesurfer` pipeline](../T1_FreeSurf
 Do not hesitate to have a look at the paragraph **[Specifying what surface data to use](#advanced-specifying-what-surface-data-to-use)** if you want to use your own surface feature.
 
 ## Dependencies
-<!--If you installed the docker image of Clinica, nothing is required.-->
 
 If you only installed the core of Clinica, this pipeline needs the installation of **Matlab** and **FreeSurfer 6.0** on your computer.
 You can find how to install these software packages on the [third-party](../../Third-party) page.

--- a/docs/Pipelines/Stats_Volume.md
+++ b/docs/Pipelines/Stats_Volume.md
@@ -8,10 +8,8 @@ Volume-based measurements are analyzed in the [IXI549Space](https://bids-specifi
 Currently, this pipeline mainly handles gray matter maps obtained from T1-weighted MR images using the [`t1-volume` pipeline](../T1_Volume) and standardized uptake value ratio (SUVR) maps obtained from PET data using the [`pet-volume` pipeline](../PET_Volume).
 
 ## Dependencies
-<!--If you installed the docker image of Clinica, nothing is required.-->
 
-If you only installed the core of Clinica, this pipeline needs the installation of **Matlab** and **SPM**, or of **SPM standalone**, on your computer.
-You can find how to install these software packages on the [third-party](../../Third-party) page.
+If you only installed the core of Clinica, this pipeline needs the installation of [Matlab](../Third-party.md#matlab) and [SPM12](../Third-party.md#spm12), or of [SPM standalone](../Third-party.md#spm12-standalone), on your computer.
 
 ## Running the pipeline
 

--- a/docs/Pipelines/T1_FreeSurfer.md
+++ b/docs/Pipelines/T1_FreeSurfer.md
@@ -5,10 +5,8 @@ This pipeline performs cortical surface extraction, segmentation of subcortical 
 Additionally, from the FreeSurfer outputs, we generate TSV files containing a summary of the regional statistics (e.g. regional volume, mean cortical thickness) to ease subsequent statistical analysis.
 
 ## Dependencies
-<!-- If you installed the docker image of Clinica, nothing is required. -->
-If you only installed the core of Clinica, this pipeline needs the installation of
-**FreeSurfer 6.0** on your computer.
-You can find how to install this software on the [third-party](../../Third-party) page.
+
+If you only installed the core of Clinica, this pipeline needs the installation of [FreeSurfer 6.0](../Third-party.md#freesurfer) on your computer.
 
 ## Running the pipeline
 

--- a/docs/Pipelines/T1_FreeSurfer_Longitudinal.md
+++ b/docs/Pipelines/T1_FreeSurfer_Longitudinal.md
@@ -23,9 +23,7 @@ The pipeline requires a prior run of the cross-sectional [`t1-freesurfer`](../T1
 
 ## Dependencies
 
-If you only installed the core of Clinica, this pipeline needs the installation of
-**FreeSurfer 6.0** on your computer.
-You can find how to install this software on the [third-party](../../Third-party) page.
+If you only installed the core of Clinica, this pipeline needs the installation of [FreeSurfer 6.0](../Third-party.md#freesurfer) on your computer.
 
 ## Running the pipeline
 

--- a/docs/Pipelines/T1_Linear.md
+++ b/docs/Pipelines/T1_Linear.md
@@ -20,9 +20,7 @@ deep learning classification algorithms presented in
 
 ## Dependencies
 
-If you only installed the core of Clinica, this pipeline needs the installation of
-**ANTs** on your computer.
-You can find how to install this software package on the [third-party](../../Third-party) page.
+If you only installed the core of Clinica, this pipeline needs the installation of [ANTs](../Third-party.md#ants) on your computer.
 
 ## Running the pipeline
 
@@ -44,7 +42,8 @@ generated to reduce the computing power required when training deep learning mod
 Use the option `--uncropped_image` if you do not want to crop the image.
 
 It is also possible to obtain a deterministic result by setting the value of the random
-seed used by ANTs with the option `--random_seed`. Default will lead to a non-determinstic result. This option requires ANTs version `2.3.0` onwards.
+seed used by ANTs with the option `--random_seed`. Default will lead to a non-determinstic result.
+This option requires ANTs version `2.3.0` onwards.
 
 !!! note
     The arguments common to all Clinica pipelines are described in

--- a/docs/Pipelines/T1_Volume.md
+++ b/docs/Pipelines/T1_Volume.md
@@ -22,15 +22,12 @@ A set of anatomical regions is obtained from different atlases in MNI space (lis
 The average gray matter density (also in MNI space) is then computed in each of the regions.
 
 ## Dependencies
-<!---If you installed the docker image of Clinica, nothing is required.-->
 
-If you only installed the core of Clinica, this pipeline needs the installation of **SPM12**.
-
-You can either install [SPM12](../Third-party.md#spm12) and [Matlab](../Third-party.md#matlab), or install the [SPM standalone](../Third-party.md#spm12-standalone).
+If you only installed the core of Clinica, this pipeline needs the installation of either [SPM12](../Third-party.md#spm12) and [Matlab](../Third-party.md#matlab), or [SPM standalone](../Third-party.md#spm12-standalone) on your computer.
 
 ## Running the pipeline
 
- The pipeline `t1-volume` can be run with the following command line:
+The pipeline `t1-volume` can be run with the following command line:
 
 ```Text
 clinica run t1-volume [OPTIONS] BIDS_DIRECTORY CAPS_DIRECTORY GROUP_LABEL

--- a/docs/Pipelines/T1_Volume.md
+++ b/docs/Pipelines/T1_Volume.md
@@ -1,8 +1,7 @@
 <!-- markdownlint-disable MD007 MD033 -->
 # `t1-volume` – Volume-based processing of T1-weighted MR images with SPM
 
-This pipeline performs four main processing steps on T1-weighted MR images using the
-[SPM](http://www.fil.ion.ucl.ac.uk/spm/) software:
+This pipeline performs four main processing steps on T1-weighted MR images using the [SPM](http://www.fil.ion.ucl.ac.uk/spm/) software:
 
 - **Tissue segmentation, bias correction and spatial normalization to MNI space**
 This corresponds to the `Segmentation` procedure of SPM that simultaneously performs tissue segmentation, bias correction and spatial normalization, a procedure also known as "Unified segmentation" [[Ashburner and Friston, 2005](http://dx.doi.org/10.1016/j.neuroimage.2005.02.018)].
@@ -25,9 +24,9 @@ The average gray matter density (also in MNI space) is then computed in each of 
 ## Dependencies
 <!---If you installed the docker image of Clinica, nothing is required.-->
 
-If you only installed the core of Clinica, this pipeline needs the installation of
-**SPM12**.
-You can find how to install these software packages on the [third-party](../../Third-party) page.
+If you only installed the core of Clinica, this pipeline needs the installation of **SPM12**.
+
+You can either install [SPM12](../Third-party.md#spm12) and [Matlab](../Third-party.md#matlab), or install the [SPM standalone](../Third-party.md#spm12-standalone).
 
 ## Running the pipeline
 

--- a/docs/Third-party.md
+++ b/docs/Third-party.md
@@ -3,8 +3,7 @@
 
 ## Converters
 
-Some converters require a recent version of [dcm2niix](https://github.com/rordenlab/dcm2niix) to transform DICOM files
-into NIfTI:
+Some converters require a recent version of [dcm2niix](https://github.com/rordenlab/dcm2niix) to transform DICOM files into NIfTI:
 
 |                   | dcm2niix |
 |:------------------|:--------:|
@@ -44,70 +43,269 @@ _*You only need to install ITK if you plan to perform partial volume correction 
 Depending on the architecture and OS of your system, setup of third party libraries can change.
 Please refer to each tool’s website for installation instructions:
 
-- [**ANTs v2.5.0**](http://stnava.github.io/ANTs/) Download [here](https://github.com/stnava/ANTs/releases) and follow the instructions on the ANTs [wiki](https://github.com/stnava/ANTs/wiki/Compiling-ANTs-on-Linux-and-Mac-OS).
-- [**Convert3D**](http://www.itksnap.org/pmwiki/pmwiki.php?n=Convert3D.Convert3D) Download [here](http://www.itksnap.org/pmwiki/pmwiki.php?n=Downloads.C3D).
-- [**FreeSurfer**](http://surfer.nmr.mgh.harvard.edu/)
-  - For Linux users, download and install FreeSurfer following the instructions on the [wiki](http://surfer.nmr.mgh.harvard.edu/fswiki/DownloadAndInstall).
-  Please note that on Ubuntu you will need to install the packages `tcsh` and `libjpeg62` ( a `sudo apt-get install tcsh libjpeg62` should do the job).
-  - For Mac users, download [here](http://surfer.nmr.mgh.harvard.edu/fswiki/DownloadAndInstall) and follow the instructions on the FreeSurfer [wiki](https://surfer.nmr.mgh.harvard.edu/fswiki/MacOsInstall).
-- [**FSL 6.0**](https://fsl.fmrib.ox.ac.uk/) Download [here](https://fsl.fmrib.ox.ac.uk/fsldownloads) and follow the instructions on the FSL wiki (this [page](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslInstallation/Linux) for Linux users and this [page](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslInstallation/MacOsX) for Mac users).
-- [**ITK**](https://itk.org/) Follow the instructions on the ITK blog (this [page](https://blog.kitware.com/itk-packages-in-linux-distributions/) for Linux users and this [page](https://blog.kitware.com/kitware-packages-on-os-x-with-homebrew/) for Mac users).
-- [**MRtrix3**](http://www.mrtrix.org) Follow the instructions on the MRtrix [website](https://www.mrtrix.org/download/)
-  - For Linux users: use the official package for [Anaconda](https://www.mrtrix.org/download/linux-anaconda/) or follow this set of [instructions](https://mrtrix.readthedocs.io/en/latest/installation/build_from_source.html#linux) to build it from source.
-  - For Mac users: use the official package for [Anaconda](https://www.mrtrix.org/download/macos-anaconda/) or the official [installer](https://www.mrtrix.org/download/macos-application/). There is also this [Homebrew formula](https://github.com/MRtrix3/homebrew-mrtrix3), although large dependencies such as XCode and Qt5 are required.
-- [**Matlab**](https://fr.mathworks.com/products/matlab/)
-- [**PETPVC 1.2.4**](https://github.com/UCL/PETPVC) Follow the instructions [here](https://github.com/UCL/PETPVC).
-Do not forget to compile in RELEASE mode, otherwise, partial volume correction will be very slow.
-- [**SPM12**](http://www.fil.ion.ucl.ac.uk/spm/) Download the latest version [here](http://www.fil.ion.ucl.ac.uk/spm/download/restricted/eldorado/spm12.zip) and follow the instructions on the SPM wiki (this [page](https://en.wikibooks.org/wiki/SPM/Installation_on_64bit_Linux) for Linux users and this [page](https://en.wikibooks.org/wiki/SPM/Installation_on_64bit_Mac_OS_(Intel)) for Mac users).
-  - For systems running on MacOS Big Sur, a development version of SPM12 (check [here](https://www.fil.ion.ucl.ac.uk/spm/download/restricted/utopia/dev/) for updates) as well as a more recent release of the MCR (minimum 2019a) are required.
+### Environment variables setup
 
-Do not forget to check the installations following each tool’s guidelines.
+When installing some of the third party software, environment variables might be needed in order to configure some installations.
 
-## Environment variables setup
+If you simply run the `export` and `source` commands in your terminal, these environment variables will be defined only for the duration of your session, and will be lost if you re-launch your terminal.
 
-Edit the configuration file associated to your shell.
-If you are using `bash`, it can be `~/.bashrc` or `~/.bash_profile`, if you are using `zsh`, it must be `~/.zshrc`.
-Your file must look like as below.
-Please be careful if you copy/paste this, some adjustments are needed.
-You must specify on the corresponding lines the path to your different installations.
+In order to define these variables permanently, you need to manually edit the configuration file associated to your shell.
 
-```bash
-# System language setting:
-export LC_ALL=en_US.UTF-8
-export LANG=en_US.UTF-8
+If you are using `bash`, it can be `~/.bashrc` or `~/.bash_profile`, if you are using `zsh`, it should be `~/.zshrc`.
 
-# Miniconda
-source /path/to/your/Miniconda/etc/profile.d/conda.sh
+!!! note "test before"
+    Please do not copy/paste the provided commands without adapting them to your system and without testing them.
+    Most paths provided here require to be adapted to your system, and also depends on how you installed the software.
+    A good approach is to verify that the different paths you want to assign to a variable exist first.
+    If they do, then try running the `export` and `source` commands in your terminal, and verify that the software run as expected.
+    You can also verify that the pipeline you want to use is also running as expected.
+    If this works, then consider modifying your shell configuration file to have these variables automatically defined on every session.
 
-# FreeSurfer
-export FREESURFER_HOME="/Applications/freesurfer"
-source ${FREESURFER_HOME}/SetUpFreeSurfer.sh &> /dev/null
 
-# FSL
-# Uncomment the line below if you are on Mac:
-#export FSLDIR="/usr/local/fsl"
-# Uncomment the line below if you are on Linux:
-#export FSLDIR="/usr/share/fsl/6.0"
-export PATH="${FSLDIR}/bin":${PATH}
-source ${FSLDIR}/etc/fslconf/fsl.sh
+### ANTs
 
-# Matlab
-export MATLAB_HOME="/path/to/your/matlab/bin/"
-export PATH=${MATLAB_HOME}:${PATH}
-export MATLABCMD="${MATLAB_HOME}/matlab"
+#### Installation
 
-# SPM
-export SPM_HOME="/path/to/your/spm12"
-```
+To install `ANTs`, download it from [here](https://github.com/stnava/ANTs/releases) and follow the instructions on the `ANTs` [wiki](https://github.com/stnava/ANTs/wiki/Compiling-ANTs-on-Linux-and-Mac-OS).
 
-We recommend installing `ANTS >= 2.5.0` from which no environment variable are needed.
-Nonetheless, if you are using an older version of ANTS, make sure to have the following environment variables defined:
+#### Configuration
+
+We strongly recommend installing `ANTs >= 2.5.0` from which **no environment variable are needed**.
+
+Nonetheless, if you are using an older version of `ANTs`, make sure to have the following environment variables defined:
 
 ```bash
-# ANTs
 export ANTSPATH="/path/to/your/ANTs/"
 export PATH=${ANTSPATH}:${PATH}
 ```
+
+### Convert3D
+
+You can find more details about `Convert3D` [here](http://www.itksnap.org/pmwiki/pmwiki.php?n=Convert3D.Convert3D).
+
+#### Installation
+
+You have two options to install `Convert3D`:
+
+- [Use pre-built binaries](http://www.itksnap.org/pmwiki/pmwiki.php?n=Downloads.C3D).
+- [Use the official conda package](https://anaconda.org/conda-forge/convert3d).
+
+### Freesurfer
+
+You can find more details about `Freesurfer` [here](http://surfer.nmr.mgh.harvard.edu/).
+
+#### Installation
+
+##### On Linux
+
+Download and install `FreeSurfer` following the instructions on the [wiki](http://surfer.nmr.mgh.harvard.edu/fswiki/DownloadAndInstall).
+
+!!! note
+    Please note that on Ubuntu you will need to install the packages `tcsh` and `libjpeg62` ( a `sudo apt-get install tcsh libjpeg62` should do the job).
+
+##### On MacOS
+
+Download it from [here](http://surfer.nmr.mgh.harvard.edu/fswiki/DownloadAndInstall) and follow the instructions on the `FreeSurfer` [wiki](https://surfer.nmr.mgh.harvard.edu/fswiki/MacOsInstall).
+
+#### Configuration
+
+Make sure to have the following environment variables defined:
+
+```bash
+export FREESURFER_HOME="/Applications/freesurfer"
+source ${FREESURFER_HOME}/SetUpFreeSurfer.sh &> /dev/null
+```
+
+### FSL
+
+We recommend installing [**FSL 6.0**](https://fsl.fmrib.ox.ac.uk/).
+
+#### Installation
+
+##### On Linux
+
+Download it from [here](https://fsl.fmrib.ox.ac.uk/fsldownloads) and follow the instructions on the [FSL wiki](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslInstallation/Linux).
+
+##### On MacOS
+
+Download it from [here](https://fsl.fmrib.ox.ac.uk/fsldownloads) and follow the instructions on the [FSL wiki](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/FslInstallation/MacOsX).
+
+#### Configuration
+
+##### On Linux
+
+Make sure to have the following environment variables defined:
+
+```bash
+export FSLDIR="/usr/share/fsl/6.0"
+export PATH="${FSLDIR}/bin":${PATH}
+source ${FSLDIR}/etc/fslconf/fsl.sh
+```
+
+##### On MacOS
+
+Make sure to have the following environment variables defined:
+
+```bash
+export FSLDIR="/usr/local/fsl"
+export PATH="${FSLDIR}/bin":${PATH}
+source ${FSLDIR}/etc/fslconf/fsl.sh
+```
+
+### ITK
+
+You can find more details about `ITK` [here](https://itk.org/).
+
+#### Installation
+
+##### On Linux
+
+Follow the instructions on the [ITK blog](https://blog.kitware.com/itk-packages-in-linux-distributions/).
+
+##### On MacOS
+
+Follow the instructions on the [ITK blog](https://blog.kitware.com/kitware-packages-on-os-x-with-homebrew/).
+
+### MRtrix3
+
+You can find more details about `MRtrix3` [here](http://www.mrtrix.org).
+
+#### Installation
+
+You can find the official instructions on the `MRtrix` [website](https://www.mrtrix.org/download/).
+
+##### On Linux
+
+You have basically two options:
+
+- [Use the official conda package](https://www.mrtrix.org/download/linux-anaconda/).
+- [Build MRtrix3 from source](https://mrtrix.readthedocs.io/en/latest/installation/build_from_source.html#linux).
+
+!!! note
+    Note that using the conda package should be easier in most cases.
+
+##### On MacOS
+
+- [Use the official conda package](https://www.mrtrix.org/download/macos-anaconda/).
+- [Use the MacOS pre-compiled application package installer](https://www.mrtrix.org/download/macos-application/).
+- [Use the Homebrew formula](https://github.com/MRtrix3/homebrew-mrtrix3) (although large dependencies such as `XCode` and `Qt5` are required).
+
+!!! note
+    As for Linux, note that using the conda package should be easier in most cases.
+
+### Matlab
+
+You can find more details about `Matlab` [here](https://fr.mathworks.com/products/matlab/).
+
+!!! note
+    Note that using `Matlab` requires having a valid license which might be available through your university or institution.
+
+#### Configuration
+
+Make sure to have the following environment variables defined:
+
+```bash
+export MATLAB_HOME="/path/to/your/matlab/bin/"
+export PATH=${MATLAB_HOME}:${PATH}
+export MATLABCMD="${MATLAB_HOME}/matlab"
+```
+
+### PETPVC
+
+You can find more details about `PETPVC` [here](https://github.com/UCL/PETPVC).
+
+#### Installation
+
+You can find the official instructions in the README of [this page](https://github.com/UCL/PETPVC).
+
+You have basically three options:
+
+- Use pre-built binaries, available [here](https://github.com/UCL/PETPVC/releases).
+- [Use the official conda package](https://anaconda.org/conda-forge/petpvc).
+- [Build from source](https://github.com/UCL/PETPVC?tab=readme-ov-file#installation-from-source-instructions).
+
+!!! note
+    If building from source, do not forget to compile in RELEASE mode, otherwise, partial volume correction will be very slow.
+
+### SPM12
+
+You can find more details about `SPM12` [here](http://www.fil.ion.ucl.ac.uk/spm/).
+
+Note that `SPM12` works with [Matlab](#matlab) such that clinica pipelines which require `SPM12`, will also need a `Matlab` installation.
+
+If you cannot install `Matlab`, you can install [SPM standalone](#spm12-standalone).
+
+#### Installation
+
+##### On Linux
+
+Download the latest version [here](http://www.fil.ion.ucl.ac.uk/spm/download/restricted/eldorado/spm12.zip) and follow the instructions on the [SPM wiki](https://en.wikibooks.org/wiki/SPM/Installation_on_64bit_Linux).
+
+##### On MacOS
+
+Download the latest version [here](http://www.fil.ion.ucl.ac.uk/spm/download/restricted/eldorado/spm12.zip) and follow the instructions on the [SPM wiki](https://en.wikibooks.org/wiki/SPM/Installation_on_64bit_Mac_OS_(Intel)).
+
+!!! note
+    For systems running on MacOS Big Sur, a [development version of SPM12](https://www.fil.ion.ucl.ac.uk/spm/download/restricted/utopia/dev/) as well as a more recent release of the MCR (minimum 2019a) are required.
+
+#### Configuration
+
+Make sure to have the following environment variable defined:
+
+```bash
+export SPM_HOME="/path/to/your/spm12"
+```
+
+You must also add `SPM` to the `MATLAB` path variable if you installed it as a toolbox.
+
+To do so, add the following line to your `startup.m` file located in your *initial working folder*, by default `~/Documents/MATLAB` (see [here](https://fr.mathworks.com/help/matlab/ref/startup.html) for more details).
+
+If the file does not exist, you can create it and type inside:
+
+```matlab
+addpath('/path/to/your/spm12');
+```
+
+You can also replace the previous line by the following, assuming the `$SPM_HOME` environment variable is set in your `~/.bashrc` file.
+
+```matlab
+[~, spmhome] = system('source ~/.bashrc > /dev/null; echo $SPM_HOME;');
+spmhome = strsplit(spmhome,'\n');
+addpath(spmhome{end-1});
+```
+
+!!! Note
+    `zsh` shell users will have to replace `~/.bashrc` by `~/.zshrc`.
+
+### SPM12 standalone
+
+If you want to install `SPM12` without installing [Matlab](#matlab), you will need to install two things:
+
+- The Matlab runtime (often abbreviated into MCR), for which no license is required.
+- The SPM standalone itself.
+
+#### Installation
+
+You can find details on how to install these on [this page](https://www.fil.ion.ucl.ac.uk/spm/docs/installation/standalone/).
+
+#### Configuration
+
+!!! note
+    If you followed the installation instructions, you should have set the environment variable `$LD_LIBRARY_PATH`.
+
+In addition, you need to define the following environment variables:
+
+```bash
+export MCR_HOME="/path/to/your/MCR/"
+export SPMSTANDALONE_HOME="/path/to/your/spmstandalone/home/"
+export SPM_HOME="/path/to/your/spmstandalone/home/"
+```
+
+!!! note
+    You still need to define `$SPM_HOME` even if using `spm standalone`, otherwise you will get a Clinica error.
+    Clinica will still use spm standalone if these variables are set correctly.
+
+## Autocompletion
 
 <!-- # Autocomplete system
 eval "$(register-python-argcomplete clinica)" -->
@@ -121,21 +319,3 @@ eval "$(register-python-argcomplete clinica)" -->
     source ~/.bash_completion.d/python-argcomplete.sh
     ```
 
-You must also add SPM to the MATLAB path variable if you installed it as a toolbox.
-To do so, add the following line to your `startup.m` file located in your *initial working folder*, by default `~/Documents/MATLAB` (see [here](https://fr.mathworks.com/help/matlab/ref/startup.html) for more details).
-If the file does not exist, you can create it and type inside:
-
-```matlab
-addpath('/path/to/your/spm12');
-```
-
-You can also replace the previous line by the following, assuming the `SPM_HOME` environment variable is set in your `~/.bashrc` file.
-
-```matlab
-[~, spmhome] = system('source ~/.bashrc > /dev/null; echo $SPM_HOME;');
-spmhome = strsplit(spmhome,'\n');
-addpath(spmhome{end-1});
-```
-
-!!! Note
-    `zsh` shell users will have to replace `~/.bashrc` by `~/.zshrc`.


### PR DESCRIPTION
Partly linked to #820, this PR proposes to improve the documentation for the installation of third party softwares.

Instead of having them simply listed in a bullet point list, this PR proposes to have a proper section for each software, with subsections concerning installation steps and configuration steps.

This also changes the explanations about environment variables which were all grouped in a single section.
This could be annoying to users who might only need a subset of them.
With the proposed organization, they only need to define the environment variables described in the configuration section of the software they are interested in.

Finally, this way of organizing things makes it possible to link directly to specific software from pipeline pages instead of linking the third-party page and let the user scroll through it.

In addition, this PR proposes to add documentation about installing and configuring SPM standalone, which was missing from current doc.