### PR TITLE
[FIX] Fix t1-freesurfer pipeline handler

### DIFF
--- a/clinica/iotools/utils/data_handling.py
+++ b/clinica/iotools/utils/data_handling.py
@@ -269,6 +269,8 @@ def _add_data_to_merge_file_from_caps(
         "dwi-dti": dwi_dti_pipeline,
     }
     merged_summary_df = pd.DataFrame()
+    if "group_selection" in kwargs and kwargs["group_selection"] is None:
+        kwargs.pop("group_selection")
     if not pipelines:
         for pipeline_name, pipeline_fn in pipeline_options.items():
             cprint(f"Extracting from CAPS pipeline output: {pipeline_name}...")

--- a/clinica/iotools/utils/pipeline_handling.py
+++ b/clinica/iotools/utils/pipeline_handling.py
@@ -12,7 +12,7 @@ def _get_atlas_name(atlas_path: Path, pipeline: str) -> str:
     """Helper function for _extract_metrics_from_pipeline."""
     if pipeline == "dwi_dti":
         splitter = "_dwi_space-"
-    elif pipeline in ("t1_freesurfer_longitudinal", "t1_freesurfer"):
+    elif pipeline in ("t1_freesurfer_longitudinal", "t1-freesurfer"):
         splitter = "_parcellation-"
     elif pipeline in ("t1-volume", "pet-volume"):
         splitter = "_space-"
@@ -46,7 +46,7 @@ def _get_mod_path(ses_path: Path, pipeline: str) -> Optional[Path]:
             / "freesurfer_longitudinal"
             / "regional_measures"
         )
-    if pipeline == "t1_freesurfer":
+    if pipeline == "t1-freesurfer":
         return ses_path / "t1" / "freesurfer_cross_sectional" / "regional_measures"
     if pipeline == "t1-volume":
         return ses_path / "t1" / "spm" / "dartel"
@@ -279,7 +279,7 @@ t1_freesurfer_longitudinal_pipeline = functools.partial(
 t1_freesurfer_pipeline = functools.partial(
     _extract_metrics_from_pipeline,
     metrics=["thickness", "segmentationVolumes"],
-    pipeline="t1_freesurfer",
+    pipeline="t1-freesurfer",
     group_selection=[""],
 )
 

--- a/clinica/iotools/utils/pipeline_handling.py
+++ b/clinica/iotools/utils/pipeline_handling.py
@@ -189,15 +189,15 @@ def _extract_metrics_from_pipeline(
         except KeyError:
             raise KeyError("Fields `participant_id` and `session_id` are required.")
 
-    if group_selection is None:
-        try:
-            group_selection = [f.name for f in (caps_dir / "groups").iterdir()]
-        except FileNotFoundError:
-            return df, None
-    else:
-        group_selection = [f"group-{group}" for group in group_selection]
     ignore_groups = group_selection == [""]
-
+    if not ignore_groups:
+        if group_selection is None:
+            try:
+                group_selection = [f.name for f in (caps_dir / "groups").iterdir()]
+            except FileNotFoundError:
+                return df, None
+        else:
+            group_selection = [f"group-{group}" for group in group_selection]
     subjects_dir = caps_dir / "subjects"
     records = []
     for participant_id, session_id in df.index.values:

--- a/clinica/iotools/utils/pipeline_handling.py
+++ b/clinica/iotools/utils/pipeline_handling.py
@@ -227,6 +227,20 @@ def _extract_metrics_from_pipeline(
                                 )
                             )
                         for atlas_path in atlas_paths:
+                            if metric == "segmentationVolumes":
+                                from clinica.iotools.converters.adni_to_bids.adni_utils import (
+                                    replace_sequence_chars,
+                                )
+
+                                atlas_df = pd.read_csv(atlas_path, sep="\t")
+                                label_list = [
+                                    f"t1-freesurfer_segmentation-volumes_ROI-{replace_sequence_chars(roi_name)}_volume"
+                                    for roi_name in atlas_df.label_name.values
+                                ]
+                                values = atlas_df["label_value"].to_numpy()
+                                for label, value in zip(label_list, values):
+                                    records[-1][label] = value
+                                continue
                             if not _skip_atlas(
                                 atlas_path, pipeline, pvc_restriction, tracers_selection
                             ):


### PR DESCRIPTION
This PR fixes a couple bugs on the iotools `merge-tsv` which occurs when providing a CAPS folder for `T1Freesurfer`.
These bugs were introduced in #869 (from clinica `0.7.4`).

- The parameter `group_selection` was not properly handled
- The `T1Freesurfer` pipeline has no groups in its CAPS and the metric extraction logic is thus a bit different. More precisely, the segmentation volume metrics were not extracted correctly.

This PR proposes to add some basic fixes as well as some unit tests.
