### PR TITLE
[TEST] Temporarily skip non regression test for `ixi-to-bids`

### DIFF
--- a/test/nonregression/iotools/test_run_converters.py
+++ b/test/nonregression/iotools/test_run_converters.py
@@ -15,6 +15,10 @@ from clinica.iotools.bids_utils import StudyName
 def test_converters(cmdopt, tmp_path, study: StudyName):
     from clinica.iotools.converters.factory import convert, get_converter_name
 
+    # To be removed once we have built and deployed our testing dataset
+    if study == StudyName.IXI:
+        pytest.skip("Non regression tests are not yet implemented for ixi-to-bids.")
+
     base_dir = Path(cmdopt["input"])
     input_dir, tmp_dir, ref_dir = configure_paths(
         base_dir, tmp_path, get_converter_name(study)


### PR DESCRIPTION
PR #1239 added a new converter named `ixi-to-bids` and added its name to the enumeration of converter names.
Because of this, there is currently a non regression test failing for this converter. It fails for a good reason though: we haven't built the test dataset yet so there is no data in the location expected by the test.

This PR proposes to temporarily skip the test for `ixi-to-bids` while #1273 is finished. It will avoid having the converter test suite marked with the nasty red cross of failure.