### PR TITLE
[MAINT] Missing unit tests for bids_utils

### DIFF
--- a/clinica/iotools/bids_utils.py
+++ b/clinica/iotools/bids_utils.py
@@ -50,7 +50,6 @@ BIDS_VALIDATOR_CONFIG = {
 
 
 # -- Methods for the clinical data --
-# @ToDo:test this function
 def create_participants_df(
     study_name: StudyName,
     clinical_specifications_folder: Path,

--- a/test/unittests/iotools/test_bids_utils.py
+++ b/test/unittests/iotools/test_bids_utils.py
@@ -82,13 +82,23 @@ def create_clinical_data(tmp_path: Path, clinical_path: Path):
     clinical_path.mkdir()
     df_adnimerge = pd.DataFrame(
         {
-            "PTID": ["001_S_0001", "001_S_0002", "001_S_0003", "001_S_0004"],
-            "PTGENDER": ["Male", "Female", "Male", "Female"],
-            "AGE": ["40", "50", "60", "70"],
+            "PTID": [
+                "001_S_0001",
+                "001_S_0002",
+                "001_S_0003",
+                "001_S_0004",
+                "001_S_0005",
+                "001_S_0006",
+            ],
+            "PTGENDER": ["Male", "Female", "Male", "Female", "Female", None],
+            "AGE": ["40", "50", "60", "70", "80", None],
         }
     )
     df_apoeres = pd.DataFrame(
-        {"APGEN1": ["3", "3", "3", "3"], "GEN2": ["2", "2", "2", "2"]}
+        {
+            "APGEN1": ["3", "3", "3", "3", None, "3"],
+            "GEN2": ["2", "2", "2", "2", None, "2"],
+        }
     )
 
     df_oasis = pd.DataFrame(
@@ -142,7 +152,7 @@ def create_clinical_data(tmp_path: Path, clinical_path: Path):
                 }
             ),
         ),
-        (
+        (  # todo : introducing None or np.nan in data changes the format for scalar values
             StudyName.ADNI,
             ["001S0001"],
             pd.DataFrame(
@@ -150,18 +160,42 @@ def create_clinical_data(tmp_path: Path, clinical_path: Path):
                     "participant_id": ["001S0001"],
                     "alternative_id_1": ["001_S_0001"],
                     "sex": ["Male"],
-                    "apoegen1": [3],
+                    "apoegen1": [3.0],
                 }
             ),
         ),
         (
             StudyName.OASIS,
-            ["0002", "0004", "0006"],
+            ["0002", "0004", "0007"],
             pd.DataFrame(
                 {
                     "participant_id": ["0002", "0004"],
                     "alternative_id_1": ["OAS1_0002_MRI1", "OAS1_0004_MRI1"],
                     "sex": ["M", "M"],
+                }
+            ),
+        ),
+        (
+            StudyName.ADNI,
+            ["001S0005"],
+            pd.DataFrame(
+                {
+                    "participant_id": ["001S0005"],
+                    "alternative_id_1": ["001_S_0005"],
+                    "sex": ["Female"],
+                    "apoegen1": ["n/a"],
+                }
+            ),
+        ),
+        (
+            StudyName.ADNI,
+            ["001S0006"],
+            pd.DataFrame(
+                {
+                    "participant_id": ["001S0006"],
+                    "alternative_id_1": ["001_S_0006"],
+                    "sex": ["n/a"],
+                    "apoegen1": [3.0],
                 }
             ),
         ),
@@ -171,6 +205,7 @@ def test_create_participants_df(tmp_path, bids_ids, expected, study_name):
     from clinica.iotools.bids_utils import create_participants_df
 
     create_clinical_data(tmp_path, tmp_path / "clinical_data")
