### PR TITLE
[CI] Fix deploy step in documentation pipeline

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -46,5 +46,5 @@ jobs:
           echo $BRANCH_NAME
           mv site "${BRANCH_NAME}"
           ls "${BRANCH_NAME}"
-          scp -r "${BRANCH_NAME}" "aramislab:/srv/local/clinica/docs/public/${BRANCH_NAME}"
+          scp -r "${BRANCH_NAME}" aramislab:/srv/local/clinica/docs/public/
 


### PR DESCRIPTION
Fix bug (discovered in #1199) in the deploy step of the documentation pipeline.
The folder containing the documentation artifact was deployed within the already deployed documentation instead of replacing it...