### PR TITLE
[ENH] Add function `log_and_raise`

### DIFF
--- a/clinica/utils/stream.py
+++ b/clinica/utils/stream.py
@@ -1,6 +1,7 @@
 """This module handles stream and log redirection."""
 
 from enum import Enum
+from typing import Type
 
 
 class LoggingLevel(str, Enum):
@@ -38,3 +39,18 @@ def cprint(msg: str, lvl: str = "info") -> None:
         logger.critical(msg=msg)
     else:
         pass
+
+
+def log_and_raise(message: str, error_type: Type[Exception]):
+    """Log the error message using cprint and raise.
+
+    Parameters
+    ----------
+    message : str
+        The error message.
+
+    error_type : Exception
+        The error type to raise.
+    """
+    cprint(message, lvl="error")
+    raise error_type(message)


### PR DESCRIPTION
Very small PR which proposes to add a `log_and_raise` function to `clinica.utils.stream` to automatically log (using `cprint`) and raise a given error message. This will be useful for example in #1237 

Also modifies `adni_json.py` where a less generic function was used to log and raise a specific error type.