### PR TITLE
[ENH] Use enumeration for SUVR reference regions

### DIFF
--- a/clinica/pipelines/cli_param/argument.py
+++ b/clinica/pipelines/cli_param/argument.py
@@ -1,7 +1,7 @@
 """Common CLI arguments used by Clinica pipelines."""
 import click
 
-from clinica.utils.pet import LIST_SUVR_REFERENCE_REGIONS, Tracer
+from clinica.utils.pet import SUVRReferenceRegion, Tracer
 
 acq_label = click.argument(
     "acq_label",
@@ -48,5 +48,6 @@ subject_visits_with_covariates_tsv = click.argument(
 )
 
 suvr_reference_region = click.argument(
-    "suvr_reference_region", type=click.Choice(LIST_SUVR_REFERENCE_REGIONS)
+    "suvr_reference_region",
+    type=click.Choice(SUVRReferenceRegion),
 )

--- a/clinica/pipelines/cli_param/option.py
+++ b/clinica/pipelines/cli_param/option.py
@@ -2,7 +2,7 @@
 
 import click
 
-from clinica.utils.pet import LIST_SUVR_REFERENCE_REGIONS, ReconstructionMethod, Tracer
+from clinica.utils.pet import ReconstructionMethod, SUVRReferenceRegion, Tracer
 
 from .option_group import option
 
@@ -118,7 +118,7 @@ subjects_sessions_tsv = option(
 suvr_reference_region = option(
     "-suvr",
     "--suvr_reference_region",
-    type=click.Choice(LIST_SUVR_REFERENCE_REGIONS),
+    type=click.Choice(SUVRReferenceRegion),
     help=(
         "Intensity normalization using the average PET uptake in reference regions "
         "resulting in a standardized uptake value ratio (SUVR) map. It can be "

--- a/clinica/pipelines/pet_linear/pet_linear_utils.py
+++ b/clinica/pipelines/pet_linear/pet_linear_utils.py
@@ -1,7 +1,5 @@
 # Functions used by nipype interface.
-import os
-
-from nibabel.nifti1 import Nifti1Image
+from clinica.utils.pet import SUVRReferenceRegion
 
 
 def init_input_node(pet):
@@ -173,7 +171,9 @@ def rename_into_caps(
         _rename_pet_into_caps,
         _rename_transformation_into_caps,
     )
+    from clinica.utils.pet import SUVRReferenceRegion
 
+    suvr_reference_region = SUVRReferenceRegion(suvr_reference_region)
     bids_entities = _get_bids_entities_without_suffix(pet_filename_bids, suffix="pet")
     if output_dir:
         bids_entities = os.path.join(output_dir, bids_entities)
@@ -201,12 +201,10 @@ def _get_bids_entities_without_suffix(filename: str, suffix: str) -> str:
 
 
 def _rename_pet_into_caps(
-    entities: str, filename: str, cropped: bool, suvr_reference_region: str
+    entities: str, filename: str, cropped: bool, region: SUVRReferenceRegion
 ) -> str:
     """Rename into CAPS PET."""
-    return _rename(
-        filename, entities, _get_pet_bids_components(cropped, suvr_reference_region)
-    )
+    return _rename(filename, entities, _get_pet_bids_components(cropped, region))
 
 
 def _rename_transformation_into_caps(entities: str, filename: str) -> str:
@@ -232,14 +230,14 @@ def _rename(filename: str, entities: str, suffix: str):
     return rename.run().outputs.out_file
 
 
-def _get_pet_bids_components(cropped: bool, suvr_reference_region: str) -> str:
+def _get_pet_bids_components(cropped: bool, region: SUVRReferenceRegion) -> str:
     """Return a string composed of the PET-specific entities (space, resolution,
     desc, and suvr), suffix, and extension.
     """
     space = "_space-MNI152NLin2009cSym"
     resolution = "_res-1x1x1"
     desc = "_desc-Crop" if cropped else ""
-    suvr = f"_suvr-{suvr_reference_region}"
+    suvr = f"_suvr-{region.value}"
 
     return f"{space}{desc}{resolution}{suvr}_pet.nii.gz"
 

--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -887,9 +887,9 @@ def get_wf(
     white_surface_left,
     white_surface_right,
     working_directory_subjects,
-    acq_label,
+    acq_label: str,
     csv_segmentation,
-    suvr_reference_region,
+    suvr_reference_region: str,
     matscript_folder_inverse_deformation,
     destrieux_left,
     destrieux_right,
@@ -934,12 +934,19 @@ def get_wf(
 
     import clinica.pipelines.pet_surface.pet_surface_utils as utils
     from clinica.utils.filemanip import get_subject_id, load_volume, unzip_nii
-    from clinica.utils.pet import get_suvr_mask, read_psf_information
+    from clinica.utils.pet import (
+        SUVRReferenceRegion,
+        Tracer,
+        get_suvr_mask,
+        read_psf_information,
+    )
     from clinica.utils.spm import get_tpm, use_spm_standalone_if_available
     from clinica.utils.ux import print_begin_image
 
     using_spm_standalone = use_spm_standalone_if_available()
 
+    suvr_reference_region = SUVRReferenceRegion(suvr_reference_region)
+    acq_label = Tracer(acq_label)
     image_id = get_subject_id(pet)
     try:
         load_volume(pet)
@@ -961,7 +968,7 @@ def get_wf(
     unzip_orig_nu = unzip_pet.clone(name="unzip_orig_nu")
 
     unzip_mask = unzip_pet.clone(name="unzip_mask")
-    unzip_mask.inputs.in_file = get_suvr_mask(suvr_reference_region)
+    unzip_mask.inputs.in_file = str(get_suvr_mask(suvr_reference_region))
 
     coreg = pe.Node(Coregister(), name="coreg")
 
@@ -1057,7 +1064,7 @@ def get_wf(
         ),
         name="pons_normalization",
     )
-    pons_normalization.inputs.pet_tracer = acq_label
+    pons_normalization.inputs.pet_tracer = acq_label.value
 
     # read_psf_information expects a list of subjects/sessions and returns a list of PSF
     psf_info = read_psf_information(pvc_psf_tsv, [subject_id], [session_id], acq_label)[
@@ -1286,36 +1293,36 @@ def get_wf(
         (
             r"(.*(sub-.*)\/(ses-.*)\/pet\/surface)\/projection_native\/.*_hemi_([a-z]+).*",
             r"\1/\2_\3_trc-"
-            + acq_label
+            + acq_label.value
             + r"_pet_space-native_suvr-"
-            + suvr_reference_region
+            + suvr_reference_region.value
             + r"_pvc-iy_hemi-\4_projection.mgh",
         ),
         # Projection in fsaverage
         (
             r"(.*(sub-.*)\/(ses-.*)\/pet\/surface)\/projection_fsaverage\/.*_hemi_([a-z]+).*_fwhm_([0-9]+).*",
             r"\1/\2_\3_trc-"
-            + acq_label
+            + acq_label.value
             + r"_pet_space-fsaverage_suvr-"
-            + suvr_reference_region
+            + suvr_reference_region.value
             + r"_pvc-iy_hemi-\4_fwhm-\5_projection.mgh",
         ),
         # TSV file for Destrieux atlas
         (
             r"(.*(sub-.*)\/(ses-.*)\/pet\/surface)\/destrieux_tsv\/destrieux.tsv",
             r"\1/atlas_statistics/\2_\3_trc-"
-            + acq_label
+            + acq_label.value
             + "_pet_space-destrieux_pvc-iy_suvr-"
-            + suvr_reference_region
+            + suvr_reference_region.value
             + "_statistics.tsv",
         ),
         # TSV file for Desikan atlas
         (
             r"(.*(sub-.*)\/(ses-.*)\/pet\/surface)\/desikan_tsv\/desikan.tsv",
             r"\1/atlas_statistics/\2_\3_trc-"
-            + acq_label
+            + acq_label.value
             + "_pet_space-desikan_pvc-iy_suvr-"
-            + suvr_reference_region
+            + suvr_reference_region.value
             + "_statistics.tsv",
         ),
     ]
@@ -1329,36 +1336,36 @@ def get_wf(
         (
             r"(.*(sub-.*)\/(ses-.*)\/pet\/(long-.*)\/surface_longitudinal)\/projection_native\/.*_hemi_([a-z]+).*",
             r"\1/\2_\3_\4_trc-"
-            + acq_label
+            + acq_label.value
             + r"_pet_space-native_suvr-"
-            + suvr_reference_region
+            + suvr_reference_region.value
             + r"_pvc-iy_hemi-\5_projection.mgh",
         ),
         # Projection in fsaverage
         (
             r"(.*(sub-.*)\/(ses-.*)\/pet\/(long-.*)\/surface_longitudinal)\/projection_fsaverage\/.*_hemi_([a-z]+).*_fwhm_([0-9]+).*",
             r"\1/\2_\3_\4_trc-"
-            + acq_label
+            + acq_label.value
             + r"_pet_space-fsaverage_suvr-"
-            + suvr_reference_region
+            + suvr_reference_region.value
             + r"_pvc-iy_hemi-\5_fwhm-\6_projection.mgh",
         ),
         # TSV file for Destrieux atlas
         (
             r"(.*(sub-.*)\/(ses-.*)\/pet\/(long-.*)\/surface_longitudinal)\/destrieux_tsv\/destrieux.tsv",
             r"\1/atlas_statistics/\2_\3_\4_trc-"
-            + acq_label
+            + acq_label.value
             + "_pet_space-destrieux_pvc-iy_suvr-"
-            + suvr_reference_region
+            + suvr_reference_region.value
             + "_statistics.tsv",
         ),
         # TSV file for Desikan atlas
         (
             r"(.*(sub-.*)\/(ses-.*)\/pet\/(long-.*)\/surface_longitudinal)\/desikan_tsv\/desikan.tsv",
             r"\1/atlas_statistics/\2_\3_\4_trc-"
-            + acq_label
+            + acq_label.value
             + "_pet_space-desikan_pvc-iy_suvr-"
-            + suvr_reference_region
+            + suvr_reference_region.value
             + "_statistics.tsv",
         ),
     ]

--- a/clinica/utils/input_files.py
+++ b/clinica/utils/input_files.py
@@ -629,7 +629,7 @@ def bids_pet_nii(
 def pet_volume_normalized_suvr_pet(
     acq_label: Union[str, Tracer],
     group_label: str,
-    region: Union[str, SUVRReferenceRegion],
+    suvr_reference_region: Union[str, SUVRReferenceRegion],
     use_brainmasked_image: bool,
     use_pvc_data: bool,
     fwhm: int = 0,
@@ -637,7 +637,7 @@ def pet_volume_normalized_suvr_pet(
     from pathlib import Path
 
     acq_label = Tracer(acq_label)
-    region = SUVRReferenceRegion(region)
+    region = SUVRReferenceRegion(suvr_reference_region)
 
     if use_brainmasked_image:
         mask_key_value = "_mask-brain"
@@ -678,13 +678,13 @@ def pet_volume_normalized_suvr_pet(
 
 def pet_linear_nii(
     acq_label: Union[str, Tracer],
-    region: Union[str, SUVRReferenceRegion],
+    suvr_reference_region: Union[str, SUVRReferenceRegion],
     uncropped_image: bool,
 ) -> dict:
     from pathlib import Path
 
     acq_label = Tracer(acq_label)
-    region = SUVRReferenceRegion(region)
+    region = SUVRReferenceRegion(suvr_reference_region)
 
     if uncropped_image:
         description = ""

--- a/clinica/utils/input_files.py
+++ b/clinica/utils/input_files.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable
 from typing import Optional, Union
 
 from clinica.pipelines.dwi.dti.utils import DTIBasedMeasure
-from clinica.utils.pet import ReconstructionMethod, Tracer
+from clinica.utils.pet import ReconstructionMethod, SUVRReferenceRegion, Tracer
 
 # BIDS
 
@@ -577,8 +577,8 @@ def dwi_dti(measure: Union[str, DTIBasedMeasure], space: Optional[str] = None) -
 
 
 def bids_pet_nii(
-    tracer: Optional[Tracer] = None,
-    reconstruction: Optional[ReconstructionMethod] = None,
+    tracer: Optional[Union[str, Tracer]] = None,
+    reconstruction: Optional[Union[str, ReconstructionMethod]] = None,
 ) -> dict:
     """Return the query dict required to capture PET scans.
 
@@ -603,8 +603,14 @@ def bids_pet_nii(
     """
     from pathlib import Path
 
-    trc = "" if tracer is None else f"_trc-{tracer.value}"
-    rec = "" if reconstruction is None else f"_rec-{reconstruction.value}"
+    trc = ""
+    if tracer is not None:
+        tracer = Tracer(tracer)
+        trc = f"_trc-{tracer.value}"
+    rec = ""
+    if reconstruction is not None:
+        reconstruction = ReconstructionMethod(reconstruction)
+        rec = f"_rec-{reconstruction.value}"
     description = f"PET data"
     if tracer:
         description += f" with {tracer.value} tracer"
@@ -621,14 +627,17 @@ def bids_pet_nii(
 
 
 def pet_volume_normalized_suvr_pet(
-    acq_label,
-    group_label,
-    suvr_reference_region,
-    use_brainmasked_image,
-    use_pvc_data,
-    fwhm=0,
-):
+    acq_label: Union[str, Tracer],
+    group_label: str,
+    region: Union[str, SUVRReferenceRegion],
+    use_brainmasked_image: bool,
+    use_pvc_data: bool,
+    fwhm: int = 0,
+) -> dict:
     from pathlib import Path
+
+    acq_label = Tracer(acq_label)
+    region = SUVRReferenceRegion(region)
 
     if use_brainmasked_image:
         mask_key_value = "_mask-brain"
@@ -651,15 +660,15 @@ def pet_volume_normalized_suvr_pet(
         fwhm_key_value = ""
         fwhm_description = "with no smoothing"
 
-    suvr_key_value = f"_suvr-{suvr_reference_region}"
+    suvr_key_value = f"_suvr-{region.value}"
 
     information = {
         "pattern": Path("pet")
         / "preprocessing"
         / f"group-{group_label}"
-        / f"*_trc-{acq_label}_pet_space-Ixi549Space{pvc_key_value}{suvr_key_value}{mask_key_value}{fwhm_key_value}_pet.nii*",
+        / f"*_trc-{acq_label.value}_pet_space-Ixi549Space{pvc_key_value}{suvr_key_value}{mask_key_value}{fwhm_key_value}_pet.nii*",
         "description": (
-            f"{mask_description} SUVR map (using {suvr_reference_region} region) of {acq_label}-PET "
+            f"{mask_description} SUVR map (using {region.value} region) of {acq_label.value}-PET "
             f"{pvc_description} and {fwhm_description} in Ixi549Space space based on {group_label} DARTEL template"
         ),
         "needed_pipeline": "pet-volume",
@@ -667,11 +676,15 @@ def pet_volume_normalized_suvr_pet(
     return information
 
 
-# pet-linear
-
-
-def pet_linear_nii(acq_label, suvr_reference_region, uncropped_image):
+def pet_linear_nii(
+    acq_label: Union[str, Tracer],
+    region: Union[str, SUVRReferenceRegion],
+    uncropped_image: bool,
+) -> dict:
     from pathlib import Path
+
+    acq_label = Tracer(acq_label)
+    region = SUVRReferenceRegion(region)
 
     if uncropped_image:
         description = ""
@@ -680,7 +693,7 @@ def pet_linear_nii(acq_label, suvr_reference_region, uncropped_image):
 
     information = {
         "pattern": Path("pet_linear")
-        / f"*_trc-{acq_label}_pet_space-MNI152NLin2009cSym{description}_res-1x1x1_suvr-{suvr_reference_region}_pet.nii.gz",
+        / f"*_trc-{acq_label.value}_pet_space-MNI152NLin2009cSym{description}_res-1x1x1_suvr-{region.value}_pet.nii.gz",
         "description": "",
         "needed_pipeline": "pet-linear",
     }

--- a/clinica/utils/input_files.py
+++ b/clinica/utils/input_files.py
@@ -603,18 +603,16 @@ def bids_pet_nii(
     """
     from pathlib import Path
 
+    description = f"PET data"
     trc = ""
     if tracer is not None:
         tracer = Tracer(tracer)
         trc = f"_trc-{tracer.value}"
+        description += f" with {tracer.value} tracer"
     rec = ""
     if reconstruction is not None:
         reconstruction = ReconstructionMethod(reconstruction)
         rec = f"_rec-{reconstruction.value}"
-    description = f"PET data"
-    if tracer:
-        description += f" with {tracer.value} tracer"
-    if reconstruction:
         description += f" and reconstruction method {reconstruction.value}"
 
     return {

--- a/clinica/utils/pet.py
+++ b/clinica/utils/pet.py
@@ -59,7 +59,7 @@ def read_psf_information(
     pvc_psf_tsv: os.PathLike,
     subject_ids: ty.List[str],
     session_ids: ty.List[str],
-    pet_tracer: str,
+    pet_tracer: ty.Union[str, Tracer],
 ) -> ty.List[ty.List[int]]:
     """Read PSF information from TSV file.
 
@@ -84,7 +84,7 @@ def read_psf_information(
         .. warning::
             Must have the same length as `subject_ids`.
 
-    pet_tracer : str
+    pet_tracer : str or Tracer
         Tracer we want to select in the 'acq_label' column.
         Other tracers will not be read in this function
 
@@ -112,6 +112,7 @@ def read_psf_information(
         "psf_y",
         "psf_z",
     }
+    pet_tracer = Tracer(pet_tracer)
     psf_df = pd.read_csv(pvc_psf_tsv, sep="\t")
     diff = valid_columns.symmetric_difference(set(psf_df.columns))
     if len(diff) > 0:
@@ -124,17 +125,17 @@ def read_psf_information(
     psf = []
     for sub, ses in zip(subject_ids, session_ids):
         result = psf_df.query(
-            f"participant_id == '{sub}' and session_id == '{ses}' and acq_label == '{pet_tracer}'"
+            f"participant_id == '{sub}' and session_id == '{ses}' and acq_label == '{pet_tracer.value}'"
         )
         if len(result) == 0:
             raise RuntimeError(
-                f"Subject {sub} with session {ses} and tracer {pet_tracer} "
+                f"Subject {sub} with session {ses} and tracer {pet_tracer.value} "
                 f"that you want to proceed was not found in the TSV file containing "
                 f"PSF specifications ({pvc_psf_tsv})."
             )
         if len(result) > 1:
             raise RuntimeError(
-                f"Subject {sub} with session {ses} and tracer {pet_tracer} "
+                f"Subject {sub} with session {ses} and tracer {pet_tracer.value} "
                 f"that you want to proceed was found multiple times "
                 f"in the TSV file containing PSF specifications ({pvc_psf_tsv})."
             )

--- a/clinica/utils/pet.py
+++ b/clinica/utils/pet.py
@@ -2,6 +2,7 @@
 import os
 import typing as ty
 from enum import Enum
+from pathlib import Path
 
 import pandas as pd
 
@@ -20,6 +21,13 @@ class Tracer(str, Enum):
     FBB = "18FFBB"
     FDG = "18FFDG"
     FMM = "18FFMM"
+
+
+class SUVRReferenceRegion(str, Enum):
+    PONS = "pons"
+    CEREBELLUM_PONS = "cerebellumPons"
+    PONS2 = "pons2"
+    CEREBELLUM_PONS2 = "cerebellumPons2"
 
 
 class ReconstructionMethod(str, Enum):
@@ -135,37 +143,34 @@ def read_psf_information(
     return psf
 
 
-LIST_SUVR_REFERENCE_REGIONS = ["pons", "cerebellumPons", "pons2", "cerebellumPons2"]
-
-
-def get_suvr_mask(suvr_reference_region: str) -> os.PathLike:
+def get_suvr_mask(region: ty.Union[str, SUVRReferenceRegion]) -> Path:
     """Returns the path to the SUVR mask from SUVR reference region label.
 
     Parameters
     ----------
-    suvr_reference_region : str
+    region : str or SUVRReferenceRegion
         The label of the SUVR reference region.
         Supported labels are: 'pons', 'cerebellumPons', 'pons2', and 'cerebellumPons2'
 
     Returns
     -------
-    PathLike :
+    Path :
         The path to the SUVR mask.
     """
-    from pathlib import Path
-
     current_dir = Path(os.path.realpath(__file__))
     masks_dir = current_dir.parent.parent / "resources" / "masks"
 
-    suvr_reference_region_labels_to_filenames = {
-        "pons": "region-pons_eroded-6mm_mask.nii.gz",
-        "cerebellumPons": "region-cerebellumPons_eroded-6mm_mask.nii.gz",
-        "pons2": "region-pons_remove-extrabrain_eroded-2it_mask.nii.gz",
-        "cerebellumPons2": "region-cerebellumPons_remove-extrabrain_eroded-3it_mask.nii.gz",
-    }
-    if suvr_reference_region not in suvr_reference_region_labels_to_filenames:
-        raise ValueError(
-            f"SUVR reference region label {suvr_reference_region} is not supported. "
-            f"Supported values are : {list(suvr_reference_region_labels_to_filenames.keys())}."
-        )
-    return masks_dir / suvr_reference_region_labels_to_filenames[suvr_reference_region]
+    return masks_dir / _get_suvr_reference_region_labels_filename(
+        SUVRReferenceRegion(region)
+    )
+
+
+def _get_suvr_reference_region_labels_filename(region: SUVRReferenceRegion) -> str:
+    if region == SUVRReferenceRegion.PONS:
+        return "region-pons_eroded-6mm_mask.nii.gz"
+    if region == SUVRReferenceRegion.CEREBELLUM_PONS:
+        return "region-cerebellumPons_eroded-6mm_mask.nii.gz"
+    if region == SUVRReferenceRegion.PONS2:
+        return "region-pons_remove-extrabrain_eroded-2it_mask.nii.gz"
+    if region == SUVRReferenceRegion.CEREBELLUM_PONS2:
+        return "region-cerebellumPons_remove-extrabrain_eroded-3it_mask.nii.gz"

--- a/docs/Pipelines/PET_Introduction.md
+++ b/docs/Pipelines/PET_Introduction.md
@@ -37,11 +37,11 @@ bids
 
 ## Reference regions used for intensity normalization
 
-In neurology, an approach widely used to allow inter- and intra-subject comparison of [PET](../glossary.md#pet) images is to compute standardized uptake value ratio (SUVR) maps.
+In neurology, an approach widely used to allow inter- and intra-subject comparison of [PET](../glossary.md#pet) images is to compute standardized uptake value ratio ([SUVR](../glossary.md#suvr)) maps.
 The images are intensity normalized by dividing each [voxel](../glossary.md#voxel) of the image by the average uptake in a reference region.
 This region is chosen according to the tracer and disease studied as it must be unaffected by the disease.
 
-Clinica `v0.3.8` introduces the possibility for the user to select the reference region for the SUVR map computation.
+Clinica `v0.3.8` introduces the possibility for the user to select the reference region for the [SUVR](../glossary.md#suvr) map computation.
 
 Reference regions provided by Clinica come from the [Pick atlas](https://www.nitrc.org/projects/wfu_pickatlas) in MNI space and currently are:
 
@@ -61,66 +61,33 @@ It is possible to run the [`pet-surface`](../PET_Surface) and [`pet-volume`](../
 
 - Install Clinica following the [developer instructions](../../Installation/#install-clinica) ;
 
-- In the `<clinica>/clinica/utils/pet.py` file, modify the following two elements:
-    - The label of the SUVR reference region that will be stored in CAPS filename(s):
+- In the `<clinica>/clinica/utils/pet.py` file:
+    - **Step 1:** Define the label of the [SUVR](../glossary.md#suvr) reference region that will be stored in CAPS filename(s).
+      To do so, you need to add a variant to the `SUVRReferenceRegion` enumeration, which should look like this:
 
     ```python
-    LIST_SUVR_REFERENCE_REGIONS = [
-        "pons",
-        "cerebellumPons",
-        "pons2",
-        "cerebellumPons2"
-    ]
+    class SUVRReferenceRegion(str, Enum):
+        PONS = "pons"
+        CEREBELLUM_PONS = "cerebellumPons"
+        PONS2 = "pons2"
+        CEREBELLUM_PONS2 = "cerebellumPons2"
     ```
 
-    Simply define a new label that will be your new SUVR reference region.
-    `LIST_SUVR_REFERENCE_REGIONS` is used by all command-line interfaces, so you do not need to modify the pipelines' CLI to make this new region appear.
+    Simply define a new label that will be your new [SUVR](../glossary.md#suvr) reference region.
+    The `SUVRReferenceRegion` enumeration is used by all command-line interfaces, so you do not need to modify the pipelines' CLI to make this new region appear.
 
-    - The path of the SUVR reference region that you will use:
+    - **Step 2:** Define the path of the [SUVR](../glossary.md#suvr) reference region that you will use.
+      The function responsible to get the [SUVR](../glossary.md#suvr) mask is called `get_suvr_mask`, and it looks by default in the folder `<clinica>/resources/masks/`.
+      You can put your mask in this folder and edit the following function (add an if statement to handle the enumeration variant you added in step 1): 
 
     ```python
-    def get_suvr_mask(suvr_reference_region):
-        """Get path of the SUVR mask from SUVR reference region label.
-
-        Args:
-            suvr_reference_region: Label of the SUVR reference region
-
-        Returns:
-            Path of the SUVR mask
-        """
-        import os
-
-        suvr_reference_region_to_suvr = {
-            "pons": os.path.join(
-                os.path.split(os.path.realpath(__file__))[0],
-                "..",
-                "resources",
-                "masks",
-                "region-pons_eroded-6mm_mask.nii.gz",
-            ),
-            "cerebellumPons": os.path.join(
-                os.path.split(os.path.realpath(__file__))[0],
-                "..",
-                "resources",
-                "masks",
-                "region-cerebellumPons_eroded-6mm_mask.nii.gz",
-            ),
-            "pons2": os.path.join(
-                os.path.split(os.path.realpath(__file__))[0],
-                "..",
-                "resources",
-                "masks",
-                "region-pons_remove-extrabrain_eroded-2it_mask.nii.gz",
-            ),
-            "cerebellumPons2": os.path.join(
-                os.path.split(os.path.realpath(__file__))[0],
-                "..",
-                "resources",
-                "masks",
-                "region-cerebellumPons_remove-extrabrain_eroded-3it_mask.nii.gz",
-            ),
-        }
-        return suvr_reference_region_to_suvr[suvr_reference_region]
+    def _get_suvr_reference_region_labels_filename(region: SUVRReferenceRegion) -> str:
+        if region == SUVRReferenceRegion.PONS:
+            return "region-pons_eroded-6mm_mask.nii.gz"
+        if region == SUVRReferenceRegion.CEREBELLUM_PONS:
+            return "region-cerebellumPons_eroded-6mm_mask.nii.gz"
+        if region == SUVRReferenceRegion.PONS2:
+            return "region-pons_remove-extrabrain_eroded-2it_mask.nii.gz"
+        if region == SUVRReferenceRegion.CEREBELLUM_PONS2:
+            return "region-cerebellumPons_remove-extrabrain_eroded-3it_mask.nii.gz"
     ```
-
-    In this example, the SUVR reference region associated with the `cerebellumPons` label is located at `<clinica>/resources/masks/region-cerebellumPons_eroded-6mm_mask.nii.gz`.

--- a/docs/Pipelines/PET_Linear.md
+++ b/docs/Pipelines/PET_Linear.md
@@ -11,7 +11,7 @@ SyN algorithm [[Avants et al., 2008](https://doi.org/10.1016/j.media.2007.06.004
 from the [ANTs](http://stnava.github.io/ANTs/) software package
 [[Avants et al., 2014](https://doi.org/10.3389/fninf.2014.00044)];
 - intensity normalization using the average [PET](../glossary.md#pet) uptake in reference regions
-resulting in a standardized uptake value ratio (SUVR) map;
+resulting in a standardized uptake value ratio ([SUVR](../glossary.md#suvr)) map;
 - cropping of the registered images to remove the background.
 
 !!! note "Clinica & BIDS specifications for PET modality"
@@ -46,7 +46,7 @@ used (`trc-<acq_label>`). It can be for instance '18FFDG' for
 <sup>18</sup>F-fluorodeoxyglucose or '18FAV45' for <sup>18</sup>F-florbetapir;
 - The reference region is used to perform intensity normalization (i.e.
   dividing each voxel of the image by the average uptake in this region)
-  resulting in a standardized uptake value ratio (SUVR) map. It can be
+  resulting in a standardized uptake value ratio ([SUVR](../glossary.md#suvr)) map. It can be
   `cerebellumPons` or `cerebellumPons2` (used for amyloid tracers) and `pons`
   or `pons2` (used for FDG). See [PET introduction](./PET_Introduction.md) for
   more details about masks versions.
@@ -70,9 +70,9 @@ Results are stored in the following folder of the [CAPS hierarchy](../../CAPS/Sp
 
 The main output files are:
 
-- `<source_file>_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-<label>_pet.nii.gz`: [PET](../glossary.md#pet) SUVR image registered to the [`MNI152NLin2009cSym` template](https://bids-specification.readthedocs.io/en/stable/99-appendices/08-coordinate-systems.html) and cropped.
+- `<source_file>_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-<label>_pet.nii.gz`: [PET](../glossary.md#pet) [SUVR](../glossary.md#suvr) image registered to the [`MNI152NLin2009cSym` template](https://bids-specification.readthedocs.io/en/stable/99-appendices/08-coordinate-systems.html) and cropped.
 - `<source_file>_space-T1w_rigid.mat`: rigid transformation between the [PET](../glossary.md#pet) and T1w images estimated with [ANTs](https://stnava.github.io/ANTs/).
-- (optional) `<source_file>_space-MNI152NLin2009cSym_res-1x1x1_pet.nii.gz`: [PET](../glossary.md#pet) SUVR image affinely registered to the [`MNI152NLin2009cSym` template](https://bids-specification.readthedocs.io/en/stable/99-appendices/08-coordinate-systems.html) (i.e. not cropped).
+- (optional) `<source_file>_space-MNI152NLin2009cSym_res-1x1x1_pet.nii.gz`: [PET](../glossary.md#pet) [SUVR](../glossary.md#suvr) image affinely registered to the [`MNI152NLin2009cSym` template](https://bids-specification.readthedocs.io/en/stable/99-appendices/08-coordinate-systems.html) (i.e. not cropped).
 - (optional) `<source_file>_space-T1w_pet.nii.gz`: [PET](../glossary.md#pet) image affinely registered to the associated T1w image.
 
 ## Going further
@@ -95,8 +95,8 @@ You can now use the [ClinicaDL framework](https://clinicadl.readthedocs.io/) pre
     [2009](https://doi.org/10.1016/S1053-8119(09)70884-5)].
     The PET image is further intensity normalized using the average PET uptake
     in a reference region ([pons | pons + cerebellum]), resulting in a
-    standardized uptake value ratio (SUVR) map.
-    The PET SUVR image in MNI space is finally cropped to remove the background,
+    standardized uptake value ratio ([SUVR](../glossary.md#suvr)) map.
+    The [PET](../glossary.md#pet) [SUVR](../glossary.md#suvr) image in MNI space is finally cropped to remove the background,
     resulting in images of size 169×208×179 with 1 mm isotropic voxels.
 
 !!! tip

--- a/docs/Pipelines/PET_Volume.md
+++ b/docs/Pipelines/PET_Volume.md
@@ -1,12 +1,12 @@
 <!-- markdownlint-disable MD046 -->
 # `pet-volume` – Volume-based processing of PET images
 
-This pipeline performs several processing steps on PET data in voxel space, which include:
+This pipeline performs several processing steps on [PET](../glossary.md#pet) data in voxel space, which include:
 
 - intra-subject registration of the PET image into the space of the subject’s T1-weighted MR image using [SPM](http://www.fil.ion.ucl.ac.uk/spm/);
-- (optional) partial volume correction (PVC) using the [PETPVC toolbox](https://github.com/UCL/PETPVC) [[Thomas et al., 2016](https://doi.org/10.1088/0031-9155/61/22/7975)];
+- (optional) partial volume correction ([PVC](../glossary.md#pvc)) using the [PETPVC toolbox](https://github.com/UCL/PETPVC) [[Thomas et al., 2016](https://doi.org/10.1088/0031-9155/61/22/7975)];
 - inter-subject spatial normalization of the PET image into MNI space based on the DARTEL deformation model of SPM [[Ashburner, 2007](http://dx.doi.org/10.1016/j.neuroimage.2007.07.007)];
-- intensity normalization using the average PET uptake in reference regions resulting in a standardized uptake value ratio (SUVR) map;
+- intensity normalization using the average PET uptake in reference regions resulting in a standardized uptake value ratio ([SUVR](../glossary.md#suvr)) map;
 - parcellation into anatomical regions based on an atlas and computation of average values within each region.
 The list of available atlases can be found [here](../../Atlases).
 
@@ -39,18 +39,18 @@ where:
 - `CAPS_DIRECTORY` acts both as an input folder (where the results of the `t1-volume-*` pipeline are stored) and as the output folder containing the results in a [CAPS](../../CAPS/Introduction) hierarchy.
 - `GROUP_LABEL` is the label of the group that is associated to the DARTEL template that you had created when running the [`t1-volume`](../T1_Volume) pipeline.
 - `ACQ_LABEL` is the label given to the PET acquisition, specifying the tracer used (`trc-<acq_label>`).
-- The reference region is used to perform intensity normalization (i.e. dividing each voxel of the image by the average uptake in this region) resulting in a standardized uptake value ratio (SUVR) map.
+- The reference region is used to perform intensity normalization (i.e. dividing each voxel of the image by the average uptake in this region) resulting in a standardized uptake value ratio ([SUVR](../glossary.md#suvr)) map.
 It can be `cerebellumPons` or `cerebellumPons2` (used for amyloid tracers) or `pons` or `pons2` (used for FDG).
 
 Pipeline options:
 
 - `--pvc_psf_tsv`: TSV file containing the `psf_x`, `psf_y` and `psf_z` of the PSF for each PET image.
 More explanation is given in [PET Introduction](../PET_Introduction) page.
-- `--smooth`: a list of integers specifying the different isotropic full width at half maximum (FWHM) in millimeters to smooth the image. Default value is: 0, 8 (both without smoothing and with an isotropic smoothing of 8 mm)
+- `--smooth`: a list of integers specifying the different isotropic full width at half maximum ([FWHM](../glossary.md#fwhm)) in millimeters to smooth the image. Default value is: 0, 8 (both without smoothing and with an isotropic smoothing of 8 mm)
 
 !!! info
     Since the release of Clinica v0.3.8, the handling of PSF information in the TSV file has changed: `fwhm_x`, `fwhm_y`, `fwhm_z` columns have been replaced by `psf_x`, `psf_y`, `psf_z` and the `acq_label` column has been added.
-    Additionally, the SUVR reference region is now a compulsory argument: it will be easier for you to modify Clinica if you want to add a custom reference region ([PET Introduction](../PET_Introduction) page).
+    Additionally, the [SUVR](../glossary.md#suvr) reference region is now a compulsory argument: it will be easier for you to modify Clinica if you want to add a custom reference region ([PET Introduction](../PET_Introduction) page).
     Choose `cerebellumPons` for amyloid tracers or `pons` for FDG to have the previous behavior.
 
 !!! note
@@ -69,18 +69,18 @@ The main output files are:
 
 - `<source_file>_space-T1w[_pvc-rbv]_pet.nii.gz`: PET image registered into the T1-weighted MRI native space.
 
-- `<source_file>_space-Ixi549Space[_pvc-rbv]_suvr-<label>_mask-brain[_fwhm-<X>mm]_pet.nii.gz`: standard uptake value ratio (SUVR) PET image in MNI space, masked to keep only the brain, and optionally smoothed.
+- `<source_file>_space-Ixi549Space[_pvc-rbv]_suvr-<label>_mask-brain[_fwhm-<X>mm]_pet.nii.gz`: standard uptake value ratio ([SUVR](../glossary.md#suvr)) [PET](../glossary.md#pet) image in MNI space, masked to keep only the brain, and optionally smoothed.
 
-- `atlas_statistics/<source_file>_space-<space>[_pvc-rbv]_suvr-<label>_statistics.tsv`: TSV files summarizing the regional statistics on the labelled atlas `<space>`.
+- `atlas_statistics/<source_file>_space-<space>[_pvc-rbv]_suvr-<label>_statistics.tsv`: [TSV](../glossary.md#tsv) files summarizing the regional statistics on the labelled atlas `<space>`.
 
 !!! note
-    The `[_pvc-rbv]` label indicates whether the PET image has undergone partial value correction (region-based voxel-wise method) or not.
+    The `[_pvc-rbv]` label indicates whether the [PET](../glossary.md#pet) image has undergone partial value correction (region-based voxel-wise method) or not.
 
     The full list of output files from the pet-volume pipeline can be found in the [The ClinicA Processed Structure (CAPS) specifications](../../CAPS/Specifications/#pet-volume-volume-based-processing-of-pet-images).
 
 ## Going further
 
-- You can use standardized uptake value ratio (SUVR) maps to perform group comparison with the [`statistics-volume` pipeline](../Stats_Volume).
+- You can use standardized uptake value ratio ([SUVR](../glossary.md#suvr)) maps to perform group comparison with the [`statistics-volume` pipeline](../Stats_Volume).
 - You can perform classification based on [machine learning](../MachineLearning_Classification), as showcased in the [AD-ML framework](https://github.com/aramis-lab/AD-ML).
 
 ## Describing this pipeline in your paper

--- a/docs/Pipelines/Stats_Volume.md
+++ b/docs/Pipelines/Stats_Volume.md
@@ -5,7 +5,7 @@ This pipeline performs statistical analysis (currently group comparison) on volu
 To that aim, the pipeline relies on the tools available in [SPM](http://www.fil.ion.ucl.ac.uk/spm/).
 
 Volume-based measurements are analyzed in the [IXI549Space](https://bids-specification.readthedocs.io/en/stable/99-appendices/08-coordinate-systems.html#standard-template-identifiers) (from SPM12).
-Currently, this pipeline mainly handles gray matter maps obtained from T1-weighted MR images using the [`t1-volume` pipeline](../T1_Volume) and standardized uptake value ratio (SUVR) maps obtained from PET data using the [`pet-volume` pipeline](../PET_Volume).
+Currently, this pipeline mainly handles gray matter maps obtained from T1-weighted MR images using the [`t1-volume` pipeline](../T1_Volume) and standardized uptake value ratio ([SUVR](../glossary.md#suvr)) maps obtained from [PET](../glossary.md#pet) data using the [`pet-volume` pipeline](../PET_Volume).
 
 ## Dependencies
 
@@ -46,7 +46,7 @@ Default value is `8` mm.
 Pipeline options if you use inputs from `pet-volume` pipeline:
 
 - `--acq_label`: Name of the label given to the PET acquisition, specifying the tracer used (`trc-<acq_label>`).
-- `--suvr_reference_region`: Reference region used to perform intensity normalization (i.e. dividing each voxel of the image by the average uptake in this region) resulting in a standardized uptake value ratio (SUVR) map.
+- `--suvr_reference_region`: Reference region used to perform intensity normalization (i.e. dividing each voxel of the image by the average uptake in this region) resulting in a standardized uptake value ratio ([SUVR](../glossary.md#suvr)) map.
 It can be `cerebellumPons` (used for amyloid tracers) or `pons` (used for FDG).
 - `--use_pvc_data`: Use PET data with partial value correction (by default, PET data with no PVC are used)
 

--- a/test/instantiation/test_instantiate_all_pipelines.py
+++ b/test/instantiation/test_instantiate_all_pipelines.py
@@ -189,13 +189,13 @@ def test_instantiate_dwi_connectome(cmdopt):
 
 def run_pet_volume(input_dir: Path) -> None:
     from clinica.pipelines.pet_volume.pet_volume_pipeline import PETVolume
-    from clinica.utils.pet import Tracer
+    from clinica.utils.pet import SUVRReferenceRegion, Tracer
 
     root = input_dir / "PETVolume"
     parameters = {
         "group_label": "UnitTest",
         "acq_label": Tracer.FDG,
-        "suvr_reference_region": "pons",
+        "suvr_reference_region": SUVRReferenceRegion.PONS,
         "skip_question": True,
         "reconstruction_method": None,
     }
@@ -210,13 +210,13 @@ def run_pet_volume(input_dir: Path) -> None:
 
 def test_instantiate_pet_linear(cmdopt):
     from clinica.pipelines.pet_linear.pet_linear_pipeline import PETLinear
-    from clinica.utils.pet import Tracer
+    from clinica.utils.pet import SUVRReferenceRegion, Tracer
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "PETLinear"
     parameters = {
         "acq_label": Tracer.FDG,
-        "suvr_reference_region": "cerebellumPons2",
+        "suvr_reference_region": SUVRReferenceRegion.CEREBELLUM_PONS2,
         "skip_question": True,
         "reconstruction_method": None,
     }
@@ -252,13 +252,13 @@ def test_instantiate_statistics_surface(cmdopt, tmp_path):
 
 def test_instantiate_pet_surface_cross_sectional(cmdopt):
     from clinica.pipelines.pet_surface.pet_surface_pipeline import PetSurface
-    from clinica.utils.pet import Tracer
+    from clinica.utils.pet import SUVRReferenceRegion, Tracer
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "PETSurface"
     parameters = {
         "acq_label": Tracer.FDG,
-        "suvr_reference_region": "pons",
+        "suvr_reference_region": SUVRReferenceRegion.PONS,
         "pvc_psf_tsv": fspath(root / "in" / "subjects.tsv"),
         "longitudinal": False,
         "skip_question": True,
@@ -276,13 +276,13 @@ def test_instantiate_pet_surface_cross_sectional(cmdopt):
 @pytest.mark.skip(reason="Currently broken. Needs to be fixed...")
 def test_instantiate_pet_surface_longitudinal(cmdopt):
     from clinica.pipelines.pet_surface.pet_surface_pipeline import PetSurface
-    from clinica.utils.pet import Tracer
+    from clinica.utils.pet import SUVRReferenceRegion, Tracer
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "PETSurfaceLongitudinal"
     parameters = {
         "acq_label": Tracer.FDG,
-        "suvr_reference_region": "pons",
+        "suvr_reference_region": SUVRReferenceRegion.PONS,
         "pvc_psf_tsv": fspath(root / "in" / "subjects.tsv"),
         "longitudinal": True,
         "reconstruction_method": None,
@@ -302,7 +302,7 @@ def test_instantiate_workflows_ml(cmdopt):
         CAPSVertexBasedInput,
         CAPSVoxelBasedInput,
     )
-    from clinica.utils.pet import Tracer
+    from clinica.utils.pet import SUVRReferenceRegion, Tracer
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "WorkflowsML"
@@ -314,6 +314,7 @@ def test_instantiate_workflows_ml(cmdopt):
     atlases = ["AAL2", "Neuromorphometrics", "AICHA", "LPBA40", "Hammers"]
     possible_fwhm = [0, 5, 10, 15, 20, 25]
     tracer = Tracer.FDG
+    region = SUVRReferenceRegion.PONS
     voxel_input = [
         CAPSVoxelBasedInput(
             {
@@ -324,7 +325,7 @@ def test_instantiate_workflows_ml(cmdopt):
                 "image_type": im,
                 "fwhm": 8,
                 "acq_label": tracer,
-                "suvr_reference_region": "pons",
+                "suvr_reference_region": region,
                 "use_pvc_data": False,
             }
         )
@@ -340,7 +341,7 @@ def test_instantiate_workflows_ml(cmdopt):
                 "image_type": im,
                 "atlas": at,
                 "acq_label": tracer,
-                "suvr_reference_region": "pons",
+                "suvr_reference_region": region,
                 "use_pvc_data": False,
             }
         )
@@ -357,7 +358,7 @@ def test_instantiate_workflows_ml(cmdopt):
                 "image_type": "PET",
                 "fwhm": fwhm,
                 "acq_label": tracer,
-                "suvr_reference_region": "pons",
+                "suvr_reference_region": region,
             }
         )
         for fwhm in possible_fwhm
@@ -437,7 +438,7 @@ def test_instantiate_statistics_volume(cmdopt):
     from clinica.pipelines.statistics_volume.statistics_volume_pipeline import (
         StatisticsVolume,
     )
-    from clinica.utils.pet import Tracer
+    from clinica.utils.pet import SUVRReferenceRegion, Tracer
 
     input_dir = Path(cmdopt["input"])
     root = input_dir / "StatisticsVolume"
@@ -447,7 +448,7 @@ def test_instantiate_statistics_volume(cmdopt):
         "contrast": "group",
         "acq_label": Tracer.FDG,
         "use_pvc_data": False,
-        "suvr_reference_region": "pons",
+        "suvr_reference_region": SUVRReferenceRegion.PONS,
     }
     pipeline = StatisticsVolume(
         caps_directory=fspath(root / "in" / "caps"),

--- a/test/nonregression/pipelines/pet/test_pet_linear.py
+++ b/test/nonregression/pipelines/pet/test_pet_linear.py
@@ -3,7 +3,7 @@ from os import fspath
 from pathlib import Path
 from test.nonregression.testing_tools import compare_folders, configure_paths
 
-from clinica.utils.pet import Tracer
+from clinica.utils.pet import SUVRReferenceRegion, Tracer
 
 
 def test_pet_linear(cmdopt, tmp_path):
@@ -20,7 +20,10 @@ def run_pet_linear(
 
     shutil.copytree(input_dir / "caps", output_dir / "caps", copy_function=shutil.copy)
 
-    parameters = {"acq_label": Tracer.FDG, "suvr_reference_region": "pons"}
+    parameters = {
+        "acq_label": Tracer.FDG,
+        "suvr_reference_region": SUVRReferenceRegion.PONS,
+    }
 
     pipeline = PETLinear(
         bids_directory=fspath(input_dir / "bids"),

--- a/test/nonregression/pipelines/pet/test_pet_surface.py
+++ b/test/nonregression/pipelines/pet/test_pet_surface.py
@@ -7,7 +7,7 @@ import nibabel as nib
 import numpy as np
 import pytest
 
-from clinica.utils.pet import Tracer
+from clinica.utils.pet import SUVRReferenceRegion, Tracer
 
 
 @pytest.mark.slow
@@ -26,10 +26,11 @@ def run_pet_surface(
     shutil.copytree(input_dir / "caps", output_dir / "caps", copy_function=shutil.copy)
 
     tracer = Tracer.FDG
+    region = SUVRReferenceRegion.PONS
 
     parameters = {
         "acq_label": tracer,
-        "suvr_reference_region": "pons",
+        "suvr_reference_region": region,
         "pvc_psf_tsv": fspath(input_dir / "subjects.tsv"),
         "longitudinal": False,
         "skip_question": False,
@@ -57,11 +58,11 @@ def run_pet_surface(
             )
             out = fspath(
                 output_folder
-                / f"sub-ADNI011S4105_ses-M000_trc-{tracer}_pet_space-fsaverage_suvr-pons_pvc-iy_hemi-{hemisphere}_fwhm-{fwhm}_projection.mgh"
+                / f"sub-ADNI011S4105_ses-M000_trc-{tracer.value}_pet_space-fsaverage_suvr-{region.value}_pvc-iy_hemi-{hemisphere}_fwhm-{fwhm}_projection.mgh"
             )
             ref = fspath(
                 ref_dir
-                / f"sub-ADNI011S4105_ses-M000_trc-{tracer}_pet_space-fsaverage_suvr-pons_pvc-iy_hemi-{hemisphere}_fwhm-{fwhm}_projection.mgh"
+                / f"sub-ADNI011S4105_ses-M000_trc-{tracer.value}_pet_space-fsaverage_suvr-{region.value}_pvc-iy_hemi-{hemisphere}_fwhm-{fwhm}_projection.mgh"
             )
             assert np.allclose(
                 np.squeeze(nib.load(out).get_fdata(dtype="float32")),
@@ -89,10 +90,11 @@ def run_pet_surface_longitudinal(
     shutil.copytree(input_dir / "caps", output_dir / "caps", copy_function=shutil.copy)
 
     tracer = Tracer.FDG
+    region = SUVRReferenceRegion.PONS
 
     parameters = {
-        "acq_label": Tracer.FDG,
-        "suvr_reference_region": "pons",
+        "acq_label": tracer,
+        "suvr_reference_region": region,
         "pvc_psf_tsv": fspath(input_dir / "subjects.tsv"),
         "longitudinal": True,
     }
@@ -124,11 +126,11 @@ def run_pet_surface_longitudinal(
         for fwhm in (0, 5, 10, 15, 20, 25):
             out = fspath(
                 output_folder
-                / f"{image_id}_trc-{tracer}_pet_space-fsaverage_suvr-pons_pvc-iy_hemi-{hemisphere}_fwhm-{fwhm}_projection.mgh"
+                / f"{image_id}_trc-{tracer.value}_pet_space-fsaverage_suvr-{region.value}_pvc-iy_hemi-{hemisphere}_fwhm-{fwhm}_projection.mgh"
             )
             ref = fspath(
                 ref_dir
-                / f"{image_id}_trc-{tracer}_pet_space-fsaverage_suvr-pons_pvc-iy_hemi-{hemisphere}_fwhm-{fwhm}_projection.mgh"
+                / f"{image_id}_trc-{tracer.value}_pet_space-fsaverage_suvr-{region.value}_pvc-iy_hemi-{hemisphere}_fwhm-{fwhm}_projection.mgh"
             )
             assert np.allclose(
                 np.squeeze(nib.load(out).get_fdata(dtype="float32")),

--- a/test/nonregression/pipelines/test_run_pipelines_ml.py
+++ b/test/nonregression/pipelines/test_run_pipelines_ml.py
@@ -7,7 +7,6 @@ different functions available in Clinica
 
 import warnings
 from os import fspath
-from pathlib import Path
 from test.nonregression.testing_tools import *
 
 import pytest
@@ -43,7 +42,7 @@ def run_workflows_ml(
         VertexBasedRepHoldOutDualSVM,
         VoxelBasedKFoldDualSVM,
     )
-    from clinica.utils.pet import Tracer
+    from clinica.utils.pet import SUVRReferenceRegion, Tracer
 
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     warnings.filterwarnings("ignore", category=UserWarning)
@@ -57,6 +56,7 @@ def run_workflows_ml(
     output_dir1 = output_dir / "VertexBasedRepHoldOutDualSVM"
 
     tracer = Tracer.FDG
+    region = SUVRReferenceRegion.PONS
 
     wf1 = VertexBasedRepHoldOutDualSVM(
         caps_directory=fspath(caps_dir),
@@ -66,7 +66,7 @@ def run_workflows_ml(
         output_dir=fspath(output_dir1),
         image_type="PET",
         acq_label=tracer,
-        suvr_reference_region="pons",
+        suvr_reference_region=region,
         fwhm=20,
         n_threads=2,
         n_iterations=10,
@@ -86,7 +86,7 @@ def run_workflows_ml(
         atlas="AICHA",
         output_dir=fspath(output_dir2),
         acq_label=tracer,
-        suvr_reference_region="pons",
+        suvr_reference_region=region,
         use_pvc_data=False,
         n_threads=2,
         n_iterations=10,
@@ -122,7 +122,7 @@ def run_workflows_ml(
         image_type="PET",
         output_dir=fspath(output_dir4),
         acq_label=tracer,
-        suvr_reference_region="pons",
+        suvr_reference_region=region,
         fwhm=8,
         n_threads=2,
         n_folds=5,
@@ -138,7 +138,6 @@ def run_spatial_svm(
     from os import fspath
 
     import nibabel as nib
-    import numpy as np
     from numpy.testing import assert_allclose
 
     from clinica.pipelines.machine_learning_spatial_svm.spatial_svm_pipeline import (

--- a/test/nonregression/pipelines/test_run_pipelines_stats.py
+++ b/test/nonregression/pipelines/test_run_pipelines_stats.py
@@ -145,7 +145,7 @@ def run_statistics_volume_pet(
     from clinica.pipelines.statistics_volume.statistics_volume_pipeline import (
         StatisticsVolume,
     )
-    from clinica.utils.pet import Tracer
+    from clinica.utils.pet import SUVRReferenceRegion, Tracer
 
     caps_dir = output_dir / "caps"
     tsv = input_dir / "group-UnitTest_covariates.tsv"
@@ -162,7 +162,7 @@ def run_statistics_volume_pet(
         # Optional arguments for inputs from pet-volume pipeline
         "acq_label": Tracer.FDG,
         "use_pvc_data": False,
-        "suvr_reference_region": "pons",
+        "suvr_reference_region": SUVRReferenceRegion.PONS,
     }
 
     pipeline = StatisticsVolume(
@@ -197,8 +197,6 @@ def run_statistics_volume_pet(
         nib.load(fspath(ref_t_stat)).get_fdata(dtype="float32"),
     )
 
-    # Remove data in out folder
-
 
 def run_statistics_volume_t1(
     input_dir: Path, output_dir: Path, ref_dir: Path, working_dir: Path
@@ -211,7 +209,6 @@ def run_statistics_volume_t1(
     from clinica.pipelines.statistics_volume.statistics_volume_pipeline import (
         StatisticsVolume,
     )
-    from clinica.utils.pet import Tracer
 
     caps_dir = output_dir / "caps"
     tsv = input_dir / "group-UnitTest_covariates.tsv"

--- a/test/unittests/pipelines/pet_linear/test_pet_linear_utils.py
+++ b/test/unittests/pipelines/pet_linear/test_pet_linear_utils.py
@@ -2,15 +2,21 @@ from pathlib import Path
 
 import pytest
 
+from clinica.utils.pet import SUVRReferenceRegion
+
 
 @pytest.mark.parametrize(
     "cropped,suvr_reference_region,expected",
     [
-        (False, "foo", "_space-MNI152NLin2009cSym_res-1x1x1_suvr-foo_pet.nii.gz"),
+        (
+            False,
+            SUVRReferenceRegion.PONS,
+            "_space-MNI152NLin2009cSym_res-1x1x1_suvr-pons_pet.nii.gz",
+        ),
         (
             True,
-            "bar",
-            "_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-bar_pet.nii.gz",
+            SUVRReferenceRegion.CEREBELLUM_PONS,
+            "_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-cerebellumPons_pet.nii.gz",
         ),
     ],
 )
@@ -50,14 +56,14 @@ def test_rename_into_caps(tmp_path):
         str(source_file),
         str(pet_file_to_rename),
         str(transformation_file_to_rename),
-        "suvrfoo",
+        SUVRReferenceRegion.PONS,
         True,
         output_dir=tmp_path,  # Force the writing to tmp_path instead of current folder...
     )
     assert (
         Path(a)
         == tmp_path
-        / "sub-01_ses-M000_run-01_space-MNI152NLin2009cSym_res-1x1x1_suvr-suvrfoo_pet.nii.gz"
+        / "sub-01_ses-M000_run-01_space-MNI152NLin2009cSym_res-1x1x1_suvr-pons_pet.nii.gz"
     )
     assert Path(b) == tmp_path / "sub-01_ses-M000_run-01_space-T1w_rigid.mat"
     assert c is None

--- a/test/unittests/utils/test_pet.py
+++ b/test/unittests/utils/test_pet.py
@@ -13,7 +13,7 @@ def psf_df() -> pd.DataFrame:
         {
             "participant_id": ["sub-CLNC01"] * 3 + ["sub-CLNC02", "sub-CLNC03"],
             "session_id": ["ses-M000", "ses-M018"] + ["ses-M000"] * 3,
-            "acq_label": ["FDG", "FDG", "AV45", "FDG", "FDG"],
+            "acq_label": ["18FFDG", "18FFDG", "18FAV45", "18FFDG", "18FFDG"],
             "psf_x": [8, 8, 7, 8, 8],
             "psf_y": [9, 9, 6, 9, 9],
             "psf_z": [10, 10, 5, 10, 10],
@@ -21,8 +21,8 @@ def psf_df() -> pd.DataFrame:
     )
 
 
-def test_read_psf_information_errors(tmp_path: os.PathLike, psf_df: pd.DataFrame):
-    from clinica.utils.pet import read_psf_information
+def test_read_psf_information_errors(tmp_path: Path, psf_df: pd.DataFrame):
+    from clinica.utils.pet import Tracer, read_psf_information
 
     with pytest.raises(
         FileNotFoundError,
@@ -32,13 +32,13 @@ def test_read_psf_information_errors(tmp_path: os.PathLike, psf_df: pd.DataFrame
             Path("foo.tsv"),
             ["sub-CLNC01", "sub-CLNC01"],
             ["ses-M000", "ses-M018"],
-            "FDG",
+            Tracer.FDG,
         )
     psf_df.to_csv(tmp_path / "psf.tsv", sep="\t", index=False)
     with pytest.raises(
         RuntimeError,
         match=(
-            "Subject sub-CLNC06 with session ses-M018 and tracer FDG "
+            "Subject sub-CLNC06 with session ses-M018 and tracer 18FFDG "
             "that you want to proceed was not found in the TSV file containing "
             "PSF specifications"
         ),
@@ -47,13 +47,13 @@ def test_read_psf_information_errors(tmp_path: os.PathLike, psf_df: pd.DataFrame
             tmp_path / "psf.tsv",
             ["sub-CLNC01", "sub-CLNC06"],
             ["ses-M000", "ses-M018"],
-            "FDG",
+            Tracer.FDG,
         )
     psf_df_2 = pd.DataFrame(
         {
             "participant_id": ["sub-CLNC01"],
             "session_id": ["ses-M000"],
-            "acq_label": ["FDG"],
+            "acq_label": ["18FFDG"],
             "psf_x": [10],
             "psf_y": [11],
             "psf_z": [12],
@@ -64,7 +64,7 @@ def test_read_psf_information_errors(tmp_path: os.PathLike, psf_df: pd.DataFrame
     with pytest.raises(
         RuntimeError,
         match=(
-            "Subject sub-CLNC01 with session ses-M000 and tracer FDG "
+            "Subject sub-CLNC01 with session ses-M000 and tracer 18FFDG "
             "that you want to proceed was found multiple times "
             "in the TSV file containing PSF specifications"
         ),
@@ -73,7 +73,7 @@ def test_read_psf_information_errors(tmp_path: os.PathLike, psf_df: pd.DataFrame
             tmp_path / "duplicate_psf.tsv",
             ["sub-CLNC01", "sub-CLNC01"],
             ["ses-M000", "ses-M018"],
-            "FDG",
+            Tracer.FDG,
         )
     psf_df["foo"] = ["bar"] * 5
     psf_df.to_csv(tmp_path / "wrong_psf.tsv", sep="\t", index=False)
@@ -85,7 +85,7 @@ def test_read_psf_information_errors(tmp_path: os.PathLike, psf_df: pd.DataFrame
             tmp_path / "wrong_psf.tsv",
             ["sub-CLNC01", "sub-CLNC01"],
             ["ses-M000", "ses-M018"],
-            "FDG",
+            Tracer.FDG,
         )
     psf_df.drop(["foo", "session_id"], axis=1).to_csv(
         tmp_path / "wrong_psf_2.tsv", sep="\t", index=False
@@ -98,19 +98,19 @@ def test_read_psf_information_errors(tmp_path: os.PathLike, psf_df: pd.DataFrame
             tmp_path / "wrong_psf_2.tsv",
             ["sub-CLNC01", "sub-CLNC01"],
             ["ses-M000", "ses-M018"],
-            "FDG",
+            Tracer.FDG,
         )
 
 
-def test_read_psf_information(tmp_path: os.PathLike, psf_df: pd.DataFrame):
-    from clinica.utils.pet import read_psf_information
+def test_read_psf_information(tmp_path: Path, psf_df: pd.DataFrame):
+    from clinica.utils.pet import Tracer, read_psf_information
 
     psf_df.to_csv(tmp_path / "psf.tsv", sep="\t", index=False)
     assert read_psf_information(
         tmp_path / "psf.tsv",
         ["sub-CLNC01", "sub-CLNC01"],
         ["ses-M000", "ses-M018"],
-        "FDG",
+        Tracer.FDG,
     ) == [[8, 9, 10], [8, 9, 10]]
     # Shuffle rows in dataframe and make sure results do not depend on row order
     psf_df = psf_df.sample(frac=1).reset_index(drop=True)
@@ -119,7 +119,7 @@ def test_read_psf_information(tmp_path: os.PathLike, psf_df: pd.DataFrame):
         tmp_path / "psf.tsv",
         ["sub-CLNC01", "sub-CLNC01"],
         ["ses-M000", "ses-M018"],
-        "FDG",
+        Tracer.FDG,
     ) == [[8, 9, 10], [8, 9, 10]]
 
 

--- a/test/unittests/utils/test_pet.py
+++ b/test/unittests/utils/test_pet.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from clinica.utils.pet import SUVRReferenceRegion
+
 
 @pytest.fixture
 def psf_df() -> pd.DataFrame:
@@ -121,13 +123,11 @@ def test_read_psf_information(tmp_path: os.PathLike, psf_df: pd.DataFrame):
     ) == [[8, 9, 10], [8, 9, 10]]
 
 
-@pytest.mark.parametrize(
-    "label", ["pons", "cerebellumPons", "pons2", "cerebellumPons2"]
-)
-def test_get_suvr_mask(label: str):
+@pytest.mark.parametrize("region", SUVRReferenceRegion)
+def test_get_suvr_mask(region):
     from clinica.utils.pet import get_suvr_mask
 
-    assert Path(get_suvr_mask(label)).exists()
+    assert Path(get_suvr_mask(region)).exists()
 
 
 @pytest.mark.parametrize("label", ["foo", "bar", "pons3", "cerebelumPons2"])
@@ -136,6 +136,6 @@ def test_get_suvr_mask_error(label: str):
 
     with pytest.raises(
         ValueError,
-        match=f"SUVR reference region label {label} is not supported.",
+        match=f"'{label}' is not a valid SUVRReferenceRegion",
     ):
         get_suvr_mask(label)


### PR DESCRIPTION
The SUVR reference region is modeled as a plain string in Clinica with a set of authorized values defined in a list:

https://github.com/aramis-lab/clinica/blob/42dcbd5fb1641011d2881eb9ce8d790b5a86c730/clinica/utils/pet.py#L138

This PR proposes to use a proper enumeration instead.