### PR TITLE
[MAINT] Move `merge_nifti_images_in_time_dimension_task` in dwi tasks module

### DIFF
--- a/clinica/pipelines/dwi/preprocessing/t1/tasks.py
+++ b/clinica/pipelines/dwi/preprocessing/t1/tasks.py
@@ -99,3 +99,10 @@ def rename_into_caps_task(
         Path(b_vectors_preproc_filename),
         Path(b0_brain_mask_filename),
     )
+
+
+def merge_nifti_images_in_time_dimension_task(image1: str, image2: str) -> str:
+    """Merges the two provided volumes in the time (4th) dimension."""
+    from clinica.utils.image import merge_nifti_images_in_time_dimension
+
+    return str(merge_nifti_images_in_time_dimension((image1, image2)))

--- a/clinica/pipelines/dwi/preprocessing/t1/workflows.py
+++ b/clinica/pipelines/dwi/preprocessing/t1/workflows.py
@@ -560,7 +560,7 @@ def b0_flirt_pipeline(num_b0s: int, name: str = "b0_coregistration"):
     import nipype.pipeline.engine as pe
     from nipype.interfaces import fsl
 
-    from clinica.utils.image import merge_nifti_images_in_time_dimension_task
+    from .tasks import merge_nifti_images_in_time_dimension_task
 
     inputnode = pe.Node(niu.IdentityInterface(fields=["in_file"]), name="inputnode")
     fslroi_ref = pe.Node(fsl.ExtractROI(args="0 1"), name="b0_reference")

--- a/clinica/utils/image.py
+++ b/clinica/utils/image.py
@@ -6,6 +6,13 @@ import nibabel as nib
 import numpy as np
 from nibabel.nifti1 import Nifti1Image
 
+__all__ = [
+    "compute_aggregated_volume",
+    "get_new_image_like",
+    "merge_nifti_images_in_time_dimension",
+    "remove_dummy_dimension_from_image",
+]
+
 
 def compute_aggregated_volume(
     image_filename: PathLike,
@@ -140,14 +147,6 @@ def _check_volumes_from_images(images: Tuple[Path, ...]) -> Tuple[np.ndarray, ..
             )
 
     return tuple(four_dimensional_volumes)
-
-
-def merge_nifti_images_in_time_dimension_task(image1: str, image2: str) -> str:
-    """Merges the two provided volumes in the time (4th) dimension."""
-    # This is needed because Nipype needs to have self-contained functions
-    from clinica.utils.image import merge_nifti_images_in_time_dimension  # noqa
-
-    return str(merge_nifti_images_in_time_dimension((image1, image2)))
 
 
 def remove_dummy_dimension_from_image(image: str, output: str) -> str:


### PR DESCRIPTION
This PR proposes to move the adapter function `merge_nifti_images_in_time_dimension_task` from `clinica.utils.image` to `clinica.pipelines.dwi.preprocessing.t1.tasks` where other tasks for this pipeline are defined.
The function definition is kept in the image module.