### PR TITLE
[FIX] Fix logging in adni to bids

### DIFF
--- a/clinica/cmdline.py
+++ b/clinica/cmdline.py
@@ -32,29 +32,24 @@ def setup_logging(verbose: bool = False) -> None:
             (0 (default): WARNING, 1: INFO, 2: DEBUG)
     """
     import logging
-    import sys
-    from logging.handlers import RotatingFileHandler as RFHandler
-
-    import nipype
-    from colorlog import ColoredFormatter, StreamHandler
 
     logging_level = "DEBUG" if verbose else "INFO"
-
     # Root logger configuration.
     root_logger = logging.getLogger()
     root_logger.setLevel(logging_level)
-
     # Clinica logger configuration.
-    clinica_logger = logging.getLogger("clinica")
-    clinica_logger.setLevel(logging_level)
-    console_handler = StreamHandler(stream=sys.stdout)
-    console_handler.setFormatter(
-        ColoredFormatter("%(log_color)s%(asctime)s:%(levelname)s:%(message)s")
-    )
-    clinica_logger.addHandler(console_handler)
-
+    setup_clinica_logging(logging_level)
     # Nipype logger configuration.
-    # Monkey-patch nipype to use Python's RFH logger.
+    setup_nipype_logging()
+
+
+def setup_nipype_logging():
+    """Monkey-patch nipype to use Python's RFH logger."""
+    import logging
+    from logging.handlers import RotatingFileHandler as RFHandler
+
+    import nipype
+
     nipype.utils.logger.RFHandler = RFHandler
     # Setup debug logging to file.
     nipype.config.enable_debug_mode()
@@ -72,6 +67,21 @@ def setup_logging(verbose: bool = False) -> None:
     nipype_logger = logging.getLogger("nipype")
     nipype_logger.removeHandler(nipype_logger.handlers[0])
     nipype_logger.addHandler(logging.NullHandler())
+
+
+def setup_clinica_logging(logging_level: str):
+    import logging
+    import sys
+
+    from colorlog import ColoredFormatter, StreamHandler
+
+    clinica_logger = logging.getLogger("clinica")
+    clinica_logger.setLevel(logging_level)
+    console_handler = StreamHandler(stream=sys.stdout)
+    console_handler.setFormatter(
+        ColoredFormatter("%(log_color)s%(asctime)s:%(levelname)s:%(message)s")
+    )
+    clinica_logger.addHandler(console_handler)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)

--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -1356,7 +1356,7 @@ def create_file(
     # Note that logging messages could easily be lost (for example when logging
     # to a file from two different processes). A better solution would be to
     # implement a logging process consuming logging messages from a multiprocessing.Queue...
-    setup_clinica_logging("DEBUG")
+    setup_clinica_logging("INFO")
 
     modality_specific = {
         "t1": {

--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -1344,11 +1344,19 @@ def create_file(
 
     import numpy as np
 
+    from clinica.cmdline import setup_clinica_logging
     from clinica.iotools.bids_utils import run_dcm2niix
     from clinica.iotools.converter_utils import viscode_to_session
     from clinica.iotools.utils.data_handling import center_nifti_origin
     from clinica.utils.pet import ReconstructionMethod, Tracer
     from clinica.utils.stream import cprint
+
+    # This function is executed in a multiprocessing context
+    # such that we need to re-configure the clinica logger in the child processes.
+    # Note that logging messages could easily be lost (for example when logging
+    # to a file from two different processes). A better solution would be to
+    # implement a logging process consuming logging messages from a multiprocessing.Queue...
+    setup_clinica_logging("DEBUG")
 
     modality_specific = {
         "t1": {


### PR DESCRIPTION
The function `create_file` in the adni-to-bids converter is executed in a multiprocessing context but doesn't handle the logging of messages in the sense that child processes do not configure their own logger.

This has a few consequences like the fact that messages logged from child processes aren't formatted or might even be missing.

This PR proposes a quick fix of re-configuring the clinica logger in child processes.

Ideally, we should have a process-safe logging architecture which would avoid race conditions (especially when logging to files for instance).
A classical solution is to dedicate a process to the logging task while other working processes send their logging messages through a Queue.