### PR TITLE
[ENH] Add third-party software version getters

### DIFF
--- a/clinica/utils/check_dependency.py
+++ b/clinica/utils/check_dependency.py
@@ -356,6 +356,24 @@ _check_fsl = functools.partial(
 def get_software_min_version_supported(
     software: Union[str, ThirdPartySoftware],
 ) -> Version:
+    """Return the minimum version of the provided third-party software required by Clinica.
+
+    Parameters
+    ----------
+    software : str or ThirdPartySoftware
+        One of the third-party software of Clinica.
+
+    Returns
+    -------
+    Version :
+        The minimum version number of the software required by Clinica.
+
+    Examples
+    --------
+    >>> from clinica.utils.check_dependency import get_software_min_version_supported
+    >>> get_software_min_version_supported("ants")
+    <Version('2.5.0')>
+    """
     software = ThirdPartySoftware(software)
     if software == ThirdPartySoftware.FREESURFER:
         return Version("6.0.0")
@@ -382,6 +400,30 @@ def get_software_min_version_supported(
 
 
 def get_software_version(software: Union[str, ThirdPartySoftware]) -> Version:
+    """Return the version of the provided third-party software.
+
+    Parameters
+    ----------
+    software : str or ThirdPartySoftware
+        One of the third-party software of Clinica.
+
+    Returns
+    -------
+    Version :
+        The version number of the installed software.
+
+    Notes
+    -----
+    This function assumes the software are correctly installed.
+    It doesn't run any check and directly try to infer the version number by calling an
+    underlying executable.
+
+    Examples
+    --------
+    >>> from clinica.utils.check_dependency import get_software_version
+    >>> get_software_version("freesurfer")
+    <Version('7.2.0')>
+    """
     software = ThirdPartySoftware(software)
     if software == ThirdPartySoftware.FREESURFER:
         return _get_freesurfer_version()
@@ -527,6 +569,13 @@ def _get_mcr_version() -> Version:
 
 
 def _map_mcr_release_to_version_number(mcr_release: str) -> Version:
+    """Map the MCR release to a proper version number.
+
+    If the found version is older than the minimum supported version, we don't bother mapping it
+    to its version number, 0.0.0 is returned.
+    If the release is >= 2024a, we use the fact that Matlab is now using proper calendar versioning.
+    If the release is in-between, we use a hardcoded mapping.
+    """
     mcr_versions_mapping = {
         "2023b": Version("23.2"),
         "2023a": Version("9.14"),
@@ -556,6 +605,7 @@ class SeverityLevel(str, Enum):
 
 
 def _check_software_version(software: ThirdPartySoftware, severity: SeverityLevel):
+    """Check that the installed version of the software is >= to the minimum version required by Clinica."""
     from clinica.utils.stream import cprint
 
     if (installed_version := get_software_version(software)) < (
@@ -576,6 +626,19 @@ def _check_software_version(software: ThirdPartySoftware, severity: SeverityLeve
 
 
 def check_software(software: Union[str, ThirdPartySoftware]):
+    """Run some checks on the given software.
+
+    These checks are of two types:
+        - checks to verify that the executable is present in the PATH.
+          Also check configurations made through environment variables.
+        - checks on the installed version. The installed version has to
+          be more recent than a minimum version supported by Clinica.
+
+    Parameters
+    ----------
+    software : str or ThirdPartySoftware
+        One of the third-party software of Clinica.
+    """
     software = ThirdPartySoftware(software)
     if software == ThirdPartySoftware.ANTS:
         _check_ants()

--- a/test/unittests/utils/test_check_dependency.py
+++ b/test/unittests/utils/test_check_dependency.py
@@ -1,8 +1,12 @@
 import os
 import re
+from test.unittests.iotools.converters.adni_to_bids.modality_converters.test_adni_fmap import (
+    expected,
+)
 from unittest import mock
 
 import pytest
+from packaging.version import Version
 
 from clinica.utils.check_dependency import (
     SoftwareEnvironmentVariable,
@@ -220,3 +224,31 @@ def test_check_spm_alone(tmp_path, mocker):
     mocker.patch("clinica.utils.check_dependency.is_binary_present", return_value=True)
     with mock.patch.dict(os.environ, {"SPM_HOME": str(tmp_path)}):
         _check_spm()
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("2024a", Version("24.1")),
+        ("2023b", Version("23.2")),
+        ("2023a", Version("9.14")),
+        ("2022b", Version("9.13")),
+        ("2022a", Version("9.12")),
+        ("2021b", Version("9.11")),
+        ("2021a", Version("9.10")),
+        ("2020b", Version("9.9")),
+        ("2020a", Version("9.8")),
+        ("2019b", Version("9.7")),
+        ("2019a", Version("9.6")),
+        ("2018b", Version("9.5")),
+        ("2018a", Version("9.4")),
+        ("2017b", Version("9.3")),
+        ("2017a", Version("9.2")),
+        ("2016b", Version("9.1")),
+        ("2016a", Version("9.0.1")),
+    ],
+)
+def test_map_mcr_release_to_version_number(version, expected):
+    from clinica.utils.check_dependency import _map_mcr_release_to_version_number
+
+    assert _map_mcr_release_to_version_number(version) == expected

--- a/test/unittests/utils/test_check_dependency.py
+++ b/test/unittests/utils/test_check_dependency.py
@@ -227,28 +227,124 @@ def test_check_spm_alone(tmp_path, mocker):
 
 
 @pytest.mark.parametrize(
-    "version,expected",
+    "software,expected",
     [
-        ("2024a", Version("24.1")),
-        ("2023b", Version("23.2")),
-        ("2023a", Version("9.14")),
-        ("2022b", Version("9.13")),
-        ("2022a", Version("9.12")),
-        ("2021b", Version("9.11")),
-        ("2021a", Version("9.10")),
-        ("2020b", Version("9.9")),
-        ("2020a", Version("9.8")),
-        ("2019b", Version("9.7")),
-        ("2019a", Version("9.6")),
-        ("2018b", Version("9.5")),
-        ("2018a", Version("9.4")),
-        ("2017b", Version("9.3")),
-        ("2017a", Version("9.2")),
-        ("2016b", Version("9.1")),
-        ("2016a", Version("9.0.1")),
+        (ThirdPartySoftware.FREESURFER, Version("6.0.0")),
+        (ThirdPartySoftware.FSL, Version("5.0.5")),
+        (ThirdPartySoftware.ANTS, Version("2.5.0")),
+        (ThirdPartySoftware.DCM2NIIX, Version("1.0.20240202")),
+        (ThirdPartySoftware.MRTRIX, Version("3.0.3")),
+        (ThirdPartySoftware.CONVERT3D, Version("1.0.0")),
+        (ThirdPartySoftware.MATLAB, Version("9.2.0.556344")),
+        (ThirdPartySoftware.SPM, Version("12.7219")),
+        (ThirdPartySoftware.MCR, Version("9.0.1")),
+        (ThirdPartySoftware.SPMSTANDALONE, Version("12.7219")),
+        (ThirdPartySoftware.PETPVC, Version("0.0.0")),
     ],
 )
+def test_get_software_min_version_supported(software: str, expected: Version):
+    from clinica.utils.check_dependency import get_software_min_version_supported
+
+    assert get_software_min_version_supported(software) == expected
+
+
+def test_get_freesurfer_version(mocker):
+    from clinica.utils.check_dependency import get_software_version
+
+    mocker.patch("nipype.interfaces.freesurfer.Info.looseversion", return_value="1.2.3")
+
+    assert get_software_version("freesurfer") == Version("1.2.3")
+
+
+def test_get_spm_version():
+    from clinica.utils.check_dependency import get_software_version
+
+    class SPMVersionMock:
+        version: str = "12.6789"
+
+    with mock.patch(
+        "nipype.interfaces.spm.SPMCommand", wraps=SPMVersionMock
+    ) as spm_mock:
+        assert get_software_version("spm") == Version("12.6789")
+        spm_mock.assert_called_once()
+
+
+def test_get_spm_standalone_version(tmp_path):
+    from clinica.utils.check_dependency import get_software_version
+
+    class SPMStandaloneVersionMock:
+        version: str = "13.234"
+
+        def set_mlab_paths(self, matlab_cmd: str, use_mcr: bool):
+            pass
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            "SPM_HOME": str(tmp_path / "spm_home_mock"),
+            "MCR_HOME": str(tmp_path / "mcr_home_mock"),
+        },
+    ):
+        with mock.patch(
+            "nipype.interfaces.spm.SPMCommand", wraps=SPMStandaloneVersionMock
+        ) as spm_mock:
+            with mock.patch.object(
+                SPMStandaloneVersionMock, "set_mlab_paths", return_value=None
+            ) as mock_method:
+                assert get_software_version("spm standalone") == Version("13.234")
+                spm_mock.set_mlab_paths.assert_called()
+                mock_method.assert_called_once_with(
+                    matlab_cmd=f"{tmp_path / 'spm_home_mock' / 'run_spm12.sh'} {tmp_path / 'mcr_home_mock'} script",
+                    use_mcr=True,
+                )
+
+
+def test_get_fsl_version(mocker):
+    from clinica.utils.check_dependency import get_software_version
+
+    mocker.patch("nipype.interfaces.fsl.Info.version", return_value="3.2.1:9e026117")
+
+    assert get_software_version("fsl") == Version("3.2.1")
+
+
+mcr_version_test_suite = [
+    ("2024a", Version("24.1")),
+    ("2023b", Version("23.2")),
+    ("2023a", Version("9.14")),
+    ("2022b", Version("9.13")),
+    ("2022a", Version("9.12")),
+    ("2021b", Version("9.11")),
+    ("2021a", Version("9.10")),
+    ("2020b", Version("9.9")),
+    ("2020a", Version("9.8")),
+    ("2019b", Version("9.7")),
+    ("2019a", Version("9.6")),
+    ("2018b", Version("9.5")),
+    ("2018a", Version("9.4")),
+    ("2017b", Version("9.3")),
+    ("2017a", Version("9.2")),
+    ("2016b", Version("9.1")),
+    ("2016a", Version("9.0.1")),
+    ("2015b", Version("0.0.0")),
+    ("1789a", Version("0.0.0")),
+]
+
+
+@pytest.mark.parametrize("version,expected", mcr_version_test_suite)
 def test_map_mcr_release_to_version_number(version, expected):
     from clinica.utils.check_dependency import _map_mcr_release_to_version_number
 
     assert _map_mcr_release_to_version_number(version) == expected
+
+
+@pytest.mark.parametrize("version,expected", mcr_version_test_suite)
+def test_get_mcr_version(tmp_path, version, expected):
+    from clinica.utils.check_dependency import get_software_version
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            "MCR_HOME": str(tmp_path / "mcr_home_mock" / version / "v95"),
+        },
+    ):
+        assert get_software_version("MCR") == expected

