### PR TITLE
[TEST] Update test for aibl-to-bids converter

### DIFF
--- a/test/nonregression/iotools/test_run_converters.py
+++ b/test/nonregression/iotools/test_run_converters.py
@@ -99,8 +99,8 @@ def test_run_aibl_to_bids(cmdopt, tmp_path):
     base_dir = Path(cmdopt["input"])
     input_dir, tmp_dir, ref_dir = configure_paths(base_dir, tmp_path, "Aibl2Bids")
     output_dir = tmp_path / "bids"
-    clinical_data_directory = input_dir / "Data_extract_3.2.5"
-    dataset_directory = input_dir / "unorganized_data"
+    clinical_data_directory = input_dir / "clinical_data"
+    dataset_directory = input_dir / "unorganized"
 
     convert(dataset_directory, clinical_data_directory, output_dir)
 


### PR DESCRIPTION
PR #1140 requires that testing data for converters have standardized input and output structures.

The aibl-to-bids converter test uses data breaking this "standard" in two ways:

- The input clinical data files are not in a folder named "clinical_data" but in "Data_extract_3.2.5"
- The input data files are not in a folder named "unorganized" but in "unorganized_data"

The data PR  https://github.com/aramis-lab/clinica_data_ci/pull/66 restructures the test data and this PR updates the test to use the correct folders.

Related: PR #1202 