### PR TITLE
[FIX] Handle string and integer logging levels in `cprint`

### DIFF
--- a/clinica/utils/stream.py
+++ b/clinica/utils/stream.py
@@ -56,10 +56,9 @@ def cprint(msg: str, lvl: Optional[Union[str, int, LoggingLevel]] = None) -> Non
     from logging import getLogger
 
     lvl = lvl or LoggingLevel.INFO
-    # Use the package level logger.
+    lvl = get_logging_level(lvl)
     logger = getLogger("clinica")
 
-    # Log message as info level.
     if lvl == LoggingLevel.DEBUG:
         logger.debug(msg=msg)
     elif lvl == LoggingLevel.INFO:


### PR DESCRIPTION
Fix bug introduced recently in #1267 

When the logging level is passed as a string or an integer to `cprint`, it needs to be converted to the corresponding `LoggingLevel`.
The call to `get_logging_level` was just missing and all calls to `cprint` with a string or integer level were ignored.