+    breakpoint()
     assert (
         create_participants_df(
             study_name,

--- a/test/unittests/iotools/test_bids_utils.py
+++ b/test/unittests/iotools/test_bids_utils.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from string import Template
-from typing import List, Union
+from typing import Union
 
 import numpy as np
 import pandas as pd

--- a/test/unittests/iotools/test_bids_utils.py
+++ b/test/unittests/iotools/test_bids_utils.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 from string import Template
-from typing import Union
+from typing import List, Union
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from clinica.iotools.bids_utils import (
@@ -37,6 +39,90 @@ EXPECTED_README_CONTENT = Template(
         "Find more about it and about the data user agreement: link"
     )
 )
+
+
+def create_clinical_data(tmp_path: Path):
+    spec_df = pd.DataFrame()
+    spec_df["BIDS Clinica"] = [
+        "participant_id",
+        "alternative_id_1",
+        "date_of_birth",
+        "sex",
+        "apoegen1",
+    ]
+    spec_df["ADNI"] = [np.nan, "PTID", np.nan, "PTGENDER", "APGEN1"]
+    spec_df["ADNI location"] = [
+        np.nan,
+        "ADNIMERGE.csv",
+        np.nan,
+        "ADNIMERGE.csv",
+        "APOERES.csv",
+    ]
+    spec_df["AIBL"] = [np.nan, "RID", np.nan, "PTDOB", "PTGENDER", "APGEN1"]
+    spec_df["AIBL location"] = [
+        np.nan,
+        "aibl_ptdemog_*.csv",
+        np.nan,
+        "aibl_ptdemog_*.csv",
+        "aibl_ptdemog_*.csv",
+        "aibl_apoeres_*.csv",
+    ]
+    spec_df["OASIS"] = [np.nan, "ID", np.nan, np.nan, "M/F", np.nan]
+    spec_df["OASIS location"] = [
+        np.nan,
+        "oasis_cross-sectional.csv",
+        np.nan,
+        np.nan,
+        "oasis_cross-sectional.csv",
+        np.nan,
+    ]
+    spec_df["OASIS3"] = [np.nan, "Subject", np.nan, np.nan, "M/F", np.nan]
+    spec_df["OASIS3 location"] = [
+        np.nan,
+        "oasis3_participants.csv",
+        np.nan,
+        np.nan,
+        "oasis3_participants.csv",
+        np.nan,
+    ]
+    spec_df.to_csv(tmp_path / "spec_participant.tsv", sep="\t")
+
+    (tmp_path / "clinical_data").mkdir()
+
+    # todo : ADNI : ADNIMERGE.csv ; APOERES.csv // AIBL aibl_ptdemog_*.csv ; aibl_apoeres_*.csv // OASIS oasis_cross-sectional.csv // OASIS3 oasis3_participants.csv
+
+    # todo : create clinical_data_dir with right files in it (for each type of study)
+    # todo : fill the files
+    pass
+
+
+@pytest.fixture
+def expected(bids_ids: List[str]):
+    # todo : write expected dataframe depending on given bids_ids
+    pass
+
+
+@pytest.mark.parametrize("study_name, bids_ids", [])
+def test_create_participants_df(tmp_path, bids_ids, expected):
+    from clinica.iotools.bids_utils import create_participants_df
+
+    # todo
+    create_clinical_data(tmp_path)
+    pass
+
+
+def test_create_sessions_dict_OASIS():
+    # todo
+    from clinica.iotools.bids_utils import create_sessions_dict_OASIS
+
+    pass
+
+
+def test_create_scans_dict():
+    # todo
+    from clinica.iotools.bids_utils import create_scans_dict
+
+    pass
 
 
 def test_get_bids_subjs_list(tmp_path):

--- a/test/unittests/iotools/test_bids_utils.py
+++ b/test/unittests/iotools/test_bids_utils.py
@@ -41,81 +41,146 @@ EXPECTED_README_CONTENT = Template(
 )
 
 
-def create_clinical_data(tmp_path: Path):
-    spec_df = pd.DataFrame()
-    spec_df["BIDS Clinica"] = [
-        "participant_id",
-        "alternative_id_1",
-        "date_of_birth",
-        "sex",
-        "apoegen1",
-    ]
-    spec_df["ADNI"] = [np.nan, "PTID", np.nan, "PTGENDER", "APGEN1"]
-    spec_df["ADNI location"] = [
-        np.nan,
-        "ADNIMERGE.csv",
-        np.nan,
-        "ADNIMERGE.csv",
-        "APOERES.csv",
-    ]
-    spec_df["AIBL"] = [np.nan, "RID", np.nan, "PTDOB", "PTGENDER", "APGEN1"]
-    spec_df["AIBL location"] = [
-        np.nan,
-        "aibl_ptdemog_*.csv",
-        np.nan,
-        "aibl_ptdemog_*.csv",
-        "aibl_ptdemog_*.csv",
-        "aibl_apoeres_*.csv",
-    ]
-    spec_df["OASIS"] = [np.nan, "ID", np.nan, np.nan, "M/F", np.nan]
-    spec_df["OASIS location"] = [
-        np.nan,
-        "oasis_cross-sectional.csv",
-        np.nan,
-        np.nan,
-        "oasis_cross-sectional.csv",
-        np.nan,
-    ]
-    spec_df["OASIS3"] = [np.nan, "Subject", np.nan, np.nan, "M/F", np.nan]
-    spec_df["OASIS3 location"] = [
-        np.nan,
-        "oasis3_participants.csv",
-        np.nan,
-        np.nan,
-        "oasis3_participants.csv",
-        np.nan,
-    ]
-    spec_df.to_csv(tmp_path / "spec_participant.tsv", sep="\t")
+def create_clinical_data(tmp_path: Path, clinical_path: Path):
+    spec_df = pd.DataFrame(
+        {
+            "BIDS CLINICA": [
+                "participant_id",
+                "alternative_id_1",
+                "date_of_birth",
+                "sex",
+                "apoegen1",
+            ],
+            "ADNI": [np.nan, "PTID", np.nan, "PTGENDER", "APGEN1"],
+            "ADNI location": [
+                np.nan,
+                "ADNIMERGE.csv",
+                np.nan,
+                "ADNIMERGE.csv",
+                "APOERES.csv",
+            ],
+            "OASIS": [np.nan, "ID", np.nan, "M/F", np.nan],
+            "OASIS location": [
+                np.nan,
+                "oasis_cross-sectional.csv",
+                np.nan,
+                "oasis_cross-sectional.csv",
+                np.nan,
+            ],
+            "OASIS3": [np.nan, "Subject", np.nan, "M/F", np.nan],
+            "OASIS3 location": [
+                np.nan,
+                "oasis3_participants.csv",
+                np.nan,
+                "oasis3_participants.csv",
+                np.nan,
+            ],
+        }
+    )
+    spec_df.to_csv(tmp_path / "participant.tsv", sep="\t", index=False)
 
-    (tmp_path / "clinical_data").mkdir()
+    clinical_path.mkdir()
+    df_adnimerge = pd.DataFrame(
+        {
+            "PTID": ["001_S_0001", "001_S_0002", "001_S_0003", "001_S_0004"],
+            "PTGENDER": ["Male", "Female", "Male", "Female"],
+            "AGE": ["40", "50", "60", "70"],
+        }
+    )
+    df_apoeres = pd.DataFrame(
+        {"APGEN1": ["3", "3", "3", "3"], "GEN2": ["2", "2", "2", "2"]}
+    )
 
-    # todo : ADNI : ADNIMERGE.csv ; APOERES.csv // AIBL aibl_ptdemog_*.csv ; aibl_apoeres_*.csv // OASIS oasis_cross-sectional.csv // OASIS3 oasis3_participants.csv
+    df_oasis = pd.DataFrame(
+        {
+            "ID": [
+                "OAS1_0001_MRI1",
+                "OAS1_0002_MRI1",
+                "OAS1_0003_MRI1",
+                "OAS1_0004_MRI1",
+            ],
+            "M/F": ["F", "M", "F", "M"],
+            "Age": ["45", "50", "55", "60"],
+        }
+    )
+    df_oasis3 = pd.DataFrame(
+        {
+            "Subject": ["OAS30001", "OAS30002", "OAS30003", "OAS30004"],
+            "M/F": ["F", "F", "M", "M"],
+            "Age": ["45", "55", "65", "75"],
+        }
+    )
 
-    # todo : create clinical_data_dir with right files in it (for each type of study)
-    # todo : fill the files
-    pass
+    df_adnimerge.to_csv(clinical_path / "ADNIMERGE.csv", index=False)
+    df_apoeres.to_csv(clinical_path / "APOERES.csv", index=False)
+    df_oasis.to_csv(clinical_path / "oasis_cross-sectional.csv", index=False)
+    df_oasis3.to_csv(clinical_path / "oasis3_participants.csv", index=False)
 
 
-@pytest.fixture
-def expected(bids_ids: List[str]):
-    # todo : write expected dataframe depending on given bids_ids
-    pass
-
-
-@pytest.mark.parametrize("study_name, bids_ids", [])
-def test_create_participants_df(tmp_path, bids_ids, expected):
+@pytest.mark.parametrize(
+    "study_name, bids_ids, expected",
+    [
+        (
+            StudyName.OASIS,
+            ["0001"],
+            pd.DataFrame(
+                {
+                    "participant_id": ["0001"],
+                    "alternative_id_1": ["OAS1_0001_MRI1"],
+                    "sex": ["F"],
+                }
+            ),
+        ),
+        (
+            StudyName.OASIS3,
+            ["0001"],
+            pd.DataFrame(
+                {
+                    "participant_id": ["0001"],
+                    "alternative_id_1": ["OAS30001"],
+                    "sex": ["F"],
+                }
+            ),
+        ),
+        (
+            StudyName.ADNI,
+            ["001S0001"],
+            pd.DataFrame(
+                {
+                    "participant_id": ["001S0001"],
+                    "alternative_id_1": ["001_S_0001"],
+                    "sex": ["Male"],
+                    "apoegen1": [3],
+                }
+            ),
+        ),
+        (
+            StudyName.OASIS,
+            ["0002", "0004", "0006"],
+            pd.DataFrame(
+                {
+                    "participant_id": ["0002", "0004"],
+                    "alternative_id_1": ["OAS1_0002_MRI1", "OAS1_0004_MRI1"],
+                    "sex": ["M", "M"],
+                }
+            ),
+        ),
+    ],
+)
+def test_create_participants_df(tmp_path, bids_ids, expected, study_name):
     from clinica.iotools.bids_utils import create_participants_df
 
-    # todo
-    create_clinical_data(tmp_path)
-    pass
-
-
-def test_create_sessions_dict_OASIS():
-    # todo
-    from clinica.iotools.bids_utils import create_sessions_dict_OASIS
-
-    pass
+    create_clinical_data(tmp_path, tmp_path / "clinical_data")
+    assert (
+        create_participants_df(
+            study_name,
+            clinical_specifications_folder=tmp_path,
+            clinical_data_dir=tmp_path / "clinical_data",
+            bids_ids=bids_ids,
+        )
+        .reset_index(drop=True)
+        .equals(expected)
+    )
 
 
 def test_create_scans_dict():

--- a/test/unittests/iotools/test_bids_utils.py
+++ b/test/unittests/iotools/test_bids_utils.py
@@ -183,13 +183,6 @@ def test_create_participants_df(tmp_path, bids_ids, expected, study_name):
     )
 
 
-def test_create_scans_dict():
-    # todo
-    from clinica.iotools.bids_utils import create_scans_dict
-
-    pass
-
-
 def test_get_bids_subjs_list(tmp_path):
     from clinica.iotools.bids_utils import get_bids_subjs_list
 


### PR DESCRIPTION
Create a unit test for the function `create_participants_df` from `bids_utils` to test before refactoring it. Parametrized only with datasets ADNI, OASIS1 and OASIS3 since the function is only used for ADNI and OASIS1.