### PR TITLE
[ENH] Replace spm index tissue map mapping with enum

### DIFF
--- a/clinica/utils/input_files.py
+++ b/clinica/utils/input_files.py
@@ -341,45 +341,48 @@ def aggregator(func):
 
 
 @aggregator
-def t1_volume_native_tpm(tissue_number):
+def t1_volume_native_tpm(tissue_number: int) -> dict:
     from pathlib import Path
 
-    from .spm import INDEX_TISSUE_MAP
+    from .spm import get_spm_tissue_from_index
 
+    tissue = get_spm_tissue_from_index(tissue_number)
     return {
         "pattern": Path("t1")
         / "spm"
         / "segmentation"
         / "native_space"
-        / f"*_*_T1w_segm-{INDEX_TISSUE_MAP[tissue_number]}_probability.nii*",
-        "description": f"Tissue probability map {INDEX_TISSUE_MAP[tissue_number]} in native space",
+        / f"*_*_T1w_segm-{tissue.value}_probability.nii*",
+        "description": f"Tissue probability map {tissue.value} in native space",
         "needed_pipeline": "t1-volume-tissue-segmentation",
     }
 
 
 @aggregator
-def t1_volume_dartel_input_tissue(tissue_number):
+def t1_volume_dartel_input_tissue(tissue_number: int) -> dict:
     from pathlib import Path
 
-    from .spm import INDEX_TISSUE_MAP
+    from .spm import get_spm_tissue_from_index
 
+    tissue = get_spm_tissue_from_index(tissue_number)
     return {
         "pattern": Path("t1")
         / "spm"
         / "segmentation"
         / "dartel_input"
-        / f"*_*_T1w_segm-{INDEX_TISSUE_MAP[tissue_number]}_dartelinput.nii*",
-        "description": f"Dartel input for tissue probability map {INDEX_TISSUE_MAP[tissue_number]} from T1w MRI",
+        / f"*_*_T1w_segm-{tissue.value}_dartelinput.nii*",
+        "description": f"Dartel input for tissue probability map {tissue.value} from T1w MRI",
         "needed_pipeline": "t1-volume-tissue-segmentation",
     }
 
 
 @aggregator
-def t1_volume_native_tpm_in_mni(tissue_number, modulation):
+def t1_volume_native_tpm_in_mni(tissue_number: int, modulation: bool) -> dict:
     from pathlib import Path
 
-    from .spm import INDEX_TISSUE_MAP
+    from .spm import get_spm_tissue_from_index
 
+    tissue = get_spm_tissue_from_index(tissue_number)
     pattern_modulation = "on" if modulation else "off"
     description_modulation = "with" if modulation else "without"
 
@@ -388,16 +391,18 @@ def t1_volume_native_tpm_in_mni(tissue_number, modulation):
         / "spm"
         / "segmentation"
         / "normalized_space"
-        / f"*_*_T1w_segm-{INDEX_TISSUE_MAP[tissue_number]}_space-Ixi549Space_modulated-{pattern_modulation}_probability.nii*",
+        / f"*_*_T1w_segm-{tissue.value}_space-Ixi549Space_modulated-{pattern_modulation}_probability.nii*",
         "description": (
-            f"Tissue probability map {INDEX_TISSUE_MAP[tissue_number]} based on "
+            f"Tissue probability map {tissue.value} based on "
             f"native MRI in MNI space (Ixi549) {description_modulation} modulation."
         ),
         "needed_pipeline": "t1-volume-tissue-segmentation",
     }
 
 
-def t1_volume_template_tpm_in_mni(group_label, tissue_number, modulation, fwhm=None):
+def t1_volume_template_tpm_in_mni(
+    group_label: str, tissue_number: int, modulation: bool, fwhm: Optional[int] = None
+) -> dict:
     """Build the dictionary required by clinica_file_reader to get the tissue
     probability maps based on group template in MNI space.
 
@@ -422,8 +427,9 @@ def t1_volume_template_tpm_in_mni(group_label, tissue_number, modulation, fwhm=N
     """
     from pathlib import Path
 
-    from .spm import INDEX_TISSUE_MAP
+    from .spm import get_spm_tissue_from_index
 
+    tissue = get_spm_tissue_from_index(tissue_number)
     pattern_modulation = "on" if modulation else "off"
     description_modulation = "with" if modulation else "without"
     fwhm_key_value = f"_fwhm-{fwhm}mm" if fwhm else ""
