### PR TITLE
[REF] Refactor dependency checking logic for third party softwares

### DIFF
--- a/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
@@ -48,9 +48,9 @@ class AdniToBids(Converter):
     @classmethod
     def check_adni_dependencies(cls) -> None:
         """Check the dependencies of ADNI converter."""
-        from clinica.utils.check_dependency import check_dcm2niix
+        from clinica.utils.check_dependency import ThirdPartySoftware, check_software
 
-        check_dcm2niix()
+        check_software(ThirdPartySoftware.DCM2NIIX)
 
     def convert_clinical_data(
         self,

--- a/clinica/iotools/converters/aibl_to_bids/aibl_to_bids.py
+++ b/clinica/iotools/converters/aibl_to_bids/aibl_to_bids.py
@@ -40,12 +40,10 @@ def convert(
         If specified, it should be between 1 and the number of available CPUs.
         Default=1.
     """
-    from clinica.utils.check_dependency import check_dcm2niix
+    from clinica.utils.check_dependency import ThirdPartySoftware, check_software
 
-    check_dcm2niix()
-
+    check_software(ThirdPartySoftware.DCM2NIIX)
     output_dataset.mkdir(parents=True, exist_ok=True)
-
     if not clinical_data_only:
         _convert_images(
             input_dataset,
@@ -54,7 +52,6 @@ def convert(
             overwrite,
             n_procs=n_procs,
         )
-
     _convert_clinical_data(input_clinical_data, output_dataset)
 
 

--- a/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_cli.py
+++ b/clinica/iotools/converters/genfi_to_bids/genfi_to_bids_cli.py
@@ -43,11 +43,10 @@ def cli(
     """
     from clinica.iotools.bids_utils import _write_bidsignore
     from clinica.iotools.converters.genfi_to_bids.genfi_to_bids import convert_images
-    from clinica.utils.check_dependency import check_dcm2niix
+    from clinica.utils.check_dependency import ThirdPartySoftware, check_software
     from clinica.utils.stream import cprint
 
-    check_dcm2niix()
-
+    check_software(ThirdPartySoftware.DCM2NIIX)
     convert_images(
         dataset_directory,
         bids_directory,
@@ -56,7 +55,6 @@ def cli(
         clinical_data_tsv,
     )
     _write_bidsignore(str(bids_directory))
-
     cprint("Conversion to BIDS succeeded.")
 
 

--- a/clinica/iotools/converters/nifd_to_bids/nifd_to_bids_cli.py
+++ b/clinica/iotools/converters/nifd_to_bids/nifd_to_bids_cli.py
@@ -20,13 +20,11 @@ def cli(
     CLINICAL_DATA_DIRECTORY respectively, to a BIDS dataset in the target BIDS_DIRECTORY.
     """
     from clinica.iotools.converters.nifd_to_bids.nifd_to_bids import convert_images
-    from clinica.utils.check_dependency import check_dcm2niix
+    from clinica.utils.check_dependency import ThirdPartySoftware, check_software
     from clinica.utils.stream import cprint
 
-    check_dcm2niix()
-
+    check_software(ThirdPartySoftware.DCM2NIIX)
     convert_images(dataset_directory, bids_directory, clinical_data_directory)
-
     cprint("Conversion to BIDS succeeded.")
 
 

--- a/clinica/iotools/converters/oasis3_to_bids/oasis3_to_bids_cli.py
+++ b/clinica/iotools/converters/oasis3_to_bids/oasis3_to_bids_cli.py
@@ -20,7 +20,6 @@ def cli(
     CLINICAL_DATA_DIRECTORY respectively, to a BIDS dataset in the target BIDS_DIRECTORY.
     """
     from clinica.iotools.converters.oasis3_to_bids.oasis3_to_bids import convert_images
-    from clinica.utils.check_dependency import check_dcm2niix
     from clinica.utils.stream import cprint
 
     convert_images(dataset_directory, bids_directory, clinical_data_directory)

--- a/clinica/iotools/converters/ukb_to_bids/ukb_to_bids_cli.py
+++ b/clinica/iotools/converters/ukb_to_bids/ukb_to_bids_cli.py
@@ -21,14 +21,12 @@ def cli(
     """
     from clinica.iotools.bids_utils import _write_bidsignore
     from clinica.iotools.converters.ukb_to_bids.ukb_to_bids import convert_images
-    from clinica.utils.check_dependency import check_dcm2niix
+    from clinica.utils.check_dependency import ThirdPartySoftware, check_software
     from clinica.utils.stream import cprint
 
-    check_dcm2niix()
-
+    check_software(ThirdPartySoftware.DCM2NIIX)
     convert_images(dataset_directory, bids_directory, clinical_data_directory)
     _write_bidsignore(str(bids_directory))
-
     cprint("Conversion to BIDS succeeded.")
 
 

--- a/clinica/pipelines/dwi/connectome/utils.py
+++ b/clinica/pipelines/dwi/connectome/utils.py
@@ -14,15 +14,11 @@ __all__ = [
 
 
 def get_luts() -> List[str]:
-    from pathlib import Path
-
-    from clinica.utils.check_dependency import check_environment_variable
-
-    freesurfer_home = Path(check_environment_variable("FREESURFER_HOME", "Freesurfer"))
+    from clinica.utils.check_dependency import get_freesurfer_home
 
     return [
-        str(freesurfer_home / "FreeSurferColorLUT.txt"),
-        str(freesurfer_home / "FreeSurferColorLUT.txt"),
+        str(get_freesurfer_home() / "FreeSurferColorLUT.txt"),
+        str(get_freesurfer_home() / "FreeSurferColorLUT.txt"),
     ]
 
 

--- a/clinica/pipelines/dwi/dti/pipeline.py
+++ b/clinica/pipelines/dwi/dti/pipeline.py
@@ -241,8 +241,6 @@ class DwiDti(Pipeline):
 
     def _build_core_nodes(self):
         """Build and connect the core nodes of the pipeline."""
-        from pathlib import Path
-
         import nipype.interfaces.fsl as fsl
         import nipype.interfaces.mrtrix as mrtrix
         import nipype.interfaces.utility as nutil
@@ -251,7 +249,7 @@ class DwiDti(Pipeline):
         from nipype.interfaces.mrtrix.preprocess import DWI2Tensor
         from nipype.interfaces.mrtrix3 import TensorMetrics
 
-        from clinica.utils.check_dependency import check_environment_variable
+        from clinica.utils.check_dependency import get_fsl_home
 
         from .tasks import compute_statistics_on_atlases_task, get_caps_filenames_task
         from .utils import (
@@ -288,8 +286,9 @@ class DwiDti(Pipeline):
         register_fa = npe.Node(interface=RegistrationSynQuick(), name="3a-Register_FA")
         if self.parameters["random_seed"] is not None:
             register_fa.inputs.random_seed = self.parameters["random_seed"]
-        fsl_dir = Path(check_environment_variable("FSLDIR", "FSL"))
-        fa_map = str(fsl_dir / "data" / "atlases" / "JHU" / "JHU-ICBM-FA-1mm.nii.gz")
+        fa_map = str(
+            get_fsl_home() / "data" / "atlases" / "JHU" / "JHU-ICBM-FA-1mm.nii.gz"
+        )
         register_fa.inputs.fixed_image = fa_map
 
         ants_transforms = npe.Node(

--- a/clinica/pipelines/engine.py
+++ b/clinica/pipelines/engine.py
@@ -763,32 +763,13 @@ class Pipeline(Workflow):
         Returns:
             self: A Pipeline object.
         """
-        import clinica.utils.check_dependency as chk
+        from clinica.utils.check_dependency import check_binary, check_software
 
-        # Checking functions preparation
-        check_software = {
-            # 'matlab': chk.check_matlab,
-            "ants": chk.check_ants,
-            "convert3d": chk.check_convert3d,
-            "spm": chk.check_spm,
-            "freesurfer": chk.check_freesurfer,
-            "fsl": chk.check_fsl,
-            "mrtrix": chk.check_mrtrix,
-            "matlab": chk.check_matlab,
-            "petpvc": chk.check_petpvc,
-        }
-        check_binary = chk.is_binary_present
-        # check_toolbox = chk.is_toolbox_present
-        # check_pipeline = chk.is_pipeline_present
-
-        # Load the info.json file
         if not self.info:
             self._load_info()
-
-        # Dependencies checking
         for d in self.info["dependencies"]:
             if d["type"] == "software":
-                check_software[d["name"]]()
+                check_software(d["name"])
             elif d["type"] == "binary":
                 check_binary(d["name"])
             elif d["type"] == "toolbox":
@@ -799,7 +780,6 @@ class Pipeline(Workflow):
                 raise Exception(
                     f"Pipeline.check_dependencies() Unknown dependency type: '{d['type']}'."
                 )
-
         self._check_custom_dependencies()
 
         return self

--- a/clinica/pipelines/statistics_surface/_utils.py
+++ b/clinica/pipelines/statistics_surface/_utils.py
@@ -211,13 +211,9 @@ def run_clinica_surfstat(
     output_dir : Path
         The path to the output directory.
     """
-    from pathlib import Path
-
     from clinica.pipelines.statistics_surface._utils import build_design_matrix
     from clinica.pipelines.statistics_surface.surfstat import clinica_surfstat
-    from clinica.utils.check_dependency import check_environment_variable
-
-    freesurfer_home = Path(check_environment_variable("FREESURFER_HOME", "FreeSurfer"))
+    from clinica.utils.check_dependency import get_freesurfer_home
 
     clinica_surfstat(
         caps_dir / "subjects",
@@ -229,7 +225,7 @@ def run_clinica_surfstat(
         pipeline_parameters["contrast"],
         pipeline_parameters["glm_type"],
         pipeline_parameters["group_label"],
-        freesurfer_home,
+        get_freesurfer_home(),
         pipeline_parameters["measure_label"],
         surface_file=pipeline_parameters["custom_file"],
         fwhm=pipeline_parameters["full_width_at_half_maximum"],

--- a/clinica/pipelines/t1_freesurfer/t1_freesurfer_visualizer.py
+++ b/clinica/pipelines/t1_freesurfer/t1_freesurfer_visualizer.py
@@ -31,11 +31,10 @@ class T1FreeSurferVisualizer(ce.CmdParser):
         import os
         import subprocess
 
-        from clinica.utils.check_dependency import check_freesurfer
+        from clinica.utils.check_dependency import ThirdPartySoftware, check_software
         from clinica.utils.stream import cprint
 
-        check_freesurfer()
-
+        check_software(ThirdPartySoftware.FREESURFER)
         participant_id = args.participant_id
         session_id = args.session_id
         subject_id = participant_id + "_" + session_id

--- a/clinica/utils/atlas.py
+++ b/clinica/utils/atlas.py
@@ -136,12 +136,11 @@ class FSLAtlas(BaseAtlas):
     """FSL atlases look for the labels in the FSL folder (requires FSL)."""
 
     def __init__(self, name: str, roi_filename: str, atlas_filename: str):
-        from .check_dependency import check_environment_variable
+        from .check_dependency import get_fsl_home
 
         super().__init__(name, roi_filename)
         self.atlas_filename = atlas_filename
-        fsl_dir = Path(check_environment_variable("FSLDIR", "FSL"))
-        self.atlas_dir = fsl_dir / "data" / "atlases" / "JHU"
+        self.atlas_dir = get_fsl_home() / "data" / "atlases" / "JHU"
 
 
 class JHUDTI811mm(FSLAtlas):

--- a/clinica/utils/check_dependency.py
+++ b/clinica/utils/check_dependency.py
@@ -3,17 +3,104 @@
 These functions can check binaries, software (e.g. FreeSurfer) or toolboxes (e.g. SPM).
 """
 import functools
-from typing import List, Optional, Tuple
+import os
+from enum import Enum
+from pathlib import Path
+from typing import Optional, Tuple, Union
 
 from clinica.utils.exceptions import ClinicaMissingDependencyError
 
+__all__ = [
+    "ThirdPartySoftware",
+    "SoftwareEnvironmentVariable",
+    "get_fsl_home",
+    "get_freesurfer_home",
+    "get_mcr_home",
+    "get_spm_standalone_home",
+    "get_spm_home",
+    "is_binary_present",
+    "check_binary",
+    "check_environment_variable",
+    "check_software",
+]
 
-def is_binary_present(binary: str) -> bool:
+
+class ThirdPartySoftware(str, Enum):
+    """Possible third party software that clinica depends on."""
+
+    ANTS = "ants"
+    CONVERT3D = "convert3d"
+    DCM2NIIX = "dcm2niix"
+    FREESURFER = "freesurfer"
+    FSL = "fsl"
+    MATLAB = "matlab"
+    MCR = "MCR"
+    MRTRIX = "mrtrix"
+    PETPVC = "petpvc"
+    SPM = "SPM"
+    SPMSTANDALONE = "SPM Standalone"
+
+
+class SoftwareEnvironmentVariable:
+    """Represents an environment variable name linked to a specific software.
+
+    Attributes
+    ----------
+    name : str
+        The name of the environment variable.
+
+    software : ThirdPartySoftware
+        The name of the software related to the environment variable.
+    """
+
+    def __init__(self, name: str, software: Union[str, ThirdPartySoftware]):
+        self.name = name
+        self.software = ThirdPartySoftware(software)
+
+
+def get_fsl_home() -> Path:
+    """Return the path to the home directory of FSL."""
+    return check_environment_variable(
+        SoftwareEnvironmentVariable("FSLDIR", ThirdPartySoftware.FSL)
+    )
+
+
+def get_freesurfer_home() -> Path:
+    """Return the path to the home directory of Freesurfer."""
+    return check_environment_variable(
+        SoftwareEnvironmentVariable("FREESURFER_HOME", ThirdPartySoftware.FREESURFER)
+    )
+
+
+def get_mcr_home() -> Path:
+    """Return the path to the home directory of Matlab MCR."""
+    return check_environment_variable(
+        SoftwareEnvironmentVariable("MCR_HOME", ThirdPartySoftware.MCR)
+    )
+
+
+def get_spm_standalone_home() -> Path:
+    """Return the path to the home directory of SPM standalone"""
+    return check_environment_variable(
+        SoftwareEnvironmentVariable(
+            "SPMSTANDALONE_HOME", ThirdPartySoftware.SPMSTANDALONE
+        )
+    )
+
+
+def get_spm_home() -> Path:
+    """Return the path to the home directory of SPM."""
+    return check_environment_variable(
+        SoftwareEnvironmentVariable("SPM_HOME", ThirdPartySoftware.SPM)
+    )
+
+
+def is_binary_present(name: str) -> bool:
     """Check if a binary is present.
 
     Parameters
     ----------
-    binary : str
+    name : str
         The name of the program.
 
     Returns
@@ -43,77 +130,82 @@ def is_binary_present(binary: str) -> bool:
 
     try:
         devnull = open(os.devnull)
-        subprocess.Popen([binary], stdout=devnull, stderr=devnull).communicate()
+        subprocess.Popen([name], stdout=devnull, stderr=devnull).communicate()
     except OSError as e:
         if e.errno == errno.ENOENT:
             return False
     return True
 
 
-def check_environment_variable(environment_variable: str, software_name: str) -> str:
+def check_binary(name: str):
+    if not is_binary_present(name):
+        raise ClinicaMissingDependencyError(
+            f"Command {name} is unknown on your system. "
+            "Please verify that you have correctly installed the corresponding software."
+        )
+
+
+def check_environment_variable(variable: SoftwareEnvironmentVariable) -> Path:
     """Check if the provided environment variable is set and returns its value.
 
     Parameters
     ----------
-    environment_variable : str
-        The name of the environment variable to check.
-
-    software_name : str
-        The name of the software related to the environment variable.
+    variable : SoftwareEnvironmentVariable
+        The software environment variable to check.
 
     Returns
     -------
-    str :
-        The value associated to the environment variable.
+    Path :
+        The path value associated to the environment variable.
 
     Raises
     ------
-    ClinicaMissingDependencyError
+    ClinicaMissingDependencyError :
         If the variable is not set.
+
+    ClinicaEnvironmentVariableError :
         If the variable associated value is not a directory.
 
     Examples
     --------
-    >>> check_environment_variable("ANTSPATH", "ANTs")
+    >>> check_environment_variable(SoftwareEnvironmentVariable("ANTSPATH", ThirdPartySoftware.ANTS))
     '/opt/ANTs/bin/'
     """
-    import os
+    from .exceptions import ClinicaEnvironmentVariableError
 
-    content_var = os.environ.get(environment_variable, "")
-    if not content_var:
+    if not (content_var := os.environ.get(variable.name, "")):
         raise ClinicaMissingDependencyError(
-            f"Clinica could not find {software_name} software: "
-            f"the {environment_variable} variable is not set."
+            f"Clinica could not find {variable.software.value} software: "
+            f"the {variable.name} variable is not set."
         )
     if not os.path.isdir(content_var):
-        raise ClinicaMissingDependencyError(
-            f"The {environment_variable} environment variable "
+        raise ClinicaEnvironmentVariableError(
+            f"The {variable.name} environment variable "
             f"you gave is not a folder (content: {content_var})."
         )
-    return content_var
+    return Path(content_var)
 
 
 def _check_software(
-    name: str,
-    binaries: Optional[List[str]] = None,
-    env: Optional[Tuple[str, str]] = None,
+    name: ThirdPartySoftware,
+    binaries: Optional[Tuple[str]] = None,
+    environment_variables: Optional[Tuple[SoftwareEnvironmentVariable]] = None,
     complementary_info: Optional[str] = None,
 ) -> None:
     """Check if the software is available.
 
     Parameters
     ----------
-    name : str
+    name : ThirdPartySoftware
         Name of the software.
 
-    binaries : list of str, optional
-        List of associated binaries to check.
+    binaries : tuple of str, optional
+        Tuple of associated binaries to check.
         If None, nothing is checked.
 
-    env : (str, str), optional
-        Tuple (environment variable, software name).
-        This environment variable will be checked, meaning
-        that it should be set and point to an existing folder.
+    environment_variables : tuple of SoftwareEnvironmentVariable, optional
+        These environment variables will be checked, meaning
+        that they should be set and point to existing folders.
         If None, nothing is checked.
 
     complementary_info : str, optional
@@ -126,62 +218,65 @@ def _check_software(
     ClinicaMissingDependencyError
         If the software checks fail.
     """
-    if env:
-        check_environment_variable(*env)
-    binaries = binaries or []
+    if environment_variables:
+        for variable in environment_variables:
+            check_environment_variable(variable)
+    binaries = binaries or ()
     complementary_info = complementary_info or ""
     for binary in binaries:
         if not is_binary_present(binary):
             raise ClinicaMissingDependencyError(
-                f"[Error] Clinica could not find {name} software: "
+                f"[Error] Clinica could not find {name.value} software: "
                 f"the {binary} command is not present in your PATH "
                 f"environment. {complementary_info}"
             )
 
 
-check_dcm2niix = functools.partial(
+_check_dcm2niix = functools.partial(
     _check_software,
-    name="dcm2niix",
-    binaries=["dcm2niix"],
+    name=ThirdPartySoftware.DCM2NIIX,
+    binaries=("dcm2niix",),
     complementary_info=(
         "This software can be downloaded and installed "
         "from https://github.com/rordenlab/dcm2niix."
     ),
 )
 
-check_ants = functools.partial(
+_check_ants = functools.partial(
     _check_software,
-    name="ANTs",
-    binaries=["N4BiasFieldCorrection", "antsRegistrationSyNQuick.sh"],
+    name=ThirdPartySoftware.ANTS,
+    binaries=("N4BiasFieldCorrection", "antsRegistrationSyNQuick.sh"),
 )
 
-check_convert3d = functools.partial(
+_check_convert3d = functools.partial(
     _check_software,
-    name="Convert3D",
-    binaries=["c3d_affine_tool", "c3d"],
+    name=ThirdPartySoftware.CONVERT3D,
+    binaries=("c3d_affine_tool", "c3d"),
 )
 
 _check_freesurfer = functools.partial(
     _check_software,
-    name="FreeSurfer",
-    binaries=["mri_convert", "recon-all"],
-    env=("FREESURFER_HOME", "FreeSurfer"),
+    name=ThirdPartySoftware.FREESURFER,
+    binaries=("mri_convert", "recon-all"),
+    environment_variables=(
+        SoftwareEnvironmentVariable("FREESURFER_HOME", ThirdPartySoftware.FREESURFER),
+    ),
     complementary_info=(
         "Do you have the line `source $FREESURFER_HOME/SetUpFreeSurfer.sh` "
         "in your configuration file?"
     ),
 )
 
-check_mrtrix = functools.partial(
+_check_mrtrix = functools.partial(
     _check_software,
-    name="MRtrix",
-    binaries=["transformconvert", "mrtransform", "dwi2response", "tckgen"],
+    name=ThirdPartySoftware.MRTRIX,
+    binaries=("transformconvert", "mrtransform", "dwi2response", "tckgen"),
 )
 
-check_petpvc = functools.partial(
+_check_petpvc = functools.partial(
     _check_software,
-    name="PETPVC",
-    binaries=[
+    name=ThirdPartySoftware.PETPVC,
+    binaries=(
         "petpvc",
         "pvc_diy",
         "pvc_gtm",
@@ -196,30 +291,63 @@ check_petpvc = functools.partial(
         "pvc_simulate",
         "pvc_stc",
         "pvc_vc",
-    ],
+    ),
 )
 
-check_spm = functools.partial(
+
+def _check_spm():
+    """Check that SPM is installed, either regular with Matlab or as a standalone."""
+    try:
+        _check_spm_standalone()
+    except ClinicaMissingDependencyError as e1:
+        try:
+            _check_spm_alone()
+        except ClinicaMissingDependencyError as e2:
+            raise ClinicaMissingDependencyError(
+                "Clinica could not find the SPM software (regular or standalone).\n"
+                "Please make sure you have installed SPM in one of these two ways "
+                "and have set the required environment variables.\n"
+                f"Full list of errors: \n- {e1}\n- {e2}"
+            )
+
+
+_check_spm_standalone = functools.partial(
     _check_software,
-    name="SPM",
-    env=("SPM_HOME", "SPM"),
+    name=ThirdPartySoftware.SPMSTANDALONE,
+    environment_variables=(
+        SoftwareEnvironmentVariable(
+            "SPMSTANDALONE_HOME", ThirdPartySoftware.SPMSTANDALONE
+        ),
+        SoftwareEnvironmentVariable("MCR_HOME", ThirdPartySoftware.MCR),
+    ),
 )
 
-check_matlab = functools.partial(
+_check_spm_alone = functools.partial(
     _check_software,
-    name="Matlab",
-    binaries=["matlab"],
+    name=ThirdPartySoftware.SPM,
+    environment_variables=(
+        SoftwareEnvironmentVariable("SPM_HOME", ThirdPartySoftware.SPM),
+    ),
+    binaries=("matlab",),
+)
+
+_check_matlab = functools.partial(
+    _check_software,
+    name=ThirdPartySoftware.MATLAB,
+    binaries=("matlab",),
 )
 
 _check_fsl = functools.partial(
     _check_software,
-    name="FSL",
-    binaries=["bet", "flirt", "fast", "first"],
-    env=("FSLDIR", "FSL"),
+    name=ThirdPartySoftware.FSL,
+    binaries=("bet", "flirt", "fast", "first"),
+    environment_variables=(
+        SoftwareEnvironmentVariable("FSLDIR", ThirdPartySoftware.FSL),
+    ),
 )
 
 
-def check_fsl() -> None:
+def _check_fsl_above_version_five() -> None:
     """Check FSL software."""
     import nipype.interfaces.fsl as fsl
 
@@ -235,8 +363,8 @@ def check_fsl() -> None:
         cprint(msg=str(e), lvl="error")
 
 
-def check_freesurfer() -> None:
-    """Check FreeSurfer software."""
+def _check_freesurfer_above_version_six() -> None:
+    """Check FreeSurfer software >= 6.0.0."""
     import nipype.interfaces.freesurfer as freesurfer
 
     from clinica.utils.stream import cprint
@@ -249,3 +377,29 @@ def check_freesurfer() -> None:
             )
     except Exception as e:
         cprint(msg=str(e), lvl="error")
+
+
+def check_software(software: Union[str, ThirdPartySoftware]):
+    software = ThirdPartySoftware(software)
+    if software == ThirdPartySoftware.ANTS:
+        return _check_ants()
+    if software == ThirdPartySoftware.FSL:
+        return _check_fsl_above_version_five()
+    if software == ThirdPartySoftware.FREESURFER:
+        return _check_freesurfer_above_version_six()
+    if (
+        software == ThirdPartySoftware.SPM
+        or software == ThirdPartySoftware.SPMSTANDALONE
+        or software == ThirdPartySoftware.MCR
+    ):
+        return _check_spm()
+    if software == ThirdPartySoftware.MATLAB:
+        return _check_matlab()
+    if software == ThirdPartySoftware.DCM2NIIX:
+        return _check_dcm2niix()
+    if software == ThirdPartySoftware.PETPVC:
+        return _check_petpvc()
+    if software == ThirdPartySoftware.MRTRIX:
+        return _check_mrtrix()
+    if software == ThirdPartySoftware.CONVERT3D:
+        return _check_convert3d()

--- a/clinica/utils/check_dependency.py
+++ b/clinica/utils/check_dependency.py
@@ -37,8 +37,8 @@ class ThirdPartySoftware(str, Enum):
     MCR = "MCR"
     MRTRIX = "mrtrix"
     PETPVC = "petpvc"
-    SPM = "SPM"
-    SPMSTANDALONE = "SPM Standalone"
+    SPM = "spm"
+    SPMSTANDALONE = "spm standalone"
 
 
 class SoftwareEnvironmentVariable:

--- a/clinica/utils/exceptions.py
+++ b/clinica/utils/exceptions.py
@@ -9,6 +9,10 @@ class ClinicaMissingDependencyError(ClinicaException):
     """Base class for Clinica dependencies errors."""
 
 
+class ClinicaEnvironmentVariableError(ClinicaException):
+    """Something is wrong with an environment variable managed by Clinica."""
+
+
 class ClinicaBIDSError(ClinicaException):
     """Base class for BIDS errors."""
 

--- a/clinica/utils/mri_registration.py
+++ b/clinica/utils/mri_registration.py
@@ -28,9 +28,9 @@ def convert_flirt_transformation_to_mrtrix_transformation(
     """
     import os
 
-    from clinica.utils.check_dependency import check_mrtrix
+    from clinica.utils.check_dependency import ThirdPartySoftware, check_software
 
-    check_mrtrix()
+    check_software(ThirdPartySoftware.MRTRIX)
 
     assert os.path.isfile(in_source_image)
     assert os.path.isfile(in_reference_image)

--- a/clinica/utils/spm.py
+++ b/clinica/utils/spm.py
@@ -1,7 +1,13 @@
+"""This module contains SPM utilities."""
 import warnings
 from os import PathLike
+from pathlib import Path
 
-"""This module contains SPM utilities."""
+__all__ = [
+    "INDEX_TISSUE_MAP",
+    "get_tpm",
+    "use_spm_standalone_if_available",
+]
 
 INDEX_TISSUE_MAP = {
     1: "graymatter",
@@ -13,33 +19,6 @@ INDEX_TISSUE_MAP = {
 }
 
 
-def check_spm_home():
-    """Check and get SPM_HOME environment variable if present."""
-    import os
-    import platform
-
-    from .check_dependency import check_environment_variable
-    from .exceptions import ClinicaMissingDependencyError
-
-    spm_home = check_environment_variable("SPM_HOME", "SPM")
-
-    spm_standalone_home = os.environ.get("SPMSTANDALONE_HOME", "")
-    if spm_standalone_home:
-        if not os.path.isdir(spm_standalone_home):
-            raise ClinicaMissingDependencyError(
-                "The SPMSTANDALONE_HOME environment variable you "
-                f"gave is not a folder (content: {spm_standalone_home})."
-            )
-        if platform.system() == "Darwin":
-            spm_home = os.path.join(
-                spm_standalone_home, "spm12.app", "Contents", "MacOS", "spm12_mcr"
-            )
-        else:
-            spm_home = os.path.join(spm_standalone_home, "spm12_mcr")
-
-    return spm_home
-
-
 def get_tpm() -> PathLike:
     """Get Tissue Probability Map (TPM) from SPM.
     Returns
@@ -47,32 +26,18 @@ def get_tpm() -> PathLike:
     PathLike :
         TPM.nii path from SPM
     """
-    import os
     from glob import glob
-    from os.path import join
 
-    spm_home = os.getenv("SPM_HOME")
+    from .check_dependency import get_spm_home
 
-    if not spm_home:
-        spm_home = os.getenv("SPMSTANDALONE_HOME")
-
-    if not spm_home:
-        raise RuntimeError(
-            "Could not determine location of your SPM installation. Neither $SPM_HOME "
-            "or $SPMSTANDALONE_HOME are present in your environment"
-        )
-
-    tpm_file_glob = glob(join(spm_home, "**/TPM.nii"), recursive=True)
-
+    spm_home = get_spm_home()
+    tpm_file_glob = glob(str(spm_home / "**/TPM.nii"), recursive=True)
     if len(tpm_file_glob) == 0:
         raise RuntimeError(f"No file found for TPM.nii in your $SPM_HOME in {spm_home}")
-
     if len(tpm_file_glob) > 1:
         error_str = f"Multiple files found for TPM.nii in your SPM_HOME {spm_home}:"
-
         for file in tpm_file_glob:
             error_str += "\n\t" + file
-
         raise RuntimeError(error_str)
 
     return tpm_file_glob[0]
@@ -80,6 +45,11 @@ def get_tpm() -> PathLike:
 
 def use_spm_standalone_if_available() -> bool:
     """Use SPM Standalone with MATLAB Common Runtime if it can be used on the user system.
+
+    If there is something wrong with either SPM Standalone or the MCR environment variables
+    configuration, a warning is given to the user, and False is returned.
+    It is thus possible to use this function to try using the standalone version of SPM12
+    while potentially defaulting to the standard SPM12 install.
 
     Returns
     -------
@@ -89,59 +59,53 @@ def use_spm_standalone_if_available() -> bool:
 
     Raises
     ------
-    FileNotFoundError :
+    ClinicaEnvironmentVariableError :
         If the environment variables are set to non-existent folders.
     """
-    import os
-    import warnings
-
     from clinica.utils.stream import cprint
 
-    if all(elem in os.environ.keys() for elem in ("SPMSTANDALONE_HOME", "MCR_HOME")):
-        if os.path.isdir(os.path.expandvars("$SPMSTANDALONE_HOME")) and os.path.isdir(
-            os.path.expandvars("$MCR_HOME")
-        ):
-            spm_standalone_home = os.getenv("SPMSTANDALONE_HOME")
-            mcr_home = os.getenv("MCR_HOME")
-            cprint(
-                f"SPM standalone has been found at {spm_standalone_home}, "
-                f"with an MCR at {mcr_home} and will be used in this pipeline"
-            )
-            matlab_command = _get_platform_dependant_matlab_command(
-                spm_standalone_home, mcr_home
-            )
-            _configure_spm_nipype_interface(matlab_command)
-            return True
-        raise FileNotFoundError(
-            "[Error] $SPMSTANDALONE_HOME and $MCR_HOME are defined, but linked to non existent folder"
+    from .check_dependency import get_mcr_home, get_spm_standalone_home
+    from .exceptions import ClinicaMissingDependencyError
+
+    try:
+        spm_standalone_home = get_spm_standalone_home()
+        mcr_home = get_mcr_home()
+        cprint(
+            f"SPM standalone has been found at {spm_standalone_home}, "
+            f"with an MCR at {mcr_home} and will be used in this pipeline"
         )
-    warnings.warn(
-        "SPM standalone is not available on this system. "
-        "The pipeline will try to use SPM and Matlab instead. "
-        "If you want to rely on spm standalone, please make sure "
-        "to set the following environment variables: "
-        "$SPMSTANDALONE_HOME, $MCR_HOME, and $SPM_HOME."
-    )
-    return False
+        matlab_command = _get_platform_dependant_matlab_command(
+            spm_standalone_home, mcr_home
+        )
+        _configure_spm_nipype_interface(matlab_command)
+        return True
+    except ClinicaMissingDependencyError:
+        warnings.warn(
+            "SPM standalone is not available on this system. "
+            "The pipeline will try to use SPM and Matlab instead. "
+            "If you want to rely on spm standalone, please make sure "
+            "to set the following environment variables: "
+            "$SPMSTANDALONE_HOME, and $MCR_HOME"
+        )
+        return False
 
 
 def _get_platform_dependant_matlab_command(
-    spm_standalone_home: str, mcr_home: str
+    spm_standalone_home: Path, mcr_home: Path
 ) -> str:
-    import os
     import platform
 
     user_system = platform.system().lower()
     if user_system.startswith("darwin"):
         return f"cd {spm_standalone_home} && ./run_spm12.sh {mcr_home} script"
     if user_system.startswith("linux"):
-        return f"{os.path.join(spm_standalone_home, 'run_spm12.sh')} {mcr_home} script"
+        return f"{spm_standalone_home / 'run_spm12.sh'} {mcr_home} script"
     raise SystemError(
         f"Clinica only support macOS and Linux. Your system is {user_system}."
     )
 
 
-def _configure_spm_nipype_interface(matlab_command: str) -> str:
+def _configure_spm_nipype_interface(matlab_command: str):
     from nipype.interfaces import spm
 
     from clinica.utils.stream import cprint

--- a/docs/Third-party.md
+++ b/docs/Third-party.md
@@ -298,12 +298,7 @@ In addition, you need to define the following environment variables:
 ```bash
 export MCR_HOME="/path/to/your/MCR/"
 export SPMSTANDALONE_HOME="/path/to/your/spmstandalone/home/"
-export SPM_HOME="/path/to/your/spmstandalone/home/"
 ```
-
-!!! note
-    You still need to define `$SPM_HOME` even if using `spm standalone`, otherwise you will get a Clinica error.
-    Clinica will still use spm standalone if these variables are set correctly.
 
 ## Autocompletion
 

--- a/test/nonregression/iotools/test_run_converters.py
+++ b/test/nonregression/iotools/test_run_converters.py
@@ -116,30 +116,29 @@ def test_run_habs_to_bids(cmdopt, tmp_path):
 
 def test_run_ukb_to_bids(cmdopt, tmp_path):
     from clinica.iotools.converters.ukb_to_bids.ukb_to_bids import convert_images
-    from clinica.utils.check_dependency import check_dcm2niix
+    from clinica.utils.check_dependency import ThirdPartySoftware, check_software
 
     base_dir = Path(cmdopt["input"])
     input_dir, tmp_dir, ref_dir = configure_paths(base_dir, tmp_path, "UkbToBids")
     output_dir = tmp_path / "bids"
     clinical_data_directory = input_dir / "clinical_data"
 
-    check_dcm2niix()
+    check_software(ThirdPartySoftware.DCM2NIIX)
     convert_images(
         input_dir / "unorganized", output_dir / "bids", clinical_data_directory
     )
-
     compare_folders(output_dir / "bids", ref_dir / "bids", output_dir)
 
 
 def test_run_genfi_to_bids(cmdopt, tmp_path):
     from clinica.iotools.converters.genfi_to_bids.genfi_to_bids import convert_images
-    from clinica.utils.check_dependency import check_dcm2niix
+    from clinica.utils.check_dependency import ThirdPartySoftware, check_software
 
     base_dir = Path(cmdopt["input"])
     input_dir, tmp_dir, ref_dir = configure_paths(base_dir, tmp_path, "GenfiToBids")
     output_dir = tmp_path / "bids"
 
-    check_dcm2niix()
+    check_software(ThirdPartySoftware.DCM2NIIX)
     convert_images(
         input_dir / "unorganized",
         output_dir,
@@ -147,5 +146,4 @@ def test_run_genfi_to_bids(cmdopt, tmp_path):
         gif=False,
         path_to_clinical_tsv=None,
     )
-
     compare_folders(output_dir, ref_dir / "bids", output_dir)

--- a/test/unittests/pipelines/dwi/test_connectome_utils.py
+++ b/test/unittests/pipelines/dwi/test_connectome_utils.py
@@ -1,12 +1,14 @@
+from pathlib import Path
+
 import pytest
 
 
 def test_get_luts(mocker):
     from clinica.pipelines.dwi.connectome.utils import get_luts
 
-    mocked_freesurfer_home = "/Applications/freesurfer/7.2.0"
+    mocked_freesurfer_home = Path("/Applications/freesurfer/7.2.0")
     mocker.patch(
-        "clinica.utils.check_dependency.check_environment_variable",
+        "clinica.utils.check_dependency.get_freesurfer_home",
         return_value=mocked_freesurfer_home,
     )
     assert get_luts() == [f"{mocked_freesurfer_home}/FreeSurferColorLUT.txt"] * 2

--- a/test/unittests/utils/test_check_dependency.py
+++ b/test/unittests/utils/test_check_dependency.py
@@ -1,105 +1,222 @@
 import os
+import re
+from unittest import mock
 
 import pytest
 
+from clinica.utils.check_dependency import (
+    SoftwareEnvironmentVariable,
+    ThirdPartySoftware,
+)
+from clinica.utils.exceptions import (
+    ClinicaEnvironmentVariableError,
+    ClinicaMissingDependencyError,
+)
 
-def test_check_dependency():
+
+def test_is_binary_present():
     from clinica.utils.check_dependency import is_binary_present
 
     assert not is_binary_present("foo")
     assert is_binary_present("ls")
 
 
-def test_check_environment_variable():
+def test_check_binary():
+    from clinica.utils.check_dependency import check_binary
+
+    check_binary("ls")
+    with pytest.raises(
+        ClinicaMissingDependencyError,
+        match=(
+            "Command foo is unknown on your system. "
+            "Please verify that you have correctly installed the corresponding software."
+        ),
+    ):
+        check_binary("foo")
+
+
+def test_check_environment_variable_not_set_error():
     from clinica.utils.check_dependency import check_environment_variable
-    from clinica.utils.exceptions import ClinicaMissingDependencyError
 
     with pytest.raises(
         ClinicaMissingDependencyError,
-        match="Clinica could not find foo software: the FOO variable is not set.",
+        match="Clinica could not find fsl software: the FOO variable is not set.",
     ):
-        check_environment_variable("FOO", "foo")
-    os.environ["FOO"] = "bar"
-    with pytest.raises(
-        ClinicaMissingDependencyError,
-        match="The FOO environment variable you gave is not a folder",
-    ):
-        check_environment_variable("FOO", "foo")
-    os.environ["FOO"] = "."
-    assert check_environment_variable("FOO", "foo") == "."
-    os.environ.pop("FOO")
+        check_environment_variable(
+            SoftwareEnvironmentVariable("FOO", ThirdPartySoftware.FSL)
+        )
+
+
+def test_check_environment_variable_not_a_folder_error(tmp_path):
+    from clinica.utils.check_dependency import check_environment_variable
+
+    not_a_folder = tmp_path / "foo.txt"
+    not_a_folder.touch()
+
+    with mock.patch.dict(os.environ, {"FOO": str(not_a_folder)}):
+        with pytest.raises(
+            ClinicaEnvironmentVariableError,
+            match="The FOO environment variable you gave is not a folder",
+        ):
+            check_environment_variable(
+                SoftwareEnvironmentVariable("FOO", ThirdPartySoftware.FSL)
+            )
+
+
+def test_check_environment_variable(tmp_path):
+    from clinica.utils.check_dependency import check_environment_variable
+
+    with mock.patch.dict(os.environ, {"FOO": str(tmp_path)}):
+        assert (
+            check_environment_variable(
+                SoftwareEnvironmentVariable("FOO", ThirdPartySoftware.FSL)
+            )
+            == tmp_path
+        )
 
 
 @pytest.mark.parametrize(
     "binaries,env,expected_msg",
     [
         (
-            ["foo"],
+            ("foo",),
             None,
-            "Clinica could not find foo software: the foo command is not present in your PATH environment.",
+            "Clinica could not find fsl software: the foo command is not present in your PATH environment.",
         ),
         (
-            ["ls"],
-            ("FOO", "foo"),
-            "Clinica could not find foo software: the FOO variable is not set.",
+            ("ls",),
+            (SoftwareEnvironmentVariable("FOO", ThirdPartySoftware.FSL),),
+            "Clinica could not find fsl software: the FOO variable is not set.",
         ),
     ],
 )
 def test_check_software_errors(binaries, env, expected_msg):
-    from clinica.utils.check_dependency import _check_software
-    from clinica.utils.exceptions import ClinicaMissingDependencyError
+    from clinica.utils.check_dependency import _check_software  # noqa
 
-    with pytest.raises(
-        ClinicaMissingDependencyError,
-        match=expected_msg,
-    ):
-        _check_software("foo", binaries=binaries, env=env)
-
-
-@pytest.mark.parametrize(
-    "binaries,env,complementary,expected_msg",
-    [
-        (
-            ["ls"],
-            ("FOO", "foo"),
-            None,
-            "The FOO environment variable you gave is not a folder",
-        ),
-        (
-            ["ls", "bar"],
-            ("FOO", "."),
-            "Foo bar baz",
-            (
-                "Clinica could not find foo software: the bar command is "
-                "not present in your PATH environment. Foo bar baz"
-            ),
-        ),
-    ],
-)
-def test_check_software_env_variable_errors(binaries, env, complementary, expected_msg):
-    from clinica.utils.check_dependency import _check_software
-    from clinica.utils.exceptions import ClinicaMissingDependencyError
-
-    name, value = env
-    os.environ[name] = value
     with pytest.raises(
         ClinicaMissingDependencyError,
         match=expected_msg,
     ):
         _check_software(
-            "foo",
-            binaries=binaries,
-            env=("FOO", "foo"),
-            complementary_info=complementary,
+            ThirdPartySoftware.FSL, binaries=binaries, environment_variables=env
         )
-    os.environ.pop(name)
 
 
-def test_check_software():
-    from clinica.utils.check_dependency import _check_software
+@pytest.mark.parametrize(
+    "binaries,env,complementary,error_class,expected_msg",
+    [
+        (
+            ("ls",),
+            ("FOO", "foo"),
+            None,
+            ClinicaEnvironmentVariableError,
+            "The FOO environment variable you gave is not a folder",
+        ),
+        (
+            ("ls", "bar"),
+            ("FOO", ""),
+            "Foo bar baz",
+            ClinicaMissingDependencyError,
+            (
+                "Clinica could not find fsl software: the bar command is "
+                "not present in your PATH environment. Foo bar baz"
+            ),
+        ),
+    ],
+)
+def test_check_software_env_variable_errors(
+    tmp_path, binaries, env, complementary, error_class, expected_msg
+):
+    from clinica.utils.check_dependency import _check_software  # noqa
+
+    with mock.patch.dict(os.environ, {env[0]: str(tmp_path / env[1])}):
+        with pytest.raises(error_class, match=expected_msg):
+            _check_software(
+                ThirdPartySoftware.FSL,
+                binaries=binaries,
+                environment_variables=(
+                    SoftwareEnvironmentVariable("FOO", ThirdPartySoftware.FSL),
+                ),
+                complementary_info=complementary,
+            )
+
+
+def test_check_software(tmp_path):
+    from clinica.utils.check_dependency import _check_software  # noqa
 
     assert _check_software("foo") is None
-    assert _check_software("foo", binaries=["ls"]) is None
-    os.environ["FOO"] = "."
-    assert _check_software("foo", binaries=["ls"], env=("FOO", "foo")) is None
-    os.environ.pop("FOO")
+    assert _check_software("foo", binaries=("ls",)) is None
+
+    (tmp_path / "foo").mkdir()
+    with mock.patch.dict(os.environ, {"FOO": str(tmp_path / "foo")}):
+        assert (
+            _check_software(
+                ThirdPartySoftware.FSL,
+                binaries=("ls",),
+                environment_variables=(
+                    SoftwareEnvironmentVariable("FOO", ThirdPartySoftware.FSL),
+                ),
+            )
+            is None
+        )
+
+
+def test_check_spm_error(tmp_path):
+    from clinica.utils.check_dependency import _check_spm  # noqa
+
+    with pytest.raises(
+        ClinicaMissingDependencyError,
+        match=re.escape(
+            "Clinica could not find the SPM software (regular or standalone)."
+        ),
+    ):
+        _check_spm()
+
+
+@pytest.mark.parametrize("env_name", ["SPMSTANDALONE_HOME", "MCR_HOME"])
+def test_check_spm_standalone_error_incomplete_config(tmp_path, env_name):
+    from clinica.utils.check_dependency import _check_spm  # noqa
+
+    with mock.patch.dict(os.environ, {env_name: str(tmp_path)}):
+        with pytest.raises(
+            ClinicaMissingDependencyError,
+            match=re.escape(
+                "Clinica could not find the SPM software (regular or standalone)."
+            ),
+        ):
+            _check_spm()
+
+
+def test_check_spm_standalone(tmp_path):
+    from clinica.utils.check_dependency import _check_spm  # noqa
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            "SPMSTANDALONE_HOME": str(tmp_path),
+            "MCR_HOME": str(tmp_path),
+        },
+    ):
+        _check_spm()
+
+
+def test_check_spm_alone_error_matlab_not_installed(tmp_path):
+    from clinica.utils.check_dependency import _check_spm  # noqa
+
+    with mock.patch.dict(os.environ, {"SPM_HOME": str(tmp_path)}):
+        with pytest.raises(
+            ClinicaMissingDependencyError,
+            match=re.escape(
+                "[Error] Clinica could not find SPM software: the matlab "
+                "command is not present in your PATH environment."
+            ),
+        ):
+            _check_spm()
+
+
+def test_check_spm_alone(tmp_path, mocker):
+    from clinica.utils.check_dependency import _check_spm  # noqa
+
+    mocker.patch("clinica.utils.check_dependency.is_binary_present", return_value=True)
+    with mock.patch.dict(os.environ, {"SPM_HOME": str(tmp_path)}):
+        _check_spm()

--- a/test/unittests/utils/test_check_dependency.py
+++ b/test/unittests/utils/test_check_dependency.py
@@ -207,7 +207,7 @@ def test_check_spm_alone_error_matlab_not_installed(tmp_path):
         with pytest.raises(
             ClinicaMissingDependencyError,
             match=re.escape(
-                "[Error] Clinica could not find SPM software: the matlab "
+                "[Error] Clinica could not find spm software: the matlab "
                 "command is not present in your PATH environment."
             ),
         ):


### PR DESCRIPTION
Closes #820 

This PR proposes to refactor the checking logic for third party dependencies, especially around SPM which was handled in very complicated ways with lots of code duplication.

This PR also solves the weird environment variable configuration which was required to use SPM standalone.
That is, it removes the need to specify a value for `SPM_HOME`. Only `SPMSTANDALONE_HOME` and `MCR_HOME` should be defined and point to the right locations.

Finally, this PR adds a lot of unit tests to improve the robustness of these functions.