### PR TITLE
[ENH] ADNI-to-BIDS converts only subjects in the provided ADNI directory if no subjects list is given

### DIFF
--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -173,6 +173,9 @@ def create_participants_df(
         else:
             participant_df.at[i, "participant_id"] = bids_id[0]
 
+    # todo : really useful ?
+    # todo : would prefer to return a list of subjects that failed something at the end of the pipeline
+
     if len(subjects_to_drop) > 0:
         cprint(
             msg=(

--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -173,8 +173,6 @@ def create_participants_df(
         else:
             participant_df.at[i, "participant_id"] = bids_id[0]
 
-    # todo : really useful ?
-
     if len(subjects_to_drop) > 0:
         cprint(
             msg=(

--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -174,7 +174,6 @@ def create_participants_df(
             participant_df.at[i, "participant_id"] = bids_id[0]
 
     # todo : really useful ?
-    # todo : would prefer to return a list of subjects that failed something at the end of the pipeline
 
     if len(subjects_to_drop) > 0:
         cprint(

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_av45_fbb_pet.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_av45_fbb_pet.py
@@ -1,6 +1,6 @@
 """Module for converting AV45 and Florbetaben PET of ADNI."""
 from os import PathLike
-from typing import List, Optional
+from typing import List
 
 
 def convert_adni_av45_fbb_pet(
@@ -49,6 +49,9 @@ def convert_adni_av45_fbb_pet(
         paths_to_bids,
     )
     from clinica.utils.stream import cprint
+
+    if not subjects:
+        cprint(f"Processing an empty list of subjects.", lvl="warning")
 
     cprint(
         f"Calculating paths of AV45 and Florbetaben PET images. Output will be stored in {conversion_dir}."

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_av45_fbb_pet.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_av45_fbb_pet.py
@@ -50,9 +50,6 @@ def convert_adni_av45_fbb_pet(
     )
     from clinica.utils.stream import cprint
 
-    if not subjects:
-        cprint(f"Processing an empty list of subjects.", lvl="warning")
-
     cprint(
         f"Calculating paths of AV45 and Florbetaben PET images. Output will be stored in {conversion_dir}."
     )

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_av45_fbb_pet.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_av45_fbb_pet.py
@@ -8,7 +8,7 @@ def convert_adni_av45_fbb_pet(
     csv_dir: PathLike,
     destination_dir: PathLike,
     conversion_dir: PathLike,
-    subjects: Optional[List[str]] = None,
+    subjects: List[str],
     mod_to_update: bool = False,
     n_procs: int = 1,
 ):
@@ -49,10 +49,6 @@ def convert_adni_av45_fbb_pet(
         paths_to_bids,
     )
     from clinica.utils.stream import cprint
-
-    if not subjects:
-        adni_merge = load_clinical_csv(csv_dir, "ADNIMERGE")
-        subjects = list(adni_merge.PTID.unique())
 
     cprint(
         f"Calculating paths of AV45 and Florbetaben PET images. Output will be stored in {conversion_dir}."

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_dwi.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_dwi.py
@@ -8,7 +8,7 @@ def convert_adni_dwi(
     csv_dir: PathLike,
     destination_dir: PathLike,
     conversion_dir: PathLike,
-    subjects: Optional[List[str]] = None,
+    subjects: List[str],
     mod_to_update: bool = False,
     n_procs: Optional[int] = 1,
 ):
@@ -49,10 +49,6 @@ def convert_adni_dwi(
         paths_to_bids,
     )
     from clinica.utils.stream import cprint
-
-    if not subjects:
-        adni_merge = load_clinical_csv(csv_dir, "ADNIMERGE")
-        subjects = list(adni_merge.PTID.unique())
 
     cprint(
         f"Calculating paths of DWI images. Output will be stored in {conversion_dir}."

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_dwi.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_dwi.py
@@ -50,6 +50,9 @@ def convert_adni_dwi(
     )
     from clinica.utils.stream import cprint
 
+    if not subjects:
+        cprint(f"Processing an empty list of subjects.", lvl="warning")
+
     cprint(
         f"Calculating paths of DWI images. Output will be stored in {conversion_dir}."
     )

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_dwi.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_dwi.py
@@ -50,9 +50,6 @@ def convert_adni_dwi(
     )
     from clinica.utils.stream import cprint
 
-    if not subjects:
-        cprint(f"Processing an empty list of subjects.", lvl="warning")
-
     cprint(
         f"Calculating paths of DWI images. Output will be stored in {conversion_dir}."
     )

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fdg_pet.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fdg_pet.py
@@ -92,6 +92,9 @@ def _convert_adni_fdg_pet(
     )
     from clinica.utils.stream import cprint
 
+    if not subjects:
+        cprint(f"Processing an empty list of subjects.", lvl="warning")
+
     cprint(
         "Calculating paths of FDG PET images. "
         f"Output will be stored in {conversion_dir}."

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fdg_pet.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fdg_pet.py
@@ -47,7 +47,7 @@ def _convert_adni_fdg_pet(
     destination_dir: PathLike,
     conversion_dir: PathLike,
     preprocessing_step: ADNIPreprocessingStep,
-    subjects: Optional[List[str]] = None,
+    subjects: List[str],
     mod_to_update: bool = False,
     n_procs: Optional[int] = 1,
 ):
@@ -92,9 +92,6 @@ def _convert_adni_fdg_pet(
     )
     from clinica.utils.stream import cprint
 
-    if subjects is None:
-        adni_merge = load_clinical_csv(csv_dir, "ADNIMERGE")
-        subjects = list(adni_merge.PTID.unique())
     cprint(
         "Calculating paths of FDG PET images. "
         f"Output will be stored in {conversion_dir}."

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fdg_pet.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fdg_pet.py
@@ -92,9 +92,6 @@ def _convert_adni_fdg_pet(
     )
     from clinica.utils.stream import cprint
 
-    if not subjects:
-        cprint(f"Processing an empty list of subjects.", lvl="warning")
-
     cprint(
         "Calculating paths of FDG PET images. "
         f"Output will be stored in {conversion_dir}."

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_flair.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_flair.py
@@ -46,6 +46,9 @@ def convert_adni_flair(
     )
     from clinica.utils.stream import cprint
 
+    if not subjects:
+        cprint(f"Processing an empty list of subjects.", lvl="warning")
+
     cprint(
         f"Calculating paths of FLAIR images. Output will be stored in {conversion_dir}.",
         lvl="info",

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_flair.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_flair.py
@@ -8,7 +8,7 @@ def convert_adni_flair(
     csv_dir: PathLike,
     destination_dir: PathLike,
     conversion_dir: PathLike,
-    subjects: Optional[List[str]] = None,
+    subjects: List[str],
     mod_to_update: bool = False,
     n_procs: Optional[int] = 1,
 ):
@@ -45,10 +45,6 @@ def convert_adni_flair(
         paths_to_bids,
     )
     from clinica.utils.stream import cprint
-
-    if not subjects:
-        adni_merge = load_clinical_csv(csv_dir, "ADNIMERGE")
-        subjects = list(adni_merge.PTID.unique())
 
     cprint(
         f"Calculating paths of FLAIR images. Output will be stored in {conversion_dir}.",

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_flair.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_flair.py
@@ -46,9 +46,6 @@ def convert_adni_flair(
     )
     from clinica.utils.stream import cprint
 
-    if not subjects:
-        cprint(f"Processing an empty list of subjects.", lvl="warning")
-
     cprint(
         f"Calculating paths of FLAIR images. Output will be stored in {conversion_dir}.",
         lvl="info",

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmap.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmap.py
@@ -54,9 +54,6 @@ def convert_adni_fmap(
     from clinica.iotools.converters.adni_to_bids.adni_utils import paths_to_bids
     from clinica.utils.stream import cprint
 
-    if not subjects:
-        cprint(f"Processing an empty list of subjects.", lvl="warning")
-
     csv_dir = Path(csv_dir)
     source_dir = Path(source_dir)
     conversion_dir = Path(conversion_dir)

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmap.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmap.py
@@ -54,6 +54,9 @@ def convert_adni_fmap(
     from clinica.iotools.converters.adni_to_bids.adni_utils import paths_to_bids
     from clinica.utils.stream import cprint
 
+    if not subjects:
+        cprint(f"Processing an empty list of subjects.", lvl="warning")
+
     csv_dir = Path(csv_dir)
     source_dir = Path(source_dir)
     conversion_dir = Path(conversion_dir)

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmap.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmap.py
@@ -58,10 +58,6 @@ def convert_adni_fmap(
     source_dir = Path(source_dir)
     conversion_dir = Path(conversion_dir)
 
-    if not subjects:
-        adni_merge = load_clinical_csv(csv_dir, "ADNIMERGE")
-        subjects = list(adni_merge.PTID.unique())
-
     cprint(
         f"Calculating paths of fMRI field maps (FMAPs). Output will be stored in {conversion_dir}.",
         lvl="debug",

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmap.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmap.py
@@ -19,7 +19,7 @@ def convert_adni_fmap(
     csv_dir: PathLike,
     destination_dir: PathLike,
     conversion_dir: PathLike,
-    subjects: Optional[List[str]] = None,
+    subjects: List[str],
     mod_to_update: bool = False,
     n_procs: Optional[int] = 1,
 ):

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmri.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmri.py
@@ -54,6 +54,9 @@ def convert_adni_fmri(
     )
     from clinica.utils.stream import cprint
 
+    if not subjects:
+        cprint(f"Processing an empty list of subjects.", lvl="warning")
+
     cprint(
         f"Calculating paths of fMRI images. Output will be stored in {conversion_dir}."
     )

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmri.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmri.py
@@ -54,9 +54,6 @@ def convert_adni_fmri(
     )
     from clinica.utils.stream import cprint
 
-    if not subjects:
-        cprint(f"Processing an empty list of subjects.", lvl="warning")
-
     cprint(
         f"Calculating paths of fMRI images. Output will be stored in {conversion_dir}."
     )

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmri.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_fmri.py
@@ -10,7 +10,7 @@ def convert_adni_fmri(
     csv_dir: PathLike,
     destination_dir: PathLike,
     conversion_dir: PathLike,
-    subjects: Optional[List[str]] = None,
+    subjects: List[str],
     mod_to_update: bool = False,
     n_procs: Optional[int] = 1,
     convert_multiband: bool = True,
@@ -53,10 +53,6 @@ def convert_adni_fmri(
         paths_to_bids,
     )
     from clinica.utils.stream import cprint
-
-    if not subjects:
-        adni_merge = load_clinical_csv(csv_dir, "ADNIMERGE")
-        subjects = list(adni_merge.PTID.unique())
 
     cprint(
         f"Calculating paths of fMRI images. Output will be stored in {conversion_dir}."

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_pib_pet.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_pib_pet.py
@@ -50,9 +50,6 @@ def convert_adni_pib_pet(
     )
     from clinica.utils.stream import cprint
 
-    if not subjects:
-        cprint(f"Processing an empty list of subjects.", lvl="warning")
-
     cprint(
         f"Calculating paths of PIB PET images. Output will be stored in {conversion_dir}."
     )

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_pib_pet.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_pib_pet.py
@@ -50,6 +50,9 @@ def convert_adni_pib_pet(
     )
     from clinica.utils.stream import cprint
 
+    if not subjects:
+        cprint(f"Processing an empty list of subjects.", lvl="warning")
+
     cprint(
         f"Calculating paths of PIB PET images. Output will be stored in {conversion_dir}."
     )

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_pib_pet.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_pib_pet.py
@@ -8,7 +8,7 @@ def convert_adni_pib_pet(
     csv_dir: PathLike,
     destination_dir: PathLike,
     conversion_dir: PathLike,
-    subjects: Optional[List[str]] = None,
+    subjects: List[str],
     mod_to_update: bool = False,
     n_procs: Optional[int] = 1,
 ):
@@ -49,10 +49,6 @@ def convert_adni_pib_pet(
         paths_to_bids,
     )
     from clinica.utils.stream import cprint
-
-    if not subjects:
-        adni_merge = load_clinical_csv(csv_dir, "ADNIMERGE")
-        subjects = list(adni_merge.PTID.unique())
 
     cprint(
         f"Calculating paths of PIB PET images. Output will be stored in {conversion_dir}."

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_t1.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_t1.py
@@ -51,9 +51,6 @@ def convert_adni_t1(
     )
     from clinica.utils.stream import cprint
 
-    if not subjects:
-        cprint(f"Processing an empty list of subjects.", lvl="warning")
-
     cprint(
         f"Calculating paths of T1 images. Output will be stored in {conversion_dir}."
     )

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_t1.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_t1.py
@@ -8,7 +8,7 @@ def convert_adni_t1(
     csv_dir: PathLike,
     destination_dir: PathLike,
     conversion_dir: PathLike,
-    subjects: Optional[List[str]] = None,
+    subjects: List[str],
     mod_to_update: bool = False,
     n_procs: Optional[int] = 1,
 ):
@@ -50,10 +50,6 @@ def convert_adni_t1(
         paths_to_bids,
     )
     from clinica.utils.stream import cprint
-
-    if not subjects:
-        adni_merge = load_clinical_csv(csv_dir, "ADNIMERGE")
-        subjects = list(adni_merge.PTID.unique())
 
     cprint(
         f"Calculating paths of T1 images. Output will be stored in {conversion_dir}."

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_t1.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_t1.py
@@ -51,6 +51,9 @@ def convert_adni_t1(
     )
     from clinica.utils.stream import cprint
 
+    if not subjects:
+        cprint(f"Processing an empty list of subjects.", lvl="warning")
+
     cprint(
         f"Calculating paths of T1 images. Output will be stored in {conversion_dir}."
     )

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_tau_pet.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_tau_pet.py
@@ -50,9 +50,6 @@ def convert_adni_tau_pet(
     )
     from clinica.utils.stream import cprint
 
-    if not subjects:
-        cprint(f"Processing an empty list of subjects.", lvl="warning")
-
     cprint(
         f"Calculating paths of TAU PET images. Output will be stored in {conversion_dir}."
     )

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_tau_pet.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_tau_pet.py
@@ -50,6 +50,9 @@ def convert_adni_tau_pet(
     )
     from clinica.utils.stream import cprint
 
+    if not subjects:
+        cprint(f"Processing an empty list of subjects.", lvl="warning")
+
     cprint(
         f"Calculating paths of TAU PET images. Output will be stored in {conversion_dir}."
     )

--- a/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_tau_pet.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_modalities/adni_tau_pet.py
@@ -8,7 +8,7 @@ def convert_adni_tau_pet(
     csv_dir: PathLike,
     destination_dir: PathLike,
     conversion_dir: PathLike,
-    subjects: Optional[List[str]] = None,
+    subjects: List[str],
     mod_to_update: bool = False,
     n_procs: Optional[int] = 1,
 ):
@@ -49,10 +49,6 @@ def convert_adni_tau_pet(
         paths_to_bids,
     )
     from clinica.utils.stream import cprint
-
-    if not subjects:
-        adni_merge = load_clinical_csv(csv_dir, "ADNIMERGE")
-        subjects = list(adni_merge.PTID.unique())
 
     cprint(
         f"Calculating paths of TAU PET images. Output will be stored in {conversion_dir}."

--- a/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import List, Optional
 
 from clinica.iotools.abstract_converter import Converter
@@ -217,7 +218,7 @@ class AdniToBids(Converter):
 
         adni_merge = load_clinical_csv(clinical_dir, "ADNIMERGE")
 
-        # Load a file with subjects list or compute all the subjects
+        # Load a file with subjects list or compute subjects in ADNI directory
         if subjs_list_path is not None:
             cprint("Loading a subjects lists provided by the user...")
             subjs_list = [line.rstrip("\n") for line in open(subjs_list_path)]
@@ -236,8 +237,20 @@ class AdniToBids(Converter):
             del subjs_list_copy
 
         else:
-            cprint("Using all the subjects contained into the ADNIMERGE.csv file...")
-            subjs_list = list(adni_merge["PTID"].unique())
+            cprint(
+                f"Using all the subjects contained in the ADNI dataset at {source_dir}"
+            )
+            subjs_list = [
+                sub.name
+                for sub in Path(source_dir).iterdir()
+                if not sub.name.startswith(".")
+            ]
+
+        if not subjs_list:
+            # todo : right type of error ?
+            raise ValueError(
+                f"There is no subjects to convert in the provided ADNI dataset {source_dir}"
+            )
 
         # Create the output folder if is not already existing
         os.makedirs(dest_dir, exist_ok=True)

--- a/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
@@ -36,10 +36,10 @@ def get_bids_subjs_info(
     return bids_ids, bids_paths
 
 
-def define_subjects_list(
-    source_dir: Path,
-    clinical_dir: Path,
-    subjs_list_path: Optional[Path] = None,
+def _define_subjects_list(
+    source_dir: str,
+    clinical_dir: str,
+    subjs_list_path: Optional[str] = None,
 ) -> List[str]:
     import re
     from copy import copy
@@ -57,7 +57,9 @@ def define_subjects_list(
         cprint(f"Using the subjects contained in the ADNI dataset at {source_dir}")
         rgx = re.compile(r"\d{3}_S_\d{4}")
         subjs_list = list(
-            filter(rgx.fullmatch, [folder.name for folder in source_dir.iterdir()])
+            filter(
+                rgx.fullmatch, [folder.name for folder in Path(source_dir).iterdir()]
+            )
         )
 
     subjs_list_copy = copy(subjs_list)
@@ -67,16 +69,12 @@ def define_subjects_list(
         adnimerge_subj = adni_merge[adni_merge.PTID == subj]
         if len(adnimerge_subj) == 0:
             cprint(
-                msg=f"Subject with PTID {subj} does not exist. Please check your subjects list or directory.",
+                msg=f"Subject with PTID {subj} does not have corresponding clinical data."
+                f"Please check your subjects list or directory.",
                 lvl="warning",
             )
             subjs_list.remove(subj)
     del subjs_list_copy
-
-    if not subjs_list:
-        raise ValueError(
-            f"No actual subjects were found in given list or ADNI directory."
-        )
 
     return subjs_list
 
@@ -257,9 +255,7 @@ class AdniToBids(Converter):
 
         modalities = modalities or self.get_modalities_supported()
 
-        subjs_list = define_subjects_list(
-            Path(source_dir), Path(clinical_dir), subjs_list_path
-        )
+        subjs_list = _define_subjects_list(source_dir, clinical_dir, subjs_list_path)
 
         # Create the output folder if is not already existing
         os.makedirs(dest_dir, exist_ok=True)

--- a/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
@@ -208,10 +208,7 @@ class AdniToBids(Converter):
         import clinica.iotools.converters.adni_to_bids.adni_modalities.adni_pib_pet as adni_pib
         import clinica.iotools.converters.adni_to_bids.adni_modalities.adni_t1 as adni_t1
         import clinica.iotools.converters.adni_to_bids.adni_modalities.adni_tau_pet as adni_tau
-        from clinica.iotools.converters.adni_to_bids.adni_utils import (
-            check_subjects_list,
-            define_subjects_list,
-        )
+        from clinica.iotools.converters.adni_to_bids.adni_utils import get_subjects_list
         from clinica.utils.stream import cprint
 
         modalities = modalities or self.get_modalities_supported()
@@ -219,9 +216,7 @@ class AdniToBids(Converter):
         if subjs_list_path:
             subjs_list_path = Path(subjs_list_path)
 
-        subjs_list = check_subjects_list(
-            define_subjects_list(Path(source_dir), subjs_list_path), clinical_dir
-        )
+        subjs_list = get_subjects_list(Path(source_dir), subjs_list_path, clinical_dir)
 
         # Create the output folder if is not already existing
         os.makedirs(dest_dir, exist_ok=True)

--- a/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
@@ -216,7 +216,9 @@ class AdniToBids(Converter):
         if subjs_list_path:
             subjs_list_path = Path(subjs_list_path)
 
-        subjs_list = get_subjects_list(Path(source_dir), subjs_list_path, clinical_dir)
+        subjs_list = get_subjects_list(
+            Path(source_dir), Path(clinical_dir), subjs_list_path
+        )
 
         # Create the output folder if is not already existing
         os.makedirs(dest_dir, exist_ok=True)

--- a/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
@@ -216,8 +216,11 @@ class AdniToBids(Converter):
 
         modalities = modalities or self.get_modalities_supported()
 
+        if subjs_list_path:
+            subjs_list_path = Path(subjs_list_path)
+
         subjs_list = check_subjects_list(
-            define_subjects_list(source_dir, subjs_list_path), clinical_dir
+            define_subjects_list(Path(source_dir), subjs_list_path), clinical_dir
         )
 
         # Create the output folder if is not already existing

--- a/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
@@ -257,7 +257,9 @@ class AdniToBids(Converter):
 
         modalities = modalities or self.get_modalities_supported()
 
-        subjs_list = define_subjects_list(source_dir, clinical_dir, subjs_list_path)
+        subjs_list = define_subjects_list(
+            Path(source_dir), Path(clinical_dir), subjs_list_path
+        )
 
         # Create the output folder if is not already existing
         os.makedirs(dest_dir, exist_ok=True)

--- a/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_to_bids.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import List, Optional
 
 from clinica.iotools.abstract_converter import Converter
@@ -197,6 +196,7 @@ class AdniToBids(Converter):
             force_new_extraction: if given pre-existing images in the BIDS directory will be erased and extracted again.
         """
         import os
+        import re
         from copy import copy
         from os import path
 
@@ -240,11 +240,8 @@ class AdniToBids(Converter):
             cprint(
                 f"Using all the subjects contained in the ADNI dataset at {source_dir}"
             )
-            subjs_list = [
-                sub.name
-                for sub in Path(source_dir).iterdir()
-                if not sub.name.startswith(".")
-            ]
+            rgx = re.compile(r"\d{3}_S_(\d{4})")
+            subjs_list = list(filter(rgx.fullmatch, os.listdir(source_dir)))
 
         if not subjs_list:
             # todo : right type of error ?

--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -981,8 +981,10 @@ def create_adni_sessions_dict(
             ]
             df_subj_session = pd.concat([df_subj_session, df_filtered], axis=1)
     if df_subj_session.empty:
-        raise ValueError("Empty dataset detected. Clinical data cannot be extracted.")
-
+        cprint(
+            "Empty dataset detected. Clinical data cannot be extracted.", lvl="warning"
+        )
+        return
     # Nv/None refer to sessions whose session is undefined. "sc" is the screening session with unreliable (incomplete)
     # data.
     df_subj_session = df_subj_session[

--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -29,7 +29,7 @@ class ADNIStudy(Enum):
         )
 
 
-def define_subjects_list(
+def _define_subjects_list(
     source_dir: Path,
     subjs_list_path: Optional[Path] = None,
 ) -> List[str]:
@@ -47,16 +47,16 @@ def define_subjects_list(
     return list(filter(rgx.fullmatch, [folder.name for folder in source_dir.iterdir()]))
 
 
-def check_subjects_list(
+def _check_subjects_list(
     subjs_list: List[str],
-    clinical_dir: str,
+    clinical_dir: Path,
 ) -> List[str]:
     from copy import copy
 
     from clinica.utils.stream import cprint
 
     subjs_list_copy = copy(subjs_list)
-    adni_merge = load_clinical_csv(clinical_dir, "ADNIMERGE")
+    adni_merge = load_clinical_csv(str(clinical_dir), "ADNIMERGE")
     # Check that there are no errors in subjs_list given by the user
     for subj in subjs_list_copy:
         adnimerge_subj = adni_merge[adni_merge.PTID == subj]
@@ -73,6 +73,16 @@ def check_subjects_list(
         cprint(f"Processing an empty list of subjects.", lvl="warning")
 
     return subjs_list
+
+
+def get_subjects_list(
+    source_dir: Path,
+    clinical_dir: Path,
+    subjs_list_path: Optional[Path] = None,
+) -> List[str]:
+    return _check_subjects_list(
+        _define_subjects_list(source_dir, subjs_list_path), clinical_dir
+    )
 
 
 def visits_to_timepoints(

--- a/clinica/iotools/converters/adni_to_bids/adni_utils.py
+++ b/clinica/iotools/converters/adni_to_bids/adni_utils.py
@@ -30,8 +30,8 @@ class ADNIStudy(Enum):
 
 
 def define_subjects_list(
-    source_dir: str,
-    subjs_list_path: Optional[str] = None,
+    source_dir: Path,
+    subjs_list_path: Optional[Path] = None,
 ) -> List[str]:
     # todo : here or in utils for all converters ?
     import re
@@ -40,17 +40,11 @@ def define_subjects_list(
 
     if subjs_list_path:
         cprint("Loading a subjects lists provided by the user...")
-        subjs_list = [line.rstrip("\n") for line in open(subjs_list_path)]
+        return subjs_list_path.read_text().splitlines()
 
-    else:
-        cprint(f"Using the subjects contained in the ADNI dataset at {source_dir}")
-        rgx = re.compile(r"\d{3}_S_\d{4}")
-        subjs_list = list(
-            filter(
-                rgx.fullmatch, [folder.name for folder in Path(source_dir).iterdir()]
-            )
-        )
-    return subjs_list
+    cprint(f"Using the subjects contained in the ADNI dataset at {source_dir}")
+    rgx = re.compile(r"\d{3}_S_\d{4}")
+    return list(filter(rgx.fullmatch, [folder.name for folder in source_dir.iterdir()]))
 
 
 def check_subjects_list(
@@ -74,6 +68,9 @@ def check_subjects_list(
             )
             subjs_list.remove(subj)
     del subjs_list_copy
+
+    if not subjs_list:
+        cprint(f"Processing an empty list of subjects.", lvl="warning")
 
     return subjs_list
 

--- a/test/unittests/iotools/converters/adni_to_bids/test_adni_utils.py
+++ b/test/unittests/iotools/converters/adni_to_bids/test_adni_utils.py
@@ -16,7 +16,7 @@ from pandas.testing import assert_frame_equal, assert_series_equal
     ],
 )
 def test_define_subjects_list_directory(tmp_path, input, expected):
-    from clinica.iotools.converters.adni_to_bids.adni_utils import define_subjects_list
+    from clinica.iotools.converters.adni_to_bids.adni_utils import _define_subjects_list
 
     source_dir = tmp_path / "source_dir"
     source_dir.mkdir()
@@ -24,11 +24,11 @@ def test_define_subjects_list_directory(tmp_path, input, expected):
     for subject in input:
         (source_dir / subject).touch()
 
-    assert set(define_subjects_list(source_dir)) == expected
+    assert set(_define_subjects_list(source_dir)) == expected
 
 
 def test_define_subjects_list_txt(tmp_path):
-    from clinica.iotools.converters.adni_to_bids.adni_utils import define_subjects_list
+    from clinica.iotools.converters.adni_to_bids.adni_utils import _define_subjects_list
 
     source_dir = tmp_path / "source_dir"
     subjs_list_path = tmp_path / "subjects_list.txt"
@@ -36,7 +36,7 @@ def test_define_subjects_list_txt(tmp_path):
     with open(subjs_list_path, "w") as f:
         f.write("\n".join(input))
 
-    assert set(define_subjects_list(source_dir, subjs_list_path)) == input
+    assert set(_define_subjects_list(source_dir, subjs_list_path)) == input
 
 
 @pytest.mark.parametrize(
@@ -47,7 +47,7 @@ def test_define_subjects_list_txt(tmp_path):
     ],
 )
 def test_check_subjects_list(tmp_path, write_all, input, expected):
-    from clinica.iotools.converters.adni_to_bids.adni_utils import check_subjects_list
+    from clinica.iotools.converters.adni_to_bids.adni_utils import _check_subjects_list
 
     clinical_dir = tmp_path / "clinical_dir"
     clinical_dir.mkdir()
@@ -58,7 +58,7 @@ def test_check_subjects_list(tmp_path, write_all, input, expected):
     adni_df = pd.DataFrame(columns=["PTID"], data=input)
     adni_df.to_csv(clinical_dir / "ADNIMERGE.csv")
 
-    assert set(check_subjects_list(input, str(clinical_dir))) == expected
+    assert set(_check_subjects_list(input, clinical_dir)) == expected
 
 
 @pytest.mark.parametrize(

--- a/test/unittests/iotools/converters/adni_to_bids/test_adni_utils.py
+++ b/test/unittests/iotools/converters/adni_to_bids/test_adni_utils.py
@@ -24,12 +24,19 @@ def test_define_subjects_list_directory(tmp_path, input, expected):
     for subject in input:
         (source_dir / subject).touch()
 
-    subjs_list_path = tmp_path / "subjects_list.txt"
-    with open(subjs_list_path, "w") as f:
-        f.write("".join([subj + "\n" for subj in input]))
+    assert set(define_subjects_list(source_dir)) == expected
 
-    assert set(define_subjects_list(str(source_dir))) == expected
-    assert set(define_subjects_list(str(source_dir), str(subjs_list_path))) == input
+
+def test_define_subjects_list_txt(tmp_path):
+    from clinica.iotools.converters.adni_to_bids.adni_utils import define_subjects_list
+
+    source_dir = tmp_path / "source_dir"
+    subjs_list_path = tmp_path / "subjects_list.txt"
+    input = {"001_S_0001", "001_S_00022", "001S0003"}
+    with open(subjs_list_path, "w") as f:
+        f.write("\n".join(input))
+
+    assert set(define_subjects_list(source_dir, subjs_list_path)) == input
 
 
 @pytest.mark.parametrize(
@@ -46,7 +53,7 @@ def test_check_subjects_list(tmp_path, write_all, input, expected):
     clinical_dir.mkdir()
 
     if not write_all:
-        input.remove(input[-1])
+        input.pop()
 
     adni_df = pd.DataFrame(columns=["PTID"], data=input)
     adni_df.to_csv(clinical_dir / "ADNIMERGE.csv")


### PR DESCRIPTION
This PR adresses the behavior described in issue #398. 

- New functions were added in adni_utils.py to define the subjects list to convert, either from the given raw ADNI dataset or a subject list. Handles cases where there is no corresponding clinical data. 
- Unit tests were also added.