### PR TITLE
[REF] BIDS : refactor function `create_participants_df` from `bids_utils` 

### DIFF
--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -75,6 +75,10 @@ def create_participants_df(
 
     from clinica.iotools.converters.adni_to_bids.adni_utils import load_clinical_csv
     from clinica.utils.stream import cprint
+    # todo : need both clinical_data_dir and clinical_data_spec ?
+    # todo : diff between what is in ADNI raw and BIDS can do get subjects (? not same naming type)
+    # todo : maybe simplify loops
+    # todo : used in all converters ? (only OASIS and ADNI, what happens if used elsewhere?)
 
     fields_bids = ["participant_id"]
     prev_location = ""
@@ -83,14 +87,17 @@ def create_participants_df(
     study_name = StudyName(study_name)
     location_name = f"{study_name.value} location"
 
-    # Load the data from the clincal specification file
+    # Load the data from the clinical specification file
     participants_specs = pd.read_csv(clinical_spec_path + "_participant.tsv", sep="\t")
     participant_fields_db = participants_specs[study_name.value]
     field_location = participants_specs[location_name]
     participant_fields_bids = participants_specs["BIDS CLINICA"]
 
+    breakpoint()
+
     # Extract the list of the available BIDS fields for the dataset
     for i in range(0, len(participant_fields_db)):
+        breakpoint()
         if not pd.isnull(participant_fields_db[i]):
             fields_bids.append(participant_fields_bids[i])
 
@@ -98,6 +105,7 @@ def create_participants_df(
     participant_df = pd.DataFrame(columns=fields_bids)
 
     for i in range(0, len(participant_fields_db)):
+        breakpoint()
         # If a field not empty is found
         if not pd.isnull(participant_fields_db[i]):
             # Extract the file location of the field and read the value from the file

--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -73,15 +73,15 @@ def create_participants_df(
 
     from clinica.iotools.converters.adni_to_bids.adni_utils import load_clinical_csv
     from clinica.utils.stream import cprint
-    # todo : diff between what is in ADNI raw and BIDS can do get subjects (? not same naming type)
     # todo : used in all converters ? (only OASIS and ADNI, what happens if used elsewhere?)
+    # todo : indicate if a subject initially asked for was not found in BIDS ?
     # todo : typing, test
 
     study_name = StudyName(study_name)
     location_name = f"{study_name.value} location"
 
     # Load the data from the clinical specification file
-    # todo : maybe better to use a handler OASIS/ADNI/AIBL for clinical_spec_path... and other parts ?
+    # todo : maybe better to use a handler OASIS/ADNI/AIBL for clinical_spec_path... and other parts ; see later
     participants_specs = pd.read_csv(clinical_spec_path + "_participant.tsv", sep="\t")
     clinical_spec_df = participants_specs[
         [study_name.value, location_name, "BIDS CLINICA"]
@@ -178,9 +178,6 @@ def create_participants_df(
     participants_df["participant_id"] = participants_df["alternative_id_1"].apply(
         lambda x: replace_id(x)
     )
-
-    # todo : indicate if a subject initially asked for was not found in BIDS ?
-    # todo : !! might be possible that some do not have the data also (different case from above, might be intersected)
 
     # Delete all the rows of the subjects that are not available in the BIDS dataset
     if delete_non_bids_info:


### PR DESCRIPTION
Small refactor of `create_participants_df` of `bids_utils` : 

Previously : 
- Compared BIDS to clinical data
- Adapted to OASIS and ADNI only
- Using dataframes but not the corresponding existing methods

Planned :
- If possible adapt it to all datasets, at least check on dataset if should not be used for it ; ex AIBL has redundant function
- Simplify code loops
- Tests if needed

Maybe in another function : 
- Compare BIDS result to initial raw dataset, available for all types of datasets (same as cleaning sessions/subjects)