### PR TITLE
add "real" and "imaginary" file endings to return fmap in adni_utils.py

### DIFF
--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -1163,6 +1163,8 @@ def find_conversion_mod(file_name):
         "phasediff",
         "magnitude1",
         "magnitude2",
+        "real",
+        "imaginary"
     ):
         return "fmap"
     elif suffix == "pet":


### PR DESCRIPTION
Adding file endings "real" and "imaginary" to adni_utils.py to return "fmap"; to cover all file endings.
This allows  running over:

"... fmap_ e2_imaginary.json"
"... fmap_e2_real.json"

and not throw an error.

This PR was mentioned in #1175.