--- a/test/unittests/utils/test_check_dependency.py
+++ b/test/unittests/utils/test_check_dependency.py
@@ -6,6 +6,7 @@ from test.unittests.iotools.converters.adni_to_bids.modality_converters.test_adn
 from unittest import mock
 
 import pytest
+from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from clinica.utils.check_dependency import (
@@ -468,12 +469,37 @@ def test_check_software_version(mocker):
 
     with pytest.raises(
         ClinicaMissingDependencyError,
-        match="ants version is 1.0.1. We strongly recommend to have ants >= 1.1.0.",
+        match="ants version is 1.0.1. We strongly recommend to have ants >=1.1.0.",
     ):
         _check_software_version(ThirdPartySoftware.ANTS, SeverityLevel.ERROR)
+    _check_software_version(
+        ThirdPartySoftware.ANTS, SeverityLevel.ERROR, SpecifierSet("==1.0.1")
+    )
+    _check_software_version(
+        ThirdPartySoftware.ANTS, SeverityLevel.ERROR, SpecifierSet("<2")
+    )
+    _check_software_version(
+        ThirdPartySoftware.ANTS, SeverityLevel.ERROR, SpecifierSet(">1.0")
+    )
+
+    with pytest.raises(
+        ClinicaMissingDependencyError,
+        match="ants version is 1.0.1. We strongly recommend to have ants ==1.2.3.",
+    ):
+        _check_software_version(
+            ThirdPartySoftware.ANTS, SeverityLevel.ERROR, SpecifierSet("==1.2.3")
+        )
 
     with pytest.warns(
         UserWarning,
-        match="ants version is 1.0.1. We strongly recommend to have ants >= 1.1.0.",
+        match="ants version is 1.0.1. We strongly recommend to have ants >=1.1.0.",
     ):
         _check_software_version(ThirdPartySoftware.ANTS, SeverityLevel.WARNING)
+
+    with pytest.warns(
+        UserWarning,
+        match="ants version is 1.0.1. We strongly recommend to have ants <=0.23.",
+    ):
+        _check_software_version(
+            ThirdPartySoftware.ANTS, SeverityLevel.WARNING, SpecifierSet("<=0.23")
+        )

--- a/test/unittests/utils/test_check_dependency.py
+++ b/test/unittests/utils/test_check_dependency.py
@@ -431,7 +431,7 @@ mcr_version_test_suite = [
 
 @pytest.mark.parametrize("version,expected", mcr_version_test_suite)
 def test_map_mcr_release_to_version_number(version, expected):
-    from clinica.utils.check_dependency import _map_mcr_release_to_version_number
+    from clinica.utils.check_dependency import _map_mcr_release_to_version_number  # noqa
 
     assert _map_mcr_release_to_version_number(version) == expected
 
@@ -456,7 +456,8 @@ def test_get_petpvc_version():
 
 
 def test_check_software_version(mocker):
-    from clinica.utils.check_dependency import SeverityLevel, _check_software_version
+    from clinica.utils.check_dependency import _check_software_version  # noqa
+    from clinica.utils.stream import LoggingLevel
 
     mocker.patch(
         "clinica.utils.check_dependency.get_software_version",
@@ -471,15 +472,21 @@ def test_check_software_version(mocker):
         ClinicaMissingDependencyError,
         match="ants version is 1.0.1. We strongly recommend to have ants >=1.1.0.",
     ):
-        _check_software_version(ThirdPartySoftware.ANTS, SeverityLevel.ERROR)
+        _check_software_version(ThirdPartySoftware.ANTS, log_level=LoggingLevel.ERROR)
     _check_software_version(
-        ThirdPartySoftware.ANTS, SeverityLevel.ERROR, SpecifierSet("==1.0.1")
+        ThirdPartySoftware.ANTS,
+        log_level=LoggingLevel.ERROR,
+        specifier=SpecifierSet("==1.0.1"),
     )
     _check_software_version(
-        ThirdPartySoftware.ANTS, SeverityLevel.ERROR, SpecifierSet("<2")
+        ThirdPartySoftware.ANTS,
+        log_level=LoggingLevel.ERROR,
+        specifier=SpecifierSet("<2"),
     )
     _check_software_version(
-        ThirdPartySoftware.ANTS, SeverityLevel.ERROR, SpecifierSet(">1.0")
+        ThirdPartySoftware.ANTS,
+        log_level=LoggingLevel.ERROR,
+        specifier=SpecifierSet(">1.0"),
     )
 
     with pytest.raises(
@@ -487,19 +494,23 @@ def test_check_software_version(mocker):
         match="ants version is 1.0.1. We strongly recommend to have ants ==1.2.3.",
     ):
         _check_software_version(
-            ThirdPartySoftware.ANTS, SeverityLevel.ERROR, SpecifierSet("==1.2.3")
+            ThirdPartySoftware.ANTS,
+            log_level=LoggingLevel.ERROR,
+            specifier=SpecifierSet("==1.2.3"),
         )
 
     with pytest.warns(
         UserWarning,
         match="ants version is 1.0.1. We strongly recommend to have ants >=1.1.0.",
     ):
-        _check_software_version(ThirdPartySoftware.ANTS, SeverityLevel.WARNING)
+        _check_software_version(ThirdPartySoftware.ANTS, log_level=LoggingLevel.WARNING)
 
     with pytest.warns(
         UserWarning,
         match="ants version is 1.0.1. We strongly recommend to have ants <=0.23.",
     ):
         _check_software_version(
-            ThirdPartySoftware.ANTS, SeverityLevel.WARNING, SpecifierSet("<=0.23")
+            ThirdPartySoftware.ANTS,
+            log_level=LoggingLevel.WARNING,
+            specifier=SpecifierSet("<=0.23"),
         )


### PR DESCRIPTION
This PR proposes to add utilities to retrieve the version numbers of the third-party softwares that Clinica depends on.

There are three main functions that have been added or modified in the public API of the `clinica.utils.check_dependency` module:

### The function `get_software_min_version_supported`

Returns the minimum version of a third party software that Clinica requires on a global level.

**Note:** It will be possible to overwrite this on a pipeline-by-pipeline basis through the use of the `info.json` configuration file. 

Here is an example:

```python
>>> from clinica.utils.check_dependency import get_software_min_version_supported
>>> get_software_min_version_supported("ants")
<Version('2.5.0')>
>>> get_software_min_version_supported("spm")
<Version('12.7219')>
```

### The function `get_software_version`

Returns the installed version of a third party software. This function assumes the software is properly installed, i.e. it tries to call the program and fails inelegantly if it is not present.
Here is an example:

```python
>>> from clinica.utils.check_dependency import get_software_version
>>> get_software_version("ants")
<Version('2.3.5')>
>>> get_software_version("dcm2niix")
<Version('1.0.20240202')>
>>> get_software_version("fsl")
<Version('6.0.5.2')>
```

If the software is not installed, it crashes badly:

```python
>>> get_software_version("matlab")
[Errno 2] No such file or directory: 'matlab'
Traceback (most recent call last):
  File "/Users/nicolas.gensollen/GitRepos/clinica-fork/clinica/utils/check_dependency.py", line 599, in _get_matlab_version
    re.search(r"\(\s*([\d.]+)\)", _get_matlab_start_session_message())
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nicolas.gensollen/GitRepos/clinica-fork/clinica/utils/check_dependency.py", line 611, in _get_matlab_start_session_message
    return subprocess.run(
           ^^^^^^^^^^^^^^^
  File "/Users/nicolas.gensollen/opt/anaconda3/envs/clinica-t/lib/python3.11/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nicolas.gensollen/opt/anaconda3/envs/clinica-t/lib/python3.11/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/Users/nicolas.gensollen/opt/anaconda3/envs/clinica-t/lib/python3.11/subprocess.py", line 1953, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'matlab'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/nicolas.gensollen/GitRepos/clinica-fork/clinica/utils/check_dependency.py", line 494, in get_software_version
    return _get_matlab_version()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nicolas.gensollen/GitRepos/clinica-fork/clinica/utils/check_dependency.py", line 604, in _get_matlab_version
    log_and_raise(str(e), RuntimeError)
  File "/Users/nicolas.gensollen/GitRepos/clinica-fork/clinica/utils/stream.py", line 89, in log_and_raise
    raise error_type(message)
RuntimeError: [Errno 2] No such file or directory: 'matlab'
```

### The function `check_software`

This function has been modified to add version constraint checks to the previous checks, i.e. the checks we previously had to make sure the software is correctly installed and configured (binary presence, environment variables settings...).

Here are some examples:

When the software is correctly installed with a version satisfying the minimum requirements:

```python
>>> from clinica.utils.check_dependency import check_software
>>> check_software("dcm2niix")
```

When the software is not installed:

```python
>>> check_software("matlab")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/nicolas.gensollen/GitRepos/clinica-fork/clinica/utils/check_dependency.py", line 753, in check_software
    _check_matlab()
  File "/Users/nicolas.gensollen/GitRepos/clinica-fork/clinica/utils/check_dependency.py", line 287, in _check_software
    raise ClinicaMissingDependencyError(
clinica.utils.exceptions.ClinicaMissingDependencyError: [Error] Clinica could not find matlab software: the matlab command is not present in your PATH environment.
```

When the software is installed, but the version is not satisfying the minimum requirements, the default behavior is a warning (except for a few cases where an error is thrown instead):

```python
>>> check_software("ants")
ants version is 2.3.5. We strongly recommend to have ants >=2.5.0.
/Users/nicolas.gensollen/GitRepos/clinica-fork/clinica/utils/stream.py:104: UserWarning: ants version is 2.3.5. We strongly recommend to have ants >=2.5.0.
  warnings.warn(message, warning_type)
```

Both the version constraint and the error vs. warning behavior can be configured:

```python
>>> check_software("ants", specifier="==2.3.5")
>>> check_software("ants", specifier="<2.4")
>>> check_software("ants", specifier=">2.5", log_level="error")
ants version is 2.3.5. We strongly recommend to have ants >2.5.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/nicolas.gensollen/GitRepos/clinica-fork/clinica/utils/check_dependency.py", line 762, in check_software
    _check_software_version(software, log_level=log_level, specifier=specifier)
  File "/Users/nicolas.gensollen/GitRepos/clinica-fork/clinica/utils/check_dependency.py", line 666, in _check_software_version
    (log_and_raise if log_level >= LoggingLevel.ERROR else log_and_warn)(
  File "/Users/nicolas.gensollen/GitRepos/clinica-fork/clinica/utils/stream.py", line 89, in log_and_raise
    raise error_type(message)
clinica.utils.exceptions.ClinicaMissingDependencyError: ants version is 2.3.5. We strongly recommend to have ants >2.5.
```