### PR TITLE
[CI] Fix MacOS GitHub runner target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
         python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR replaces the macOS image target from `macos-latest` to `macos-12` for unit tests supposed to run on Intel chips.
This is because the former now refers to `macos-14` ARM which is not playing nice with our test suite with Python >= 3.11 atm...
I'll open a dedicated issue to remember to investigate why this is the case.