### PR TITLE
[FIX] Specify path to SPM when using Matlab and SPM12

### DIFF
--- a/clinica/utils/spm.py
+++ b/clinica/utils/spm.py
@@ -64,7 +64,7 @@ def use_spm_standalone_if_available() -> bool:
     """
     from clinica.utils.stream import cprint
 
-    from .check_dependency import get_mcr_home, get_spm_standalone_home
+    from .check_dependency import get_mcr_home, get_spm_home, get_spm_standalone_home
     from .exceptions import ClinicaMissingDependencyError
 
     try:
@@ -87,6 +87,10 @@ def use_spm_standalone_if_available() -> bool:
             "to set the following environment variables: "
             "$SPMSTANDALONE_HOME, and $MCR_HOME"
         )
+        import nipype.interfaces.matlab as mlab
+
+        cprint(f"Setting SPM path to {get_spm_home()}", lvl="info")
+        mlab.MatlabCommand.set_default_paths(f"{get_spm_home()}")
         return False
 
 

--- a/test/unittests/pipelines/statistics_volume/test_statistics_volume_utils.py
+++ b/test/unittests/pipelines/statistics_volume/test_statistics_volume_utils.py
@@ -1,7 +1,9 @@
 import math
+import os
 from functools import partial
 from pathlib import Path
 from typing import List
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -304,12 +306,16 @@ def test_run_m_script_no_output_file_error(tmp_path, mocker):
         "clinica.pipelines.statistics_volume.statistics_volume_utils._run_matlab_script_with_matlab",
         return_value=None,
     )
+    (tmp_path / "spm_home_folder").mkdir()
 
     with pytest.raises(
         RuntimeError,
         match="Output matrix",
     ):
-        run_m_script(m_file)
+        with mock.patch.dict(
+            os.environ, {"SPM_HOME": str(tmp_path / "spm_home_folder")}
+        ):
+            run_m_script(m_file)
 
 
 def test_run_m_script(tmp_path, mocker):
@@ -327,8 +333,10 @@ def test_run_m_script(tmp_path, mocker):
         "clinica.pipelines.statistics_volume.statistics_volume_utils._run_matlab_script_with_matlab",
         return_value=None,
     )
+    (tmp_path / "spm_home_folder").mkdir()
 
-    assert run_m_script(m_file) == str(expected_output_file)
+    with mock.patch.dict(os.environ, {"SPM_HOME": str(tmp_path / "spm_home_folder")}):
+        assert run_m_script(m_file) == str(expected_output_file)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Related to discussion #1256 

I believe this should avoid the "SPM not in matlab path" issue when using Matlab and SPM12.