### PR TITLE
[TEST] Update test for habs-to-bids converter

### DIFF
--- a/test/nonregression/iotools/test_run_converters.py
+++ b/test/nonregression/iotools/test_run_converters.py
@@ -117,10 +117,10 @@ def test_run_habs_to_bids(cmdopt, tmp_path):
     output_dir = tmp_path / "bids"
 
     runner = CliRunner()
-    result = runner.invoke(cli, [str(input_dir), str(output_dir)])
+    result = runner.invoke(cli, [str(input_dir / "unorganized"), str(output_dir)])
 
     assert result.exit_code == 0
-    compare_folders(output_dir, ref_dir, output_dir)
+    compare_folders(output_dir, ref_dir / "bids", output_dir)
 
 
 def test_run_ukb_to_bids(cmdopt, tmp_path):


### PR DESCRIPTION
PR #1140 requires that testing data for converters have standardized input and output structures.

The `habs-to-bids` converter test uses data breaking this "standard" in two ways:

- The input data files are not in a folder named "unorganized"
- The output data files are not in a folder named "bids"

The data PR https://github.com/aramis-lab/clinica_data_ci/pull/64 restructures the test data and this PR updates the test to use the correct folders.