### PR TITLE
[TEST] Update test for nifd-to-bids converter

### DIFF
--- a/test/nonregression/iotools/test_run_converters.py
+++ b/test/nonregression/iotools/test_run_converters.py
@@ -19,7 +19,7 @@ def test_run_nifd_to_bids(cmdopt, tmp_path):
         bids_dir=output_dir,
     )
 
-    compare_folders(output_dir, ref_dir, output_dir)
+    compare_folders(output_dir, ref_dir / "bids", output_dir)
 
 
 def test_run_oasis_to_bids(cmdopt, tmp_path):


### PR DESCRIPTION
PR #1140 requires that testing data for converters have standardized input and output structures.

The nifd-to-bids converter test uses data breaking this "standard" because the output reference files are not within a folder named "bids".

The data PR https://github.com/aramis-lab/clinica_data_ci/pull/67 restructures the test data and this PR updates the test to use the correct folders.

Related: PR #1202 and #1203