### PR TITLE
[REF] Move class `PETPipeline` to new `clinica.pipelines.pet` module

### DIFF
--- a/clinica/pipelines/engine.py
+++ b/clinica/pipelines/engine.py
@@ -1001,28 +1001,3 @@ class Pipeline(Workflow):
     @abc.abstractmethod
     def _check_pipeline_parameters(self) -> None:
         """Check pipeline parameters."""
-
-
-class PETPipeline(Pipeline):
-    def _check_pipeline_parameters(self) -> None:
-        """Check pipeline parameters."""
-        if "acq_label" not in self.parameters.keys():
-            raise KeyError("Missing compulsory acq_label key in pipeline parameter.")
-        self.parameters.setdefault("reconstruction_method", None)
-
-    def _get_pet_scans_query(self) -> dict:
-        """Return the query to retrieve PET scans."""
-        from clinica.utils.input_files import bids_pet_nii
-        from clinica.utils.pet import ReconstructionMethod, Tracer
-
-        pet_tracer = None
-        if self.parameters["acq_label"] is not None:
-            pet_tracer = Tracer(self.parameters["acq_label"])
-
-        reconstruction_method = None
-        if self.parameters["reconstruction_method"] is not None:
-            reconstruction_method = ReconstructionMethod(
-                self.parameters["reconstruction_method"]
-            )
-
-        return bids_pet_nii(pet_tracer, reconstruction_method)

--- a/clinica/pipelines/pet/engine.py
+++ b/clinica/pipelines/pet/engine.py
@@ -1,0 +1,26 @@
+from clinica.pipelines.engine import Pipeline
+
+
+class PETPipeline(Pipeline):
+    def _check_pipeline_parameters(self) -> None:
+        """Check pipeline parameters."""
+        if "acq_label" not in self.parameters.keys():
+            raise KeyError("Missing compulsory acq_label key in pipeline parameter.")
+        self.parameters.setdefault("reconstruction_method", None)
+
+    def _get_pet_scans_query(self) -> dict:
+        """Return the query to retrieve PET scans."""
+        from clinica.utils.input_files import bids_pet_nii
+        from clinica.utils.pet import ReconstructionMethod, Tracer
+
+        pet_tracer = None
+        if self.parameters["acq_label"] is not None:
+            pet_tracer = Tracer(self.parameters["acq_label"])
+
+        reconstruction_method = None
+        if self.parameters["reconstruction_method"] is not None:
+            reconstruction_method = ReconstructionMethod(
+                self.parameters["reconstruction_method"]
+            )
+
+        return bids_pet_nii(pet_tracer, reconstruction_method)

--- a/clinica/pipelines/pet_linear/pet_linear_pipeline.py
+++ b/clinica/pipelines/pet_linear/pet_linear_pipeline.py
@@ -4,7 +4,7 @@ from typing import List
 
 from nipype import config
 
-from clinica.pipelines.engine import PETPipeline
+from clinica.pipelines.pet.engine import PETPipeline
 
 cfg = dict(execution={"parameterize_dirs": False})
 config.update_config(cfg)

--- a/clinica/pipelines/pet_surface/pet_surface_pipeline.py
+++ b/clinica/pipelines/pet_surface/pet_surface_pipeline.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from clinica.pipelines.engine import PETPipeline
+from clinica.pipelines.pet.engine import PETPipeline
 
 
 class PetSurface(PETPipeline):

--- a/clinica/pipelines/pet_volume/pet_volume_pipeline.py
+++ b/clinica/pipelines/pet_volume/pet_volume_pipeline.py
@@ -2,7 +2,7 @@ from typing import List
 
 from nipype import config
 
-from clinica.pipelines.engine import PETPipeline
+from clinica.pipelines.pet.engine import PETPipeline
 
 # Use hash instead of parameters for iterables folder names
 # Otherwise path will be too long and generate OSError


### PR DESCRIPTION
PR #1122 is applying the same kind of refactoring to PET pipelines as the one we did a few months ago to DWI pipelines for example. The basic idea is to regroup similar pipelines and related code in the same sub-module.

Since #1122 is enormous and hasn't been updated in a while, I believe it would be easier to split it in smaller PRs.

This is the first of the series and it does the following:

- create new `pet` submodule under `clinica.pipelines`
- move the `PETPipeline` class definition to this new module
- updates the imports in the existing pipelines