### PR TITLE
ADNI_to_BIDS utils : `load_clinical_csv`, hidden csv file matching, issue #1163

### DIFF
--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -1644,7 +1644,7 @@ def load_clinical_csv(clinical_dir: str, filename: str) -> pd.DataFrame:
 
     pattern = filename + r"(_\d{1,2}[A-Za-z]{3}\d{4})?.csv"
     files_matching_pattern = [
-        f for f in Path(clinical_dir).rglob("*.csv") if re.search(pattern, (f.name))
+        f for f in Path(clinical_dir).rglob("*.csv") if re.match(pattern, (f.name))
     ]
     if len(files_matching_pattern) != 1:
         raise IOError(


### PR DESCRIPTION
Fix issue #1163

Change `re.search ` by `re.match`. 

It will avoid hidden file matching by constraining to an exact match with the pattern 

if we have two files: 
- correct file: `ADNIMERGE_25Apr2024.csv`
- hidden file: `.ADNIMERGE_25Apr2024.csv`

the pattern is `"ADNIMERGE"+ r"(_\d{1,2}[A-Za-z]{3}\d{4})?.csv"`, only the correct file will be returned.
