### PR TITLE
[ENH] Implement `LoggingLevel` as an `IntEnum`

### DIFF
--- a/clinica/utils/stream.py
+++ b/clinica/utils/stream.py
@@ -1,41 +1,74 @@
 """This module handles stream and log redirection."""
 import warnings
-from enum import Enum
-from typing import Type
+from enum import IntEnum
+from typing import Optional, Type, Union
+
+__all__ = [
+    "LoggingLevel",
+    "get_logging_level",
+    "cprint",
+    "log_and_raise",
+    "log_and_warn",
+]
 
 
-class LoggingLevel(str, Enum):
-    debug = "debug"
-    info = "info"
-    warning = "warning"
-    error = "error"
-    critical = "critical"
+class LoggingLevel(IntEnum):
+    DEBUG = 1
+    INFO = 2
+    WARNING = 3
+    ERROR = 4
+    CRITICAL = 5
 
 
-def cprint(msg: str, lvl: str = "info") -> None:
-    """
-    Print message to the console at the desired logging level.
+def get_logging_level(level: Union[str, int, LoggingLevel]) -> LoggingLevel:
+    if isinstance(level, str):
+        if level == "debug":
+            return LoggingLevel.DEBUG
+        if level == "info":
+            return LoggingLevel.INFO
+        if level == "warning":
+            return LoggingLevel.WARNING
+        if level == "error":
+            return LoggingLevel.ERROR
+        if level == "critical":
+            return LoggingLevel.CRITICAL
+        raise ValueError(f"Logging level {level} is not valid.")
+    return LoggingLevel(level)
 
-    Args:
-        msg (str): Message to print.
-        lvl (str): Logging level between "debug", "info", "warning", "error" and "critical".
-                   The default value is "info".
+
+def cprint(msg: str, lvl: Optional[Union[str, int, LoggingLevel]] = None) -> None:
+    """Print message to the console at the desired logging level.
+
+    Parameters
+    ----------
+    msg : str
+        The message to log.
+
+    lvl : str or int, or LoggingLevel, optional
+        The logging level:
+            - 1 = "debug"
+            - 2 = "info"
+            - 3 = "warning"
+            - 4 = "error"
+            - 5 = "critical"
+        The default value is "info".
     """
     from logging import getLogger
 
+    lvl = lvl or LoggingLevel.INFO
     # Use the package level logger.
     logger = getLogger("clinica")
 
     # Log message as info level.
-    if lvl == LoggingLevel.debug:
+    if lvl == LoggingLevel.DEBUG:
         logger.debug(msg=msg)
-    elif lvl == LoggingLevel.info:
+    elif lvl == LoggingLevel.INFO:
         logger.info(msg=msg)
-    elif lvl == LoggingLevel.warning:
+    elif lvl == LoggingLevel.WARNING:
         logger.warning(msg=msg)
-    elif lvl == LoggingLevel.error:
+    elif lvl == LoggingLevel.ERROR:
         logger.error(msg=msg)
-    elif lvl == LoggingLevel.critical:
+    elif lvl == LoggingLevel.CRITICAL:
         logger.critical(msg=msg)
     else:
         pass
@@ -52,7 +85,7 @@ def log_and_raise(message: str, error_type: Type[Exception]):
     error_type : Exception
         The error type to raise.
     """
-    cprint(message, lvl="error")
+    cprint(message, lvl=LoggingLevel.ERROR)
     raise error_type(message)
 
 
@@ -67,5 +100,5 @@ def log_and_warn(message: str, warning_type: Type[Warning]):
     warning_type : Warning
         The warning type to use.
     """
-    cprint(message, lvl="warning")
+    cprint(message, lvl=LoggingLevel.WARNING)
     warnings.warn(message, warning_type)

--- a/test/unittests/utils/test_stream.py
+++ b/test/unittests/utils/test_stream.py
@@ -1,0 +1,73 @@
+from typing import Type
+
+import pytest
+
+from clinica.utils.exceptions import ClinicaMissingDependencyError
+from clinica.utils.stream import LoggingLevel
+
+
+@pytest.mark.parametrize(
+    "level,expected",
+    [
+        ("debug", LoggingLevel.DEBUG),
+        ("info", LoggingLevel.INFO),
+        ("warning", LoggingLevel.WARNING),
+        ("error", LoggingLevel.ERROR),
+        ("critical", LoggingLevel.CRITICAL),
+        (1, LoggingLevel.DEBUG),
+        (2, LoggingLevel.INFO),
+        (3, LoggingLevel.WARNING),
+        (4, LoggingLevel.ERROR),
+        (5, LoggingLevel.CRITICAL),
+    ],
+)
+def test_get_logging_level(level, expected):
+    from clinica.utils.stream import get_logging_level
+
+    assert get_logging_level(level) == expected
+
+
+def test_get_logging_level_error():
+    from clinica.utils.stream import get_logging_level
+
+    with pytest.raises(
+        ValueError,
+        match="Logging level foo is not valid.",
+    ):
+        get_logging_level("foo")
+
+
+@pytest.mark.parametrize(
+    "message,error_type",
+    [
+        ("foo bar error", FileNotFoundError),
+        ("bar baz error", RuntimeError),
+        ("missing dependency", ClinicaMissingDependencyError),
+    ],
+)
+def test_log_and_raise(message: str, error_type: Type[Exception]):
+    from clinica.utils.stream import log_and_raise
+
+    with pytest.raises(
+        error_type,
+        match=message,
+    ):
+        log_and_raise(message, error_type)
+
+
+@pytest.mark.parametrize(
+    "message,warning_type",
+    [
+        ("foo bar warning", UserWarning),
+        ("bar baz warning", DeprecationWarning),
+        ("warning", FutureWarning),
+    ],
+)
+def test_log_and_warn(message: str, warning_type: Type[Warning]):
+    from clinica.utils.stream import log_and_warn
+
+    with pytest.warns(
+        warning_type,
+        match=message,
+    ):
+        log_and_warn(message, warning_type)


### PR DESCRIPTION
The enumeration `LoggingLevel` is currently implemented as an `StrEnum` which does not reflect the ordering of the different levels. For example, we expect to be able to do things like:

```python
level = LoggingLevel.INFO
if level < LoggingLevel.ERROR:
    # do something
```

This PR proposes to implement `LoggingLevel` as an `IntEnum`. It also adds some unit tests for the functions of the `clinica.utils.stream` module.