### PR TITLE
[FIX] Fix DWI preprocessing using T1 rename to caps node

### DIFF
--- a/clinica/pipelines/dwi/preprocessing/t1/pipeline.py
+++ b/clinica/pipelines/dwi/preprocessing/t1/pipeline.py
@@ -157,7 +157,6 @@ class DwiPreprocessingUsingT1(DWIPreprocessingPipeline):
             name="container_path",
         )
         files_to_write_in_caps = [
-            "dwi_filename",
             "dwi_preproc_filename",
             "b_values_preproc_filename",
             "b_vectors_preproc_filename",
@@ -166,7 +165,7 @@ class DwiPreprocessingUsingT1(DWIPreprocessingPipeline):
 
         rename_into_caps = npe.Node(
             nutil.Function(
-                input_names=files_to_write_in_caps,
+                input_names=["dwi_filename"] + files_to_write_in_caps,
                 output_names=[f"{x}_caps" for x in files_to_write_in_caps],
                 function=rename_into_caps_task,
             ),


### PR DESCRIPTION
Fixes #1143 

The issue comes from the fact that the `rename_into_caps` node is supposed to have 5 inputs and 4 outputs in the computation DAG, while the code was defining 5 inputs and 5 outputs. This is due to the same list being used to define the input and output names.

This bug was introduced recently in #1074 