@@ -434,10 +440,10 @@ def t1_volume_template_tpm_in_mni(group_label, tissue_number, modulation, fwhm=N
         / "spm"
         / "dartel"
         / f"group-{group_label}"
-        / f"*_T1w_segm-{INDEX_TISSUE_MAP[tissue_number]}_space-Ixi549Space_modulated-{pattern_modulation}{fwhm_key_value}_probability.nii*",
+        / f"*_T1w_segm-{tissue.value}_space-Ixi549Space_modulated-{pattern_modulation}{fwhm_key_value}_probability.nii*",
         "description": (
-            f"Tissue probability map {INDEX_TISSUE_MAP[tissue_number]} based "
-            f"on {group_label} template in MNI space (Ixi549) {description_modulation} modulation and {fwhm_description}."
+            f"Tissue probability map {tissue.value} based on {group_label} template in MNI space "
+            f"(Ixi549) {description_modulation} modulation and {fwhm_description}."
         ),
         "needed_pipeline": "t1-volume",
     }

--- a/clinica/utils/spm.py
+++ b/clinica/utils/spm.py
@@ -1,22 +1,40 @@
 """This module contains SPM utilities."""
 import warnings
+from enum import Enum
 from os import PathLike
 from pathlib import Path
 
 __all__ = [
-    "INDEX_TISSUE_MAP",
+    "SPMTissue",
+    "get_spm_tissue_from_index",
     "get_tpm",
     "use_spm_standalone_if_available",
 ]
 
-INDEX_TISSUE_MAP = {
-    1: "graymatter",
-    2: "whitematter",
-    3: "csf",
-    4: "bone",
-    5: "softtissue",
-    6: "background",
-}
+
+class SPMTissue(str, Enum):
+    GRAY_MATTER = "graymatter"
+    WHITE_MATTER = "whitematter"
+    CSF = "csf"
+    BONE = "bone"
+    SOFT_TISSUE = "softtissue"
+    BACKGROUND = "background"
+
+
+def get_spm_tissue_from_index(index: int) -> SPMTissue:
+    if index == 1:
+        return SPMTissue.GRAY_MATTER
+    if index == 2:
+        return SPMTissue.WHITE_MATTER
+    if index == 3:
+        return SPMTissue.CSF
+    if index == 4:
+        return SPMTissue.BONE
+    if index == 5:
+        return SPMTissue.SOFT_TISSUE
+    if index == 6:
+        return SPMTissue.BACKGROUND
+    raise ValueError(f"No SPM tissue matching index {index}.")
 
 
 def get_tpm() -> PathLike:

--- a/test/unittests/utils/test_spm.py
+++ b/test/unittests/utils/test_spm.py
@@ -6,6 +6,36 @@ from unittest import mock
 import pytest
 
 from clinica.utils.exceptions import ClinicaMissingDependencyError
+from clinica.utils.spm import SPMTissue
+
+
+@pytest.mark.parametrize("index", [-1, 0, 7, 10.2, 3.3, "foo", "3", "", None])
+def test_get_spm_tissue_from_index_error(index):
+    from clinica.utils.spm import get_spm_tissue_from_index
+
+    with pytest.raises(
+        ValueError,
+        match=f"No SPM tissue matching index {index}.",
+    ):
+        get_spm_tissue_from_index(index)
+
+
+@pytest.mark.parametrize(
+    "index,expected,expected_value",
+    [
+        (1, SPMTissue.GRAY_MATTER, "graymatter"),
+        (2, SPMTissue.WHITE_MATTER, "whitematter"),
+        (3, SPMTissue.CSF, "csf"),
+        (4, SPMTissue.BONE, "bone"),
+        (5, SPMTissue.SOFT_TISSUE, "softtissue"),
+        (6, SPMTissue.BACKGROUND, "background"),
+    ],
+)
+def test_get_spm_tissue_from_index_error(index, expected, expected_value):
+    from clinica.utils.spm import get_spm_tissue_from_index
+
+    assert get_spm_tissue_from_index(index) == expected
+    assert get_spm_tissue_from_index(index).value == expected_value
 
 
 def test_spm_standalone_is_available_no_env_variable_error():


### PR DESCRIPTION
Small PR to improve the way SPM index tissues are represented and the way they are mapped to spm indices.
Instead of having a mutable mapping between integers and strings, this PR proposes to have an enumeration for the SPM tissues and a simple function doing the mapping from integer indices to the right variant. This function raises a proper `ValueError` if the index doesn't correspond to a tissue.
The PR also adds some basic unit tests.