### PR TITLE
[TEST] Skip statistic-surface test

### DIFF
--- a/test/nonregression/pipelines/test_run_pipelines_stats.py
+++ b/test/nonregression/pipelines/test_run_pipelines_stats.py
@@ -16,6 +16,7 @@ warnings.filterwarnings("ignore")
 
 
 @pytest.mark.fast
+@pytest.mark.skip(reason="Brainstat is not compatible with Numpy 2.")
 def test_statistics_surface(cmdopt, tmp_path):
     base_dir = Path(cmdopt["input"])
     working_dir = Path(cmdopt["wd"])


### PR DESCRIPTION
Related to #1269 

This PR proposes to skip the currently broken non regression test for the statistics-surface pipeline while we decide which way to go with `brainstat` and our implementation of this pipeline.