### PR TITLE
[REF] Move DWI specific functions from `filemanip.py` utils to dwi preprocessing utils

### DIFF
--- a/clinica/pipelines/dwi/preprocessing/t1/workflows.py
+++ b/clinica/pipelines/dwi/preprocessing/t1/workflows.py
@@ -420,7 +420,7 @@ def perform_dwi_epi_correction(
     import nipype.interfaces.utility as niu
     import nipype.pipeline.engine as pe
 
-    from clinica.utils.filemanip import delete_directories
+    from clinica.utils.filemanip import delete_directories_task
 
     workflow_inputs = ["t1_filename", "dwi_filename", "merged_transforms"]
     workflow_outputs = ["epi_corrected_dwi_image"]
@@ -479,8 +479,8 @@ def perform_dwi_epi_correction(
         delete_cache_node = pe.Node(
             name="delete_cache",
             interface=niu.Function(
-                inputs=["directories", "checkpoint"],
-                function=delete_directories,
+                inputs=["directories"],
+                function=delete_directories_task,
             ),
         )
         delete_cache_node.inputs.directories = [
@@ -521,11 +521,6 @@ def perform_dwi_epi_correction(
         (threshold_negative, merge_dwi_volumes, [("out_file", "in_files")]),
         (merge_dwi_volumes, outputnode, [("merged_file", "epi_corrected_dwi_image")]),
     ]
-
-    if delete_cache:
-        connections += [
-            (merge_dwi_volumes, delete_cache_node, [("merged_file", "checkpoint")])
-        ]
 
     if output_dir:
         connections += [

--- a/clinica/pipelines/dwi/preprocessing/utils.py
+++ b/clinica/pipelines/dwi/preprocessing/utils.py
@@ -248,7 +248,7 @@ def check_b_value_threshold(b_value_threshold: float) -> None:
 
 
 def get_readout_time_and_phase_encoding_direction(
-    dwi_json_filename: str | Path,
+    dwi_json_filename: Union[str, Path],
 ) -> tuple[str, str]:
     """Extract the readout time and phase encoding direction from the DWI JSON file."""
     from clinica.utils.filemanip import extract_metadata_from_json

--- a/clinica/pipelines/dwi/preprocessing/utils.py
+++ b/clinica/pipelines/dwi/preprocessing/utils.py
@@ -248,13 +248,10 @@ def check_b_value_threshold(b_value_threshold: float) -> None:
 
 
 def get_readout_time_and_phase_encoding_direction(
-    dwi_json_filename: str,
-) -> Tuple[str, str]:
+    dwi_json_filename: str | Path,
+) -> tuple[str, str]:
     """Extract the readout time and phase encoding direction from the DWI JSON file."""
-    from clinica.utils.filemanip import (
-        extract_metadata_from_json,
-        handle_missing_keys_dwi,
-    )
+    from clinica.utils.filemanip import extract_metadata_from_json
 
     [total_readout_time, phase_encoding_direction] = extract_metadata_from_json(
         dwi_json_filename,
@@ -262,11 +259,93 @@ def get_readout_time_and_phase_encoding_direction(
             "TotalReadoutTime",
             "PhaseEncodingDirection",
         ],
-        handle_missing_keys=handle_missing_keys_dwi,
+        handle_missing_keys=_handle_missing_keys_dwi,
     )
     phase_encoding_direction = _bids_dir_to_fsl_dir(phase_encoding_direction)
 
     return total_readout_time, phase_encoding_direction
+
+
+def _handle_missing_keys_dwi(data: dict, missing_keys: set[str]) -> dict:
+    """Find alternative fields from the bids/sub-X/ses-Y/dwi/sub-X_ses-Y_dwi.json
+    file to replace those which were not found in this very json.
+
+
+    Parameters
+    ----------
+    data: dict
+        Dictionary containing the json data.
+
+    missing_keys: set of str
+        Set of keys that are required and were not found in the json.
+
+    Returns
+    -------
+    dict:
+        Contains the values for the requested fields.
+    """
+    handlers = {
+        "TotalReadoutTime": _handle_missing_total_readout_time,
+        "PhaseEncodingDirection": _handle_missing_phase_encoding_direction,
+    }
+    try:
+        return {k: handlers[k](data, missing_keys) for k in missing_keys}
+    except KeyError:
+        raise ValueError(
+            f"Could not recover the missing keys {missing_keys} from JSON file."
+        )
+
+
+def _handle_missing_total_readout_time(data: dict, missing_keys: set) -> float:
+    """Find an alternative field in the json to replace the TotalReadoutTime.
+
+    Parameters
+    ----------
+    data: dict
+        Dictionary containing the json data.
+
+    missing_keys: set
+        Set of keys that are required and were not found in the json.
+
+    Returns
+    -------
+    float:
+        Value for TotalReadoutTime.
+    """
+    from clinica.utils.exceptions import ClinicaException
+
+    if "EstimatedTotalReadoutTime" in data:
+        return data["EstimatedTotalReadoutTime"]
+    if "PhaseEncodingSteps" in data and "PixelBandwidth" in data:
+        if data["PixelBandwidth"] != 0:
+            return data["PhaseEncodingSteps"] / data["PixelBandwidth"]
+        raise ValueError("Pixel Bandwidth value is not valid.")
+    raise ClinicaException("Could not recover the TotalReadoutTime from JSON file.")
+
+
+def _handle_missing_phase_encoding_direction(data: dict, missing_keys: set) -> float:
+    """Find an alternative field in the json to replace the PhaseEncodingDirection.
+
+    Parameters
+    ----------
+    data: dict
+        Dictionary containing the json data.
+
+    missing_keys: set
+        Set of keys that are required and were not found in the json.
+
+    Returns
+    -------
+    float:
+        Value for PhaseEncodingDirection.
+    """
+    from clinica.utils.exceptions import ClinicaException
+
+    if "PhaseEncodingAxis" in data:
+        return data["PhaseEncodingAxis"] + "+"
+    raise ClinicaException(
+        "Could not recover the PhaseEncodingDirection from JSON file."
+    )
 
 
 def _bids_dir_to_fsl_dir(bids_dir):

--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -11,7 +11,6 @@ def _zip_unzip_nii(in_file: str, same_dir: bool, compress: bool):
     from pathlib import Path
 
     from nipype.utils.filemanip import split_filename
-    from traits.trait_base import _Undefined
 
     try:
         # Assuming in_file is path-like.
@@ -196,7 +195,6 @@ def save_participants_sessions(
         If provided `participant_ids` and `session_ids` do not have
         the same length.
     """
-    import os
     from pathlib import Path
 
     import pandas as pd
@@ -413,12 +411,12 @@ def extract_crash_files_from_log_file(filename: str) -> List[str]:
     return crash_files
 
 
-def read_participant_tsv(tsv_file: str) -> Tuple[List[str], List[str]]:
+def read_participant_tsv(tsv_file: str | Path) -> Tuple[List[str], List[str]]:
     """Extract participant IDs and session IDs from TSV file.
 
     Parameters
     ----------
-    tsv_file: str
+    tsv_file: str or Path
         Participant TSV file from which to extract the participant and session IDs.
 
     Returns
@@ -471,7 +469,7 @@ def read_participant_tsv(tsv_file: str) -> Tuple[List[str], List[str]]:
 
 
 def extract_metadata_from_json(
-    json_file: str,
+    json_file: str | Path,
     list_keys: List[str],
     handle_missing_keys: Optional[Callable] = None,
 ) -> List[str]:
@@ -479,7 +477,7 @@ def extract_metadata_from_json(
 
     Parameters
     ----------
-    json_file: str
+    json_file: str or Path
         Path to a json file containing metadata needed for the pipeline.
 
     list_keys: list of str
@@ -513,91 +511,6 @@ def extract_metadata_from_json(
         patch = handle_missing_keys(data, missing_keys)
         data.update(patch)
     return [data[k] for k in list_keys]
-
-
-def handle_missing_keys_dwi(data: dict, missing_keys: set) -> dict:
-    """Find alternative fields from the bids/sub-X/ses-Y/dwi/sub-X_ses-Y_dwi.json
-    file to replace those which were not found in this very json.
-
-
-    Parameters
-    ----------
-    data: dict
-        Dictionary containing the json data.
-
-    missing_keys: set
-        Set of keys that are required and were not found in the json.
-
-    Returns
-    -------
-    dict:
-        Contains the values for the requested fields.
-    """
-    handlers = {
-        "TotalReadoutTime": _handle_missing_total_readout_time,
-        "PhaseEncodingDirection": _handle_missing_phase_encoding_direction,
-    }
-    try:
-        return {k: handlers[k](data, missing_keys) for k in missing_keys}
-    except KeyError:
-        raise ValueError(
-            f"Could not recover the missing keys {missing_keys} from JSON file."
-        )
-
-
-def _handle_missing_total_readout_time(data: dict, missing_keys: set) -> float:
-    """Find an alternative field in the json to replace the TotalReadoutTime.
-
-    Parameters
-    ----------
-    data: dict
-        Dictionary containing the json data.
-
-    missing_keys: set
-        Set of keys that are required and were not found in the json.
-
-    Returns
-    -------
-    float:
-        Value for TotalReadoutTime.
-    """
-    from clinica.utils.exceptions import ClinicaException
-
-    if "EstimatedTotalReadoutTime" in data:
-        return data["EstimatedTotalReadoutTime"]
-    if "PhaseEncodingSteps" in data and "PixelBandwidth" in data:
-        if data["PixelBandwidth"] != 0:
-            return data["PhaseEncodingSteps"] / data["PixelBandwidth"]
-        raise ValueError("Pixel Bandwidth value is not valid.")
-    raise ClinicaException("Could not recover the TotalReadoutTime from JSON file.")
-
-
-def _handle_missing_phase_encoding_direction(
-    data: dict,
-    missing_keys: set,
-) -> float:
-    """Find an alternative field in the json to replace the PhaseEncodingDirection.
-
-    Parameters
-    ----------
-    data: dict
-        Dictionary containing the json data.
-
-    missing_keys: set
-        Set of keys that are required and were not found in the json.
-
-    Returns
-    -------
-    float:
-        Value for PhaseEncodingDirection.
-    """
-    from clinica.utils.exceptions import ClinicaException
-
-    if "PhaseEncodingAxis" in data:
-        return data["PhaseEncodingAxis"] + "+"
-    raise ClinicaException(
-        "Could not recover the PhaseEncodingDirection from JSON file."
-    )
 
 
 def get_parent(path: str, n: int = 1) -> Path:

--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Union
 
 
 def _zip_unzip_nii(in_file: str, same_dir: bool, compress: bool):
@@ -411,7 +411,7 @@ def extract_crash_files_from_log_file(filename: str) -> List[str]:
     return crash_files
 
 
-def read_participant_tsv(tsv_file: str | Path) -> Tuple[List[str], List[str]]:
+def read_participant_tsv(tsv_file: Union[str, Path]) -> Tuple[List[str], List[str]]:
     """Extract participant IDs and session IDs from TSV file.
 
     Parameters
@@ -469,10 +469,10 @@ def read_participant_tsv(tsv_file: str | Path) -> Tuple[List[str], List[str]]:
 
 
 def extract_metadata_from_json(
-    json_file: str | Path,
-    list_keys: List[str],
+    json_file: Union[str, Path],
+    list_keys: list[str],
     handle_missing_keys: Optional[Callable] = None,
-) -> List[str]:
+) -> list[str]:
     """Extract fields from JSON file.
 
     Parameters
@@ -488,7 +488,7 @@ def extract_metadata_from_json(
 
     Returns
     -------
-    list:
+    list of str:
         Contains the values for the requested fields.
     """
     import json

--- a/test/nonregression/pipelines/dwi/preprocessing/test_phase_diff.py
+++ b/test/nonregression/pipelines/dwi/preprocessing/test_phase_diff.py
@@ -36,13 +36,9 @@ def test_dwi_compute_reference_b0(cmdopt, tmp_path):
         - The reference B0 volume
         - The brain mask computed on the B0 volume
     """
-    from clinica.pipelines.dwi.preprocessing.fmap.workflows import (
-        compute_reference_b0,
-    )
-    from clinica.pipelines.dwi.preprocessing.utils import _bids_dir_to_fsl_dir  # noqa
-    from clinica.utils.filemanip import (
-        extract_metadata_from_json,
-        handle_missing_keys_dwi,
+    from clinica.pipelines.dwi.preprocessing.fmap.workflows import compute_reference_b0
+    from clinica.pipelines.dwi.preprocessing.utils import (
+        get_readout_time_and_phase_encoding_direction,
     )
 
     base_dir = Path(cmdopt["input"])
@@ -51,13 +47,12 @@ def test_dwi_compute_reference_b0(cmdopt, tmp_path):
     )
     (tmp_path / "tmp").mkdir()
 
-    [total_readout_time, phase_encoding_direction] = extract_metadata_from_json(
-        str(input_dir / "sub-01_ses-M000_dwi.json"),
-        ["TotalReadoutTime", "PhaseEncodingDirection"],
-        handle_missing_keys=handle_missing_keys_dwi,
+    (
+        total_readout_time,
+        phase_encoding_direction,
+    ) = get_readout_time_and_phase_encoding_direction(
+        str(input_dir / "sub-01_ses-M000_dwi.json")
     )
-    phase_encoding_direction = _bids_dir_to_fsl_dir(phase_encoding_direction)
-
     wf = compute_reference_b0(
         base_dir=str(tmp_dir),
         b_value_threshold=5.0,

--- a/test/unittests/utils/test_filemanip.py
+++ b/test/unittests/utils/test_filemanip.py
@@ -1,144 +1,12 @@
 import json
 import os
+from pathlib import Path
 
 import nibabel as nib
 import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
-
-from clinica.utils.exceptions import ClinicaException
-
-
-@pytest.mark.parametrize(
-    "dictionary, expected",
-    [
-        (
-            {
-                "TotalReadoutTime": 1,
-                "EstimatedTotalReadoutTime": "",
-                "PhaseEncodingSteps": "",
-                "PixelBandwidth": "",
-                "PhaseEncodingDirection": "j+",
-                "PhaseEncodingAxis": "",
-            },
-            [1, "j+"],
-        ),
-        (
-            {
-                "EstimatedTotalReadoutTime": 1,
-                "PhaseEncodingAxis": "j",
-            },
-            [1, "j+"],
-        ),
-        (
-            {
-                "PhaseEncodingSteps": 1,
-                "PixelBandwidth": 0.5,
-                "PhaseEncodingDirection": "j-",
-            },
-            [2, "j-"],
-        ),
-    ],
-)
-def test_extract_metadata_from_json_dwi(tmp_path, dictionary, expected):
-    """This function tests that the outputs of `extract_metadata_from_json` are what you'd expect in the case of DWI."""
-    import json
-
-    from clinica.utils.filemanip import (
-        extract_metadata_from_json,
-        handle_missing_keys_dwi,
-    )
-
-    with open(tmp_path / "metadata.json", "w") as outfile:
-        json.dump(dictionary, outfile)
-    assert (
-        extract_metadata_from_json(
-            tmp_path / "metadata.json",
-            [
-                "TotalReadoutTime",
-                "PhaseEncodingDirection",
-            ],
-            handle_missing_keys_dwi,
-        )
-        == expected
-    )
-
-
-@pytest.mark.parametrize(
-    "input_list, dictionary, error_type, error_log",
-    [
-        (
-            [
-                "TotalReadoutTime",
-                "PhaseEncodingDirection",
-            ],
-            {
-                "PhaseEncodingSteps": 1,
-                "PixelBandwidth": 0.5,
-            },
-            ClinicaException,
-            "Could not recover the PhaseEncodingDirection from JSON file.",
-        ),
-        (
-            [
-                "TotalReadoutTime",
-                "PhaseEncodingDirection",
-            ],
-            {
-                "PhaseEncodingDirection": "j+",
-            },
-            ClinicaException,
-            "Could not recover the TotalReadoutTime from JSON file.",
-        ),
-        (
-            [
-                "TotalReadoutTime",
-                "PhaseEncodingDirection",
-            ],
-            {
-                "PhaseEncodingSteps": 1,
-                "PixelBandwidth": 0,
-                "PhaseEncodingDirection": "j+",
-            },
-            ValueError,
-            "Pixel Bandwidth value is not valid.",
-        ),
-        (
-            [
-                "blabla",
-                "PhaseEncodingDirection",
-            ],
-            {
-                "PhaseEncodingDirection": "j+",
-            },
-            ValueError,
-            "Could not recover the missing keys {'blabla'} from JSON file.",
-        ),
-    ],
-)
-def test_extract_metadata_from_json_dwi_errors(
-    tmp_path, input_list, dictionary, error_type, error_log
-):
-    """This function tests that `extract_metadata_from_json` errors as expected in the case of DWI."""
-    import json
-
-    from clinica.utils.filemanip import (
-        extract_metadata_from_json,
-        handle_missing_keys_dwi,
-    )
-
-    with open(tmp_path / "metadata.json", "w") as outfile:
-        json.dump(dictionary, outfile)
-    with pytest.raises(
-        error_type,
-        match=error_log,
-    ):
-        extract_metadata_from_json(
-            tmp_path / "metadata.json",
-            input_list,
-            handle_missing_keys_dwi,
-        )
 
 
 def test_zip_nii(tmp_path):
@@ -181,7 +49,7 @@ def test_zip_unzip_nii(tmp_path):
 
 
 @pytest.fixture
-def test_image(case):
+def test_image(case) -> nib.Nifti1Image:
     shapes = {
         "3d": (5, 6, 7),
         "4d_dummy": (5, 6, 7, 1),
@@ -219,7 +87,7 @@ def test_load_img_3d(tmp_path, case, test_image):
             assert_array_equal(test_image.get_fdata().squeeze(), img2.get_fdata())
 
 
-def test_save_participants_sessions(tmp_path):
+def test_save_participants_sessions_error(tmp_path):
     from clinica.utils.filemanip import save_participants_sessions
 
     with pytest.raises(
@@ -227,8 +95,14 @@ def test_save_participants_sessions(tmp_path):
         match="The number of participant IDs is not equal to the number of session IDs.",
     ):
         save_participants_sessions(["sub-01"], ["ses-M000", "ses-M006"], tmp_path)
+
+
+def test_save_participants_sessions(tmp_path):
+    from clinica.utils.filemanip import save_participants_sessions
+
     save_participants_sessions(["sub-01"] * 2, ["ses-M000", "ses-M006"], tmp_path)
     assert (tmp_path / "participants.tsv").exists()
+
     df = pd.read_csv(tmp_path / "participants.tsv", sep="\t")
     for col in ("participant_id", "session_id"):
         assert col in df.columns
@@ -344,7 +218,7 @@ def test_extract_crash_files_from_log_file_error():
         extract_crash_files_from_log_file("foo.log")
 
 
-def test_read_participant_tsv(tmp_path):
+def test_read_participant_tsv_error(tmp_path):
     from clinica.utils.exceptions import ClinicaException
     from clinica.utils.filemanip import read_participant_tsv
 
@@ -354,6 +228,11 @@ def test_read_participant_tsv(tmp_path):
     ):
         read_participant_tsv(tmp_path / "foo.tsv")
 
+
+def test_read_participant_tsv(tmp_path):
+    from clinica.utils.exceptions import ClinicaException
+    from clinica.utils.filemanip import read_participant_tsv
+
     df = pd.DataFrame(
         {
             "participant_id": ["sub-01", "sub-01", "sub-02"],
@@ -361,6 +240,7 @@ def test_read_participant_tsv(tmp_path):
         }
     )
     df.to_csv(tmp_path / "foo.tsv", sep="\t")
+
     assert read_participant_tsv(tmp_path / "foo.tsv") == (
         ["sub-01", "sub-01", "sub-02"],
         ["ses-M000", "ses-M006", "ses-M000"],
@@ -375,11 +255,8 @@ def test_read_participant_tsv(tmp_path):
             read_participant_tsv(tmp_path / "foo.tsv")
 
 
-def test_extract_metadata_from_json(tmp_path):
-    from clinica.utils.exceptions import ClinicaException
+def test_extract_metadata_from_json_missing_file_error(tmp_path):
     from clinica.utils.filemanip import extract_metadata_from_json
-
-    data = {"foo": "foo_val", "bar": "bar_val"}
 
     with pytest.raises(
         FileNotFoundError,
@@ -387,14 +264,28 @@ def test_extract_metadata_from_json(tmp_path):
     ):
         extract_metadata_from_json(tmp_path / "foo.json", ["foo", "bar"])
 
+
+@pytest.fixture
+def json_data_for_test(tmp_path: Path):
+    data = {"foo": "foo_val", "bar": "bar_val"}
+
     with open(tmp_path / "foo.json", "w") as fp:
         json.dump(data, fp)
+
+
+def test_extract_metadata_from_json_missing_keys_error(tmp_path, json_data_for_test):
+    from clinica.utils.exceptions import ClinicaException
+    from clinica.utils.filemanip import extract_metadata_from_json
 
     with pytest.raises(
         ClinicaException,
         match="Clinica could not find the following keys in the following JSON file",
     ):
         extract_metadata_from_json(tmp_path / "foo.json", ["foo", "baz"])
+
+
+def test_extract_metadata_from_json(tmp_path, json_data_for_test):
+    from clinica.utils.filemanip import extract_metadata_from_json
 
     assert extract_metadata_from_json(tmp_path / "foo.json", ["foo", "bar"]) == [
         "foo_val",


### PR DESCRIPTION
This PR proposes to move a few functions specific to DWI preprocessing pipelines from the `clinica.utils.filemanip` module to the `clinica.pipelines.dwi.preprocessing.utils` module, in order to reduce coupling.