### PR TITLE
[ENH]  Allow the T1-Linear pipeline to go over (subject, session) couples that do not have data

### DIFF
--- a/clinica/pipelines/anatomical/freesurfer/atlas/pipeline.py
+++ b/clinica/pipelines/anatomical/freesurfer/atlas/pipeline.py
@@ -81,10 +81,16 @@ class T1FreeSurferAtlas(Pipeline):
                     - set(t1_freesurfer_longitudinal_output_atlas)
                 )
                 t1_freesurfer_output, _ = clinica_file_reader(
-                    subjects, sessions, caps_directory, T1_FS_DESTRIEUX, False
+                    subjects,
+                    sessions,
+                    caps_directory,
+                    T1_FS_DESTRIEUX,
                 )
                 t1_freesurfer_files, _ = clinica_file_reader(
-                    subjects, sessions, caps_directory, atlas_info, False
+                    subjects,
+                    sessions,
+                    caps_directory,
+                    atlas_info,
                 )
                 image_ids = extract_image_ids(t1_freesurfer_files)
                 image_ids_2 = extract_image_ids(t1_freesurfer_output)

--- a/clinica/pipelines/anatomical/freesurfer/longitudinal/correction/pipeline.py
+++ b/clinica/pipelines/anatomical/freesurfer/longitudinal/correction/pipeline.py
@@ -60,7 +60,10 @@ class T1FreeSurferLongitudinalCorrection(Pipeline):
         )
         from clinica.utils.exceptions import ClinicaException
         from clinica.utils.input_files import T1_FS_DESTRIEUX, T1_FS_T_DESTRIEUX
-        from clinica.utils.inputs import _format_errors, clinica_file_reader
+        from clinica.utils.inputs import (
+            clinica_file_reader,
+            format_clinica_file_reader_errors,
+        )
         from clinica.utils.stream import cprint
 
         from .utils import (
@@ -128,7 +131,7 @@ class T1FreeSurferLongitudinalCorrection(Pipeline):
         if any(all_errors):
             message = "Clinica faced errors while trying to read files in your CAPS directory.\n"
             for error, info in zip(all_errors, [T1_FS_DESTRIEUX, T1_FS_T_DESTRIEUX]):
-                message += _format_errors(error, info)
+                message += format_clinica_file_reader_errors(error, info)
             raise ClinicaException(message)
 
         save_part_sess_long_ids_to_tsv(

--- a/clinica/pipelines/anatomical/freesurfer/longitudinal/correction/pipeline.py
+++ b/clinica/pipelines/anatomical/freesurfer/longitudinal/correction/pipeline.py
@@ -60,7 +60,7 @@ class T1FreeSurferLongitudinalCorrection(Pipeline):
         )
         from clinica.utils.exceptions import ClinicaException
         from clinica.utils.input_files import T1_FS_DESTRIEUX, T1_FS_T_DESTRIEUX
-        from clinica.utils.inputs import clinica_file_reader
+        from clinica.utils.inputs import _format_errors, clinica_file_reader
         from clinica.utils.stream import cprint
 
         from .utils import (
@@ -117,26 +117,19 @@ class T1FreeSurferLongitudinalCorrection(Pipeline):
                     to_process_ids
                 )
 
-        all_errors = []
-        try:
-            # Check that t1-freesurfer has run on the CAPS directory
-            clinica_file_reader(
-                self.subjects, self.sessions, self.caps_directory, T1_FS_DESTRIEUX
-            )
-        except ClinicaException as e:
-            all_errors.append(e)
-        try:
-            # Check that t1-freesurfer-template has run on the CAPS directory
-            clinica_file_reader(
-                self.subjects, list_long_id, self.caps_directory, T1_FS_T_DESTRIEUX
-            )
-        except ClinicaException as e:
-            all_errors.append(e)
-        if len(all_errors) > 0:
-            error_message = "Clinica faced errors while trying to read files in your CAPS directory.\n"
-            for msg in all_errors:
-                error_message += str(msg)
-            raise ClinicaException(error_message)
+        _, errors_destrieux = clinica_file_reader(
+            self.subjects, self.sessions, self.caps_directory, T1_FS_DESTRIEUX
+        )
+        _, errors_t_destrieux = clinica_file_reader(
+            self.subjects, list_long_id, self.caps_directory, T1_FS_T_DESTRIEUX
+        )
+        all_errors = [errors_destrieux, errors_t_destrieux]
+
+        if any(all_errors):
+            message = "Clinica faced errors while trying to read files in your CAPS directory.\n"
+            for error, info in zip(all_errors, [T1_FS_DESTRIEUX, T1_FS_T_DESTRIEUX]):
+                message += _format_errors(error, info)
+            raise ClinicaException(message)
 
         save_part_sess_long_ids_to_tsv(
             self.subjects, self.sessions, list_long_id, self.base_dir / self.name

--- a/clinica/pipelines/anatomical/freesurfer/longitudinal/template/pipeline.py
+++ b/clinica/pipelines/anatomical/freesurfer/longitudinal/template/pipeline.py
@@ -32,11 +32,7 @@ class T1FreeSurferTemplate(Pipeline):
         image_ids: List[str] = []
         if caps_directory.is_dir():
             t1_freesurfer_files, _ = clinica_file_reader(
-                list_participant_id,
-                list_long_id,
-                caps_directory,
-                T1_FS_T_DESTRIEUX,
-                False,
+                list_participant_id, list_long_id, caps_directory, T1_FS_T_DESTRIEUX
             )
             image_ids = [
                 re.search(r"(sub-[a-zA-Z0-9]+)_(long-[a-zA-Z0-9]+)", file).group()
@@ -95,7 +91,7 @@ class T1FreeSurferTemplate(Pipeline):
         from clinica.utils.exceptions import ClinicaCAPSError, ClinicaException
         from clinica.utils.filemanip import extract_subjects_sessions_from_filename
         from clinica.utils.input_files import T1_FS_DESTRIEUX
-        from clinica.utils.inputs import clinica_file_reader
+        from clinica.utils.inputs import clinica_file_filter
         from clinica.utils.longitudinal import (
             get_long_id,
             get_participants_long_id,
@@ -153,16 +149,10 @@ class T1FreeSurferTemplate(Pipeline):
                 self.subjects, self.sessions = extract_subjects_sessions_from_filename(
                     to_process_ids
                 )
-        try:
-            clinica_file_reader(
-                self.subjects, self.sessions, self.caps_directory, T1_FS_DESTRIEUX
-            )
-        except ClinicaException as e:
-            err_msg = (
-                "Clinica faced error(s) while trying to read files in your CAPS directory.\n"
-                + str(e)
-            )
-            raise ClinicaCAPSError(err_msg)
+
+        _, self.subjects, self.sessions = clinica_file_filter(
+            self.subjects, self.sessions, self.caps_directory, T1_FS_DESTRIEUX
+        )
 
         long_ids = get_participants_long_id(self.subjects, self.sessions)
         save_part_sess_long_ids_to_tsv(

--- a/clinica/pipelines/anatomical/freesurfer/t1/pipeline.py
+++ b/clinica/pipelines/anatomical/freesurfer/t1/pipeline.py
@@ -27,7 +27,7 @@ class T1FreeSurfer(Pipeline):
         image_ids: List[str] = []
         if caps_directory.is_dir():
             t1_freesurfer_files, _ = clinica_file_reader(
-                subjects, sessions, caps_directory, T1_FS_DESTRIEUX, False
+                subjects, sessions, caps_directory, T1_FS_DESTRIEUX
             )
             image_ids = extract_image_ids(t1_freesurfer_files)
         return image_ids
@@ -97,7 +97,7 @@ class T1FreeSurfer(Pipeline):
             save_participants_sessions,
         )
         from clinica.utils.input_files import T1W_NII
-        from clinica.utils.inputs import clinica_file_reader
+        from clinica.utils.inputs import clinica_file_filter
         from clinica.utils.stream import cprint
         from clinica.utils.ux import print_images_to_process
 
@@ -130,16 +130,9 @@ class T1FreeSurfer(Pipeline):
                     to_process_ids
                 )
 
-        t1w_files, error_message = clinica_file_reader(
-            self.subjects,
-            self.sessions,
-            self.bids_directory,
-            T1W_NII,
-            raise_exception=False,
+        t1w_files, self.subjects, self.sessions = clinica_file_filter(
+            self.subjects, self.sessions, self.bids_directory, T1W_NII
         )
-
-        if error_message:
-            cprint(error_message, lvl="warning")
 
         if not t1w_files:
             raise ClinicaException("Empty dataset or already processed")

--- a/clinica/pipelines/dwi/preprocessing/fmap/pipeline.py
+++ b/clinica/pipelines/dwi/preprocessing/fmap/pipeline.py
@@ -36,7 +36,7 @@ class DwiPreprocessingUsingPhaseDiffFMap(DWIPreprocessingPipeline):
         image_ids: List[str] = []
         if caps_directory.is_dir():
             preproc_files, _ = clinica_file_reader(
-                subjects, sessions, caps_directory, DWI_PREPROC_NII, False
+                subjects, sessions, caps_directory, DWI_PREPROC_NII
             )
             image_ids = extract_image_ids(preproc_files)
         return image_ids

--- a/clinica/pipelines/dwi/preprocessing/t1/pipeline.py
+++ b/clinica/pipelines/dwi/preprocessing/t1/pipeline.py
@@ -40,7 +40,7 @@ class DwiPreprocessingUsingT1(DWIPreprocessingPipeline):
         image_ids: List[str] = []
         if caps_directory.is_dir():
             preproc_files, _ = clinica_file_reader(
-                subjects, sessions, caps_directory, DWI_PREPROC_NII, False
+                subjects, sessions, caps_directory, DWI_PREPROC_NII
             )
             image_ids = extract_image_ids(preproc_files)
         return image_ids

--- a/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
+++ b/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
@@ -63,7 +63,11 @@ class SpatialSVM(Pipeline):
             pet_volume_normalized_suvr_pet,
             t1_volume_final_group_template,
         )
-        from clinica.utils.inputs import clinica_file_reader, clinica_group_reader
+        from clinica.utils.inputs import (
+            _format_errors,
+            clinica_file_reader,
+            clinica_group_reader,
+        )
         from clinica.utils.ux import print_groups_in_caps_directory
 
         if not (
@@ -118,15 +122,13 @@ class SpatialSVM(Pipeline):
                 f"Image type {self.parameters['orig_input_data_ml']} unknown."
             )
 
-        try:
-            input_image, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                caps_files_information,
-            )
-        except ClinicaException as e:
-            all_errors.append(e)
+        input_image, caps_error = clinica_file_reader(
+            self.subjects,
+            self.sessions,
+            self.caps_directory,
+            caps_files_information,
+        )
+        all_errors.append(_format_errors(caps_error, caps_files_information))
 
         try:
             dartel_input = clinica_group_reader(
@@ -137,7 +139,7 @@ class SpatialSVM(Pipeline):
             all_errors.append(e)
 
         # Raise all errors if some happened
-        if len(all_errors) > 0:
+        if any(all_errors):
             error_message = "Clinica faced errors while trying to read files in your CAPS directories.\n"
             for msg in all_errors:
                 error_message += str(msg)

--- a/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
+++ b/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
@@ -64,9 +64,9 @@ class SpatialSVM(Pipeline):
             t1_volume_final_group_template,
         )
         from clinica.utils.inputs import (
-            _format_errors,
             clinica_file_reader,
             clinica_group_reader,
+            format_clinica_file_reader_errors,
         )
         from clinica.utils.ux import print_groups_in_caps_directory
 
@@ -129,7 +129,9 @@ class SpatialSVM(Pipeline):
             caps_files_information,
         )
         if caps_error:
-            all_errors.append(_format_errors(caps_error, caps_files_information))
+            all_errors.append(
+                format_clinica_file_reader_errors(caps_error, caps_files_information)
+            )
 
         try:
             dartel_input = clinica_group_reader(

--- a/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
+++ b/clinica/pipelines/machine_learning_spatial_svm/spatial_svm_pipeline.py
@@ -128,7 +128,8 @@ class SpatialSVM(Pipeline):
             self.caps_directory,
             caps_files_information,
         )
-        all_errors.append(_format_errors(caps_error, caps_files_information))
+        if caps_error:
+            all_errors.append(_format_errors(caps_error, caps_files_information))
 
         try:
             dartel_input = clinica_group_reader(

--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -67,7 +67,7 @@ class PETLinear(PETPipeline):
         )
         from clinica.utils.image import get_mni_template
         from clinica.utils.input_files import T1W_NII, T1W_TO_MNI_TRANSFORM
-        from clinica.utils.inputs import clinica_file_reader
+        from clinica.utils.inputs import _format_errors, clinica_file_reader
         from clinica.utils.stream import cprint
         from clinica.utils.ux import print_images_to_process
 
@@ -75,44 +75,33 @@ class PETLinear(PETPipeline):
         self.ref_mask = get_suvr_mask(self.parameters["suvr_reference_region"])
 
         # Inputs from BIDS directory
-        try:
-            pet_files, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.bids_directory,
-                self._get_pet_scans_query(),
+        pet_files, pet_errors = clinica_file_reader(
+            self.subjects,
+            self.sessions,
+            self.bids_directory,
+            self._get_pet_scans_query(),
+        )
+        if pet_errors:
+            raise ClinicaBIDSError(
+                _format_errors(pet_errors, self._get_pet_scans_query())
             )
-        except ClinicaException as e:
-            err = (
-                "Clinica faced error(s) while trying to read pet files in your BIDS directory.\n"
-                + str(e)
-            )
-            raise ClinicaBIDSError(err)
 
         # T1w file:
-        try:
-            t1w_files, _ = clinica_file_reader(
-                self.subjects, self.sessions, self.bids_directory, T1W_NII
-            )
-        except ClinicaException as e:
-            err = (
-                "Clinica faced error(s) while trying to read t1w files in your BIDS directory.\n"
-                + str(e)
-            )
-            raise ClinicaBIDSError(err)
+        t1w_files, t1w_errors = clinica_file_reader(
+            self.subjects, self.sessions, self.bids_directory, T1W_NII
+        )
+        if t1w_errors:
+            raise ClinicaBIDSError(_format_errors(t1w_errors, T1W_NII))
 
         # Inputs from t1-linear pipeline
         # Transformation files from T1w files to MNI:
-        try:
-            t1w_to_mni_transformation_files, _ = clinica_file_reader(
-                self.subjects, self.sessions, self.caps_directory, T1W_TO_MNI_TRANSFORM
+        t1w_to_mni_transformation_files, t1w_to_mni_errors = clinica_file_reader(
+            self.subjects, self.sessions, self.caps_directory, T1W_TO_MNI_TRANSFORM
+        )
+        if t1w_to_mni_errors:
+            raise ClinicaCAPSError(
+                _format_errors(t1w_to_mni_errors, T1W_TO_MNI_TRANSFORM)
             )
-        except ClinicaException as e:
-            err = (
-                "Clinica faced error(s) while trying to read transformation files in your CAPS directory.\n"
-                + str(e)
-            )
-            raise ClinicaCAPSError(err)
 
         if len(self.subjects):
             print_images_to_process(self.subjects, self.sessions)

--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -67,7 +67,10 @@ class PETLinear(PETPipeline):
         )
         from clinica.utils.image import get_mni_template
         from clinica.utils.input_files import T1W_NII, T1W_TO_MNI_TRANSFORM
-        from clinica.utils.inputs import _format_errors, clinica_file_reader
+        from clinica.utils.inputs import (
+            clinica_file_reader,
+            format_clinica_file_reader_errors,
+        )
         from clinica.utils.stream import cprint
         from clinica.utils.ux import print_images_to_process
 
@@ -83,7 +86,9 @@ class PETLinear(PETPipeline):
         )
         if pet_errors:
             raise ClinicaBIDSError(
-                _format_errors(pet_errors, self._get_pet_scans_query())
+                format_clinica_file_reader_errors(
+                    pet_errors, self._get_pet_scans_query()
+                )
             )
 
         # T1w file:
@@ -91,7 +96,9 @@ class PETLinear(PETPipeline):
             self.subjects, self.sessions, self.bids_directory, T1W_NII
         )
         if t1w_errors:
-            raise ClinicaBIDSError(_format_errors(t1w_errors, T1W_NII))
+            raise ClinicaBIDSError(
+                format_clinica_file_reader_errors(t1w_errors, T1W_NII)
+            )
 
         # Inputs from t1-linear pipeline
         # Transformation files from T1w files to MNI:
@@ -100,7 +107,9 @@ class PETLinear(PETPipeline):
         )
         if t1w_to_mni_errors:
             raise ClinicaCAPSError(
-                _format_errors(t1w_to_mni_errors, T1W_TO_MNI_TRANSFORM)
+                format_clinica_file_reader_errors(
+                    t1w_to_mni_errors, T1W_TO_MNI_TRANSFORM
+                )
             )
 
         if len(self.subjects):

--- a/clinica/pipelines/pet/volume/pipeline.py
+++ b/clinica/pipelines/pet/volume/pipeline.py
@@ -98,10 +98,10 @@ class PETVolume(PETPipeline):
             t1_volume_native_tpm_in_mni,
         )
         from clinica.utils.inputs import (
-            _format_errors,
             clinica_file_reader,
             clinica_group_reader,
             clinica_list_of_files_reader,
+            format_clinica_file_reader_errors,
         )
         from clinica.utils.stream import cprint
         from clinica.utils.ux import (
@@ -174,7 +174,7 @@ class PETVolume(PETPipeline):
         )
         if flowfields_errors:
             all_errors.append(
-                _format_errors(
+                format_clinica_file_reader_errors(
                     flowfields_errors,
                     t1_volume_deformation_to_template(self.parameters["group_label"]),
                 )

--- a/clinica/pipelines/pet_surface/pet_surface_pipeline.py
+++ b/clinica/pipelines/pet_surface/pet_surface_pipeline.py
@@ -78,9 +78,9 @@ class PetSurface(PETPipeline):
         )
         from clinica.utils.exceptions import ClinicaException
         from clinica.utils.inputs import (
-            _format_errors,
             clinica_file_reader,
             clinica_list_of_files_reader,
+            format_clinica_file_reader_errors,
         )
 
         read_parameters_node = npe.Node(
@@ -100,7 +100,7 @@ class PetSurface(PETPipeline):
             self._get_pet_scans_query(),
         )
         if pet_errors:
-            all_errors.append(_format_errors(pet_errors))
+            all_errors.append(format_clinica_file_reader_errors(pet_errors))
 
         try:
             (
@@ -170,9 +170,9 @@ class PetSurface(PETPipeline):
         )
         from clinica.utils.exceptions import ClinicaException
         from clinica.utils.inputs import (
-            _format_errors,
             clinica_file_reader,
             clinica_list_of_files_reader,
+            format_clinica_file_reader_errors,
         )
 
         read_parameters_node = npe.Node(
@@ -191,7 +191,7 @@ class PetSurface(PETPipeline):
             self._get_pet_scans_query(),
         )
         if pet_errors:
-            all_errors.append(_format_errors(pet_errors))
+            all_errors.append(format_clinica_file_reader_errors(pet_errors))
 
         try:
             (

--- a/clinica/pipelines/pet_surface/pet_surface_pipeline.py
+++ b/clinica/pipelines/pet_surface/pet_surface_pipeline.py
@@ -77,7 +77,11 @@ class PetSurface(PETPipeline):
             check_relative_volume_location_in_world_coordinate_system,
         )
         from clinica.utils.exceptions import ClinicaException
-        from clinica.utils.inputs import clinica_file_reader
+        from clinica.utils.inputs import (
+            _format_errors,
+            clinica_file_reader,
+            clinica_list_of_files_reader,
+        )
 
         read_parameters_node = npe.Node(
             name="LoadingCLIArguments",
@@ -88,93 +92,44 @@ class PetSurface(PETPipeline):
         )
 
         all_errors = []
-        try:
-            read_parameters_node.inputs.pet, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.bids_directory,
-                self._get_pet_scans_query(),
-            )
-        except ClinicaException as e:
-            all_errors.append(e)
+
+        read_parameters_node.inputs.pet, pet_errors = clinica_file_reader(
+            self.subjects,
+            self.sessions,
+            self.bids_directory,
+            self._get_pet_scans_query(),
+        )
+        if pet_errors:
+            all_errors.append(_format_errors(pet_errors))
 
         try:
-            read_parameters_node.inputs.orig_nu, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                input_files.T1_FS_LONG_ORIG_NU,
-            )
-
-        except ClinicaException as e:
-            all_errors.append(e)
-
-        try:
-            read_parameters_node.inputs.white_surface_right, _ = clinica_file_reader(
+            (
+                read_parameters_node.inputs.orig_nu,
+                read_parameters_node.inputs.white_surface_right,
+                read_parameters_node.inputs.white_surface_left,
+                read_parameters_node.inputs.destrieux_left,
+                read_parameters_node.inputs.destrieux_right,
+                read_parameters_node.inputs.desikan_left,
+                read_parameters_node.inputs.desikan_right,
+            ) = clinica_list_of_files_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
-                input_files.T1_FS_LONG_SURF_R,
-            )
-        except ClinicaException as e:
-            all_errors.append(e)
-
-        try:
-            read_parameters_node.inputs.white_surface_left, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                input_files.T1_FS_LONG_SURF_L,
+                [
+                    input_files.T1_FS_LONG_ORIG_NU,
+                    input_files.T1_FS_LONG_SURF_R,
+                    input_files.T1_FS_LONG_SURF_L,
+                    input_files.T1_FS_LONG_DESTRIEUX_PARC_L,
+                    input_files.T1_FS_LONG_DESTRIEUX_PARC_R,
+                    input_files.T1_FS_LONG_DESIKAN_PARC_L,
+                    input_files.T1_FS_LONG_DESIKAN_PARC_R,
+                ],
             )
 
         except ClinicaException as e:
             all_errors.append(e)
 
-        try:
-            read_parameters_node.inputs.destrieux_left, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                input_files.T1_FS_LONG_DESTRIEUX_PARC_L,
-            )
-
-        except ClinicaException as e:
-            all_errors.append(e)
-
-        try:
-            read_parameters_node.inputs.destrieux_right, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                input_files.T1_FS_LONG_DESTRIEUX_PARC_R,
-            )
-
-        except ClinicaException as e:
-            all_errors.append(e)
-
-        try:
-            read_parameters_node.inputs.desikan_left, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                input_files.T1_FS_LONG_DESIKAN_PARC_L,
-            )
-
-        except ClinicaException as e:
-            all_errors.append(e)
-
-        try:
-            read_parameters_node.inputs.desikan_right, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                input_files.T1_FS_LONG_DESIKAN_PARC_R,
-            )
-
-        except ClinicaException as e:
-            all_errors.append(e)
-
-        if len(all_errors) > 0:
+        if any(all_errors):
             error_message = "Clinica faced errors while trying to read files in your BIDS or CAPS directories.\n"
             for msg in all_errors:
                 error_message += str(msg)
@@ -214,7 +169,11 @@ class PetSurface(PETPipeline):
             check_relative_volume_location_in_world_coordinate_system,
         )
         from clinica.utils.exceptions import ClinicaException
-        from clinica.utils.inputs import clinica_file_reader
+        from clinica.utils.inputs import (
+            _format_errors,
+            clinica_file_reader,
+            clinica_list_of_files_reader,
+        )
 
         read_parameters_node = npe.Node(
             name="LoadingCLIArguments",
@@ -225,87 +184,42 @@ class PetSurface(PETPipeline):
         )
 
         all_errors = []
-        try:
-            read_parameters_node.inputs.pet, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.bids_directory,
-                self._get_pet_scans_query(),
-            )
-        except ClinicaException as e:
-            all_errors.append(e)
+        read_parameters_node.inputs.pet, pet_errors = clinica_file_reader(
+            self.subjects,
+            self.sessions,
+            self.bids_directory,
+            self._get_pet_scans_query(),
+        )
+        if pet_errors:
+            all_errors.append(_format_errors(pet_errors))
 
         try:
-            read_parameters_node.inputs.orig_nu, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                input_files.T1_FS_ORIG_NU,
-            )
-        except ClinicaException as e:
-            all_errors.append(e)
-
-        try:
-            read_parameters_node.inputs.white_surface_right, _ = clinica_file_reader(
+            (
+                read_parameters_node.inputs.orig_nu,
+                read_parameters_node.inputs.white_surface_right,
+                read_parameters_node.inputs.white_surface_left,
+                read_parameters_node.inputs.destrieux_left,
+                read_parameters_node.inputs.destrieux_right,
+                read_parameters_node.inputs.desikan_left,
+                read_parameters_node.inputs.desikan_right,
+            ) = clinica_list_of_files_reader(
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
-                input_files.T1_FS_WM_SURF_R,
+                [
+                    input_files.T1_FS_ORIG_NU,
+                    input_files.T1_FS_WM_SURF_R,
+                    input_files.T1_FS_WM_SURF_L,
+                    input_files.T1_FS_DESTRIEUX_PARC_L,
+                    input_files.T1_FS_DESTRIEUX_PARC_R,
+                    input_files.T1_FS_DESIKAN_PARC_L,
+                    input_files.T1_FS_DESIKAN_PARC_R,
+                ],
             )
         except ClinicaException as e:
             all_errors.append(e)
 
-        try:
-            read_parameters_node.inputs.white_surface_left, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                input_files.T1_FS_WM_SURF_L,
-            )
-        except ClinicaException as e:
-            all_errors.append(e)
-
-        try:
-            read_parameters_node.inputs.destrieux_left, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                input_files.T1_FS_DESTRIEUX_PARC_L,
-            )
-        except ClinicaException as e:
-            all_errors.append(e)
-
-        try:
-            read_parameters_node.inputs.destrieux_right, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                input_files.T1_FS_DESTRIEUX_PARC_R,
-            )
-        except ClinicaException as e:
-            all_errors.append(e)
-
-        try:
-            read_parameters_node.inputs.desikan_left, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                input_files.T1_FS_DESIKAN_PARC_L,
-            )
-        except ClinicaException as e:
-            all_errors.append(e)
-
-        try:
-            read_parameters_node.inputs.desikan_right, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                input_files.T1_FS_DESIKAN_PARC_R,
-            )
-        except ClinicaException as e:
-            all_errors.append(e)
-
-        if len(all_errors) > 0:
+        if any(all_errors):
             error_message = "Clinica faced errors while trying to read files in your BIDS or CAPS directories.\n"
             for msg in all_errors:
                 error_message += str(msg)

--- a/clinica/pipelines/statistics_surface/pipeline.py
+++ b/clinica/pipelines/statistics_surface/pipeline.py
@@ -114,7 +114,7 @@ class StatisticsSurface(Pipeline):
     def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
         from clinica.utils.exceptions import ClinicaException
-        from clinica.utils.inputs import clinica_file_reader
+        from clinica.utils.inputs import clinica_list_of_files_reader
 
         # Check if already present in CAPS
         # ================================
@@ -133,7 +133,7 @@ class StatisticsSurface(Pipeline):
             )
 
         # Check input files
-        all_errors = []
+        surface_query = []
         # clinica_files_reader expects regexp to start at subjects/ so sub-*/ses-*/ is removed here
         fwhm = str(self.parameters["full_width_at_half_maximum"])
         for direction, hemi in zip(["left", "right"], ["lh", "rh"]):
@@ -146,21 +146,16 @@ class StatisticsSurface(Pipeline):
                 ],
                 "description": f"surface-based features on {direction} hemisphere at FWHM = {fwhm}",
             }
-            try:
-                clinica_file_reader(
-                    self.subjects,
-                    self.sessions,
-                    self.caps_directory,
-                    surface_based_info,
-                )
-            except ClinicaException as e:
-                all_errors.append(e)
-
-        if len(all_errors) > 0:
-            error_message = "Clinica faced errors while trying to read files in your CAPS directory.\n"
-            for msg in all_errors:
-                error_message += str(msg)
-            raise RuntimeError(error_message)
+            surface_query.append(surface_based_info)
+        try:
+            clinica_list_of_files_reader(
+                self.subjects,
+                self.sessions,
+                self.caps_directory,
+                surface_query,
+            )
+        except ClinicaException as e:
+            raise RuntimeError(e)
 
     def _build_output_node(self):
         """Build and connect an output node to the pipeline."""

--- a/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
+++ b/clinica/pipelines/statistics_volume/statistics_volume_pipeline.py
@@ -100,11 +100,10 @@ class StatisticsVolume(Pipeline):
             pet_volume_normalized_suvr_pet,
             t1_volume_template_tpm_in_mni,
         )
-        from clinica.utils.inputs import clinica_file_reader
+        from clinica.utils.inputs import clinica_file_filter
         from clinica.utils.stream import cprint
         from clinica.utils.ux import print_begin_image, print_images_to_process
 
-        all_errors = []
         if self.parameters["orig_input_data_volume"] == "pet-volume":
             if not (
                 self.parameters["acq_label"]
@@ -151,18 +150,9 @@ class StatisticsVolume(Pipeline):
                 f"Input data {self.parameters['orig_input_data_volume']} unknown."
             )
 
-        try:
-            input_files, _ = clinica_file_reader(
-                self.subjects, self.sessions, self.caps_directory, information_dict
-            )
-        except ClinicaException as e:
-            all_errors.append(e)
-
-        if len(all_errors) > 0:
-            error_message = "Clinica faced errors while trying to read files in your CAPS directories.\n"
-            for msg in all_errors:
-                error_message += str(msg)
-            raise ClinicaException(error_message)
+        input_files, self.subjects, self.sessions = clinica_file_filter(
+            self.subjects, self.sessions, self.caps_directory, information_dict
+        )
 
         read_parameters_node = npe.Node(
             name="LoadingCLIArguments",

--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -154,9 +154,11 @@ class AnatLinear(Pipeline):
         # anat image file:
         query = T1W_NII if self.name == "t1-linear" else Flair_T2W_NII
 
-        anat_files = clinica_file_filter(
+        anat_files, filtered_subjects, filtered_sessions = clinica_file_filter(
             self.subjects, self.sessions, self.bids_directory, query
         )
+        self.subjects = filtered_subjects
+        self.sessions = filtered_sessions
 
         if len(self.subjects):
             print_images_to_process(self.subjects, self.sessions)

--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -110,7 +110,6 @@ class AnatLinear(Pipeline):
 
     def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
-
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
 
@@ -159,11 +158,10 @@ class AnatLinear(Pipeline):
             self.subjects, self.sessions, self.bids_directory, file
         )
 
-        breakpoint()
-
-        _remove_sub_ses_from_list(self.subjects, self.sessions, wrong_sub_sess)
-
-        breakpoint()
+        if wrong_sub_sess:
+            # todo : message to say which removed
+            # todo : consider get_ + _remove in the same function if used for several pipelines
+            _remove_sub_ses_from_list(self.subjects, self.sessions, wrong_sub_sess)
 
         if len(self.subjects):
             print_images_to_process(self.subjects, self.sessions)

--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -110,7 +110,6 @@ class AnatLinear(Pipeline):
 
     def _build_input_node(self):
         """Build and connect an input node to the pipeline."""
-        import re
 
         import nipype.interfaces.utility as nutil
         import nipype.pipeline.engine as npe
@@ -120,6 +119,7 @@ class AnatLinear(Pipeline):
         from clinica.utils.image import get_mni_template
         from clinica.utils.input_files import T1W_NII, Flair_T2W_NII
         from clinica.utils.inputs import (
+            _remove_sub_ses_from_list,
             clinica_file_reader,
             get_images_and_errors_from_dir,
         )
@@ -159,22 +159,11 @@ class AnatLinear(Pipeline):
             self.subjects, self.sessions, self.bids_directory, file
         )
 
-        # todo : write in other function
-        tuple_subsess = []
-        for subses in wrong_sub_sess:
-            m = re.search(r"(sub-\w*).*(ses-M\d{3})", subses)
-            tuple_subsess += [(m.group(1), m.group(2))]
+        breakpoint()
 
-        for sub, ses in tuple_subsess:
-            sub_indexes = [
-                i for i, subject in enumerate(self.subjects) if subject == sub
-            ]
-            session_indexes = [
-                i for i, session in enumerate(self.sessions) if session == ses
-            ]
-            to_remove = list(set(sub_indexes) & set(session_indexes))[0]
-            self.subjects.pop(to_remove)
-            self.sessions.pop(to_remove)
+        _remove_sub_ses_from_list(self.subjects, self.sessions, wrong_sub_sess)
+
+        breakpoint()
 
         if len(self.subjects):
             print_images_to_process(self.subjects, self.sessions)

--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -75,7 +75,10 @@ class AnatLinear(Pipeline):
         image_ids: List[str] = []
         if caps_directory.is_dir():
             cropped_files, _ = clinica_file_reader(
-                subjects, sessions, caps_directory, T1W_LINEAR_CROPPED, False
+                subjects,
+                sessions,
+                caps_directory,
+                T1W_LINEAR_CROPPED,
             )
             image_ids = extract_image_ids(cropped_files)
         return image_ids
@@ -117,11 +120,7 @@ class AnatLinear(Pipeline):
         from clinica.utils.filemanip import extract_subjects_sessions_from_filename
         from clinica.utils.image import get_mni_template
         from clinica.utils.input_files import T1W_NII, Flair_T2W_NII
-        from clinica.utils.inputs import (
-            _remove_sub_ses_from_list,
-            clinica_file_reader,
-            get_images_and_errors_from_dir,
-        )
+        from clinica.utils.inputs import clinica_file_filter
         from clinica.utils.stream import cprint
         from clinica.utils.ux import print_images_to_process
 
@@ -154,14 +153,11 @@ class AnatLinear(Pipeline):
         # ========================
         # anat image file:
         file = T1W_NII if self.name == "t1-linear" else Flair_T2W_NII
-        anat_files, wrong_sub_sess = get_images_and_errors_from_dir(
+
+        anat_files = clinica_file_filter(
             self.subjects, self.sessions, self.bids_directory, file
         )
-
-        if wrong_sub_sess:
-            # todo : message to say which removed
-            # todo : consider get_ + _remove in the same function if used for several pipelines
-            _remove_sub_ses_from_list(self.subjects, self.sessions, wrong_sub_sess)
+        # todo : what happens if empty self.subjects ?
 
         if len(self.subjects):
             print_images_to_process(self.subjects, self.sessions)

--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -152,12 +152,11 @@ class AnatLinear(Pipeline):
         # Inputs from anat/ folder
         # ========================
         # anat image file:
-        file = T1W_NII if self.name == "t1-linear" else Flair_T2W_NII
+        query = T1W_NII if self.name == "t1-linear" else Flair_T2W_NII
 
         anat_files = clinica_file_filter(
-            self.subjects, self.sessions, self.bids_directory, file
+            self.subjects, self.sessions, self.bids_directory, query
         )
-        # todo : what happens if empty self.subjects ?
 
         if len(self.subjects):
             print_images_to_process(self.subjects, self.sessions)

--- a/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
+++ b/clinica/pipelines/t1_volume_dartel2mni/t1_volume_dartel2mni_pipeline.py
@@ -58,10 +58,10 @@ class T1VolumeDartel2MNI(Pipeline):
             t1_volume_native_tpm,
         )
         from clinica.utils.inputs import (
-            _format_errors,
             clinica_file_reader,
             clinica_group_reader,
             clinica_list_of_files_reader,
+            format_clinica_file_reader_errors,
         )
         from clinica.utils.stream import cprint
         from clinica.utils.ux import (
@@ -117,7 +117,7 @@ class T1VolumeDartel2MNI(Pipeline):
             t1_volume_deformation_to_template(self.parameters["group_label"]),
         )
         if flowfield_errors:
-            all_errors.append(_format_errors(flowfield_errors))
+            all_errors.append(format_clinica_file_reader_errors(flowfield_errors))
 
         # Dartel Template
         # ================

--- a/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
+++ b/clinica/pipelines/t1_volume_parcellation/t1_volume_parcellation_pipeline.py
@@ -51,7 +51,7 @@ class T1VolumeParcellation(Pipeline):
 
         from clinica.utils.exceptions import ClinicaCAPSError, ClinicaException
         from clinica.utils.input_files import t1_volume_template_tpm_in_mni
-        from clinica.utils.inputs import clinica_file_reader
+        from clinica.utils.inputs import clinica_file_filter, clinica_file_reader
         from clinica.utils.stream import cprint
         from clinica.utils.ux import (
             print_groups_in_caps_directory,
@@ -67,21 +67,16 @@ class T1VolumeParcellation(Pipeline):
                 "Did you run t1-volume or t1-volume-create-dartel pipeline?"
             )
 
-        try:
-            gm_mni, _ = clinica_file_reader(
-                self.subjects,
-                self.sessions,
-                self.caps_directory,
-                t1_volume_template_tpm_in_mni(
-                    group_label=self.parameters["group_label"],
-                    tissue_number=1,
-                    modulation=self.parameters["modulate"],
-                ),
-            )
-        except ClinicaException as e:
-            final_error_str = "Clinica faced error(s) while trying to read files in your CAPS directory.\n"
-            final_error_str += str(e)
-            raise ClinicaCAPSError(final_error_str)
+        gm_mni, self.subjects, self.sessions = clinica_file_filter(
+            self.subjects,
+            self.sessions,
+            self.caps_directory,
+            t1_volume_template_tpm_in_mni(
+                group_label=self.parameters["group_label"],
+                tissue_number=1,
+                modulation=self.parameters["modulate"],
+            ),
+        )
 
         read_parameters_node = npe.Node(
             name="LoadingCLIArguments",

--- a/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
+++ b/clinica/pipelines/t1_volume_tissue_segmentation/t1_volume_tissue_segmentation_pipeline.py
@@ -77,20 +77,18 @@ class T1VolumeTissueSegmentation(Pipeline):
         )
         from clinica.utils.exceptions import ClinicaBIDSError, ClinicaException
         from clinica.utils.input_files import T1W_NII
-        from clinica.utils.inputs import clinica_file_reader
+        from clinica.utils.inputs import clinica_file_filter
         from clinica.utils.stream import cprint
         from clinica.utils.ux import print_images_to_process
 
         # Inputs from anat/ folder
         # ========================
         # T1w file:
-        try:
-            t1w_files, _ = clinica_file_reader(
-                self.subjects, self.sessions, self.bids_directory, T1W_NII
-            )
-        except ClinicaException as e:
-            err = f"Clinica faced error(s) while trying to read files in your BIDS directory.\n{str(e)}"
-            raise ClinicaBIDSError(err)
+        t1w_files, subjects, sessions = clinica_file_filter(
+            self.subjects, self.sessions, self.bids_directory, T1W_NII
+        )
+        self.subjects = subjects
+        self.sessions = sessions
 
         check_volume_location_in_world_coordinate_system(
             t1w_files,

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -627,6 +627,7 @@ def _remove_sub_ses_from_list(
     return list_subjects, list_sessions
 
 
+# todo : generalize
 def clinica_file_reader(
     subjects: List[str],
     sessions: List[str],
@@ -825,6 +826,7 @@ def _read_files_sequential(
     return results, errors_encountered
 
 
+# todo : generalize
 def clinica_list_of_files_reader(
     participant_ids: List[str],
     session_ids: List[str],

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -581,6 +581,7 @@ def clinica_file_filter(
         subjects, sessions, input_directory, information, n_procs
     )
     cprint(_format_errors(errors, information), "warning")
+    # todo : dont remove but return filtered
     _remove_sub_ses_from_list(subjects, sessions, errors)
     return files
 
@@ -868,10 +869,11 @@ def clinica_list_of_files_reader(
             bids_or_caps_directory,
             info_file,
         )
-        # todo : should it work like that ?? maybe after change need to filter subject list ?
 
         list_found_files.append(files)
         all_errors += errors
+
+    # todo : _format_errors
 
     if len(all_errors) > 0 and raise_exception:
         error_message = "Clinica faced error(s) while trying to read files in your BIDS or CAPS directory.\n"

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -576,17 +576,17 @@ def clinica_file_filter(
 ) -> List[str]:
     from clinica.utils.stream import cprint
 
+    # todo : test ?
     # todo : typing ?
     files, errors = clinica_file_reader(
         subjects, sessions, input_directory, information, n_procs
     )
-    cprint(_format_errors(errors, information))
+    cprint(_format_errors(errors, information), "warning")
     _remove_sub_ses_from_list(subjects, sessions, errors)
     return files
 
 
 def _format_errors(errors: List[Tuple[str, str]], information: Dict) -> str:
-    # todo : test new
     message = (
         f"Clinica encountered {len(errors)} "
         f"problem(s) while getting {information['description']}:\n"

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -945,6 +945,7 @@ def _format_and_raise_group_reader_errors(
     found_files: List,
     information: Dict,
 ) -> None:
+    # todo : TEST
     from clinica.utils.exceptions import ClinicaCAPSError
 
     error_string = (

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -752,6 +752,7 @@ def clinica_file_reader(
     or even more precise: 't1/freesurfer_cross_sectional/sub-*_ses-*/surf/rh.white'
     It then gives: ['/caps/subjects/sub-ADNI011S4105/ses-M00/t1/freesurfer_cross_sectional/sub-ADNI011S4105_ses-M00/surf/rh.white']
     """
+    # todo : change function description
 
     input_directory = Path(input_directory)
     _check_information(information)
@@ -864,29 +865,26 @@ def clinica_list_of_files_reader(
     list_found_files : List[List[str]]
         List of lists of found files following order of `list_information`
     """
-    from .exceptions import ClinicaBIDSError, ClinicaException
+    from .exceptions import ClinicaBIDSError
 
     all_errors = []
     list_found_files = []
     for info_file in list_information:
-        try:
-            list_found_files.append(
-                clinica_file_reader(
-                    participant_ids,
-                    session_ids,
-                    bids_or_caps_directory,
-                    info_file,
-                    True,
-                )[0]
-            )
-        except ClinicaException as e:
-            list_found_files.append([])
-            all_errors.append(e)
+        files, errors = clinica_file_reader(
+            participant_ids,
+            session_ids,
+            bids_or_caps_directory,
+            info_file,
+        )
+        # todo : should it work like that ?? maybe after change need to filter subject list ?
+
+        list_found_files.append(files)
+        all_errors += errors
 
     if len(all_errors) > 0 and raise_exception:
         error_message = "Clinica faced error(s) while trying to read files in your BIDS or CAPS directory.\n"
-        for msg in all_errors:
-            error_message += str(msg)
+        for error in all_errors:
+            error_message += f"\n\t({error[0]} | {error[1]})"
         raise ClinicaBIDSError(error_message)
 
     return list_found_files

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -604,10 +604,10 @@ def get_images_and_errors_from_dir(
         raise ValueError("Subjects and sessions must have the same length.")
 
     if len(subjects) == 0:
-        return [], ""
+        return [], []
 
     file_reader = _read_files_parallel if n_procs > 1 else _read_files_sequential
-    test = file_reader(
+    return file_reader(
         input_directory,
         subjects,
         sessions,
@@ -615,7 +615,6 @@ def get_images_and_errors_from_dir(
         pattern,
         n_procs=n_procs,
     )
-    return test
 
 
 def _remove_sub_ses_from_list(
@@ -623,6 +622,8 @@ def _remove_sub_ses_from_list(
     list_sessions: List[str],
     wrong_sub_ses: List[Tuple[str, str]],
 ) -> None:
+    # todo : test this !!
+    # todo : message
     for sub, ses in wrong_sub_ses:
         sub_indexes = [i for i, subject in enumerate(list_subjects) if subject == sub]
         session_indexes = [
@@ -785,9 +786,9 @@ def clinica_file_reader(
         n_procs,
     )
 
+    # todo : use of this ??? -> need for _format_errors ?
     if len(errors_encountered) > 0 and raise_exception:
         error_message = _format_errors(errors_encountered, information)
-        # todo : construct error message based on errors_encountered ; might need to modify _format_errors
         if determine_caps_or_bids(input_directory):
             raise ClinicaBIDSError(error_message)
         else:

--- a/clinica/utils/inputs.py
+++ b/clinica/utils/inputs.py
@@ -629,9 +629,12 @@ def _remove_sub_ses_from_list(
         session_indexes = [
             i for i, session in enumerate(list_sessions) if session == ses
         ]
-        to_remove = list(set(sub_indexes) & set(session_indexes))[0]
-        list_subjects.pop(to_remove)
-        list_sessions.pop(to_remove)
+        to_remove = list(set(sub_indexes) & set(session_indexes))
+        if to_remove:
+            if len(to_remove) > 1:
+                raise ValueError("")
+            list_subjects.pop(to_remove[0])
+            list_sessions.pop(to_remove[0])
 
 
 def clinica_file_reader(

--- a/test/unittests/utils/test_utils_inputs.py
+++ b/test/unittests/utils/test_utils_inputs.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from clinica.utils.exceptions import ClinicaBIDSError, ClinicaCAPSError
-from clinica.utils.inputs import DatasetType
+from clinica.utils.inputs import DatasetType, InvalidSubjectSession
 from clinica.utils.testing_utils import (
     build_bids_directory,
     build_caps_directory,
@@ -20,7 +20,10 @@ from clinica.utils.testing_utils import (
         (
             ["sub1", "sub1", "sub2"],
             ["ses1", "ses2", "ses1"],
-            [("sub1", "ses1"), ("sub3", "ses1")],
+            [
+                InvalidSubjectSession("sub1", "ses1"),
+                InvalidSubjectSession("sub3", "ses1"),
+            ],
             ["sub1", "sub2"],
             ["ses2", "ses1"],
         ),
@@ -28,7 +31,7 @@ from clinica.utils.testing_utils import (
         (
             ["sub1", "sub2", "sub2"],
             ["ses1", "ses1", "ses1"],
-            [("sub2", "ses1")],
+            [InvalidSubjectSession("sub2", "ses1")],
             ["sub1"],
             ["ses1"],
         ),
@@ -537,7 +540,11 @@ def test_format_errors():
         "Please note that the following clinica pipeline(s) must have "
         "run to obtain these files: ['pipeline_1', 'pipeline_3']\n"
     )
-    errors = [("sub1", "ses1"), ("sub2", "ses1"), ("sub3", "ses1")]
+    errors = [
+        InvalidSubjectSession("sub1", "ses1"),
+        InvalidSubjectSession("sub2", "ses1"),
+        InvalidSubjectSession("sub3", "ses1"),
+    ]
     assert _format_errors(errors, information) == (
         "Clinica encountered 3 problem(s) while getting foo bar baz:\n"
         "Please note that the following clinica pipeline(s) must have "
@@ -614,7 +621,7 @@ def test_clinica_file_reader_bids_directory(tmp_path, data_type):
         ["sub-01"], ["ses-M00"], tmp_path, information, n_procs=1
     )
     assert len(results) == 0
-    assert errors == [("sub-01", "ses-M00")]
+    assert errors == [InvalidSubjectSession("sub-01", "ses-M00")]
 
 
 def test_clinica_file_reader_caps_directory(tmp_path):
@@ -680,7 +687,7 @@ def test_clinica_file_reader_caps_directory(tmp_path):
         ["sub-01"], ["ses-M00"], tmp_path, information, n_procs=1
     )
     assert len(results) == 0
-    assert errors == [("sub-01", "ses-M00")]
+    assert errors == [InvalidSubjectSession("sub-01", "ses-M00")]
 
 
 def test_clinica_file_reader_dwi_dti_error(tmp_path):
@@ -793,9 +800,7 @@ def test_clinica_list_of_files_reader(tmp_path):
 
     assert len(results) == 2
     assert len(results[0]) == 3
-    assert (
-        len(results[1]) == 2
-    )  # todo : change in behaviour... see what we really want ?
+    assert len(results[1]) == 2
 
 
 def test_clinica_group_reader(tmp_path):

--- a/test/unittests/utils/test_utils_inputs.py
+++ b/test/unittests/utils/test_utils_inputs.py
@@ -16,30 +16,23 @@ from clinica.utils.testing_utils import (
 
 @pytest.mark.parametrize(
     "input_subjects, input_sessions, to_remove, expected_subjects, expected_sessions",
-    (
-        [
+    [
+        (
             ["sub1", "sub1", "sub2"],
             ["ses1", "ses2", "ses1"],
             [("sub1", "ses1"), ("sub3", "ses1")],
             ["sub1", "sub2"],
             ["ses2", "ses1"],
-        ],
-        [
-            [
-                "sub1",
-            ],
-            [
-                "ses1",
-            ],
-            [],
-            [
-                "sub1",
-            ],
-            [
-                "ses1",
-            ],
-        ],
-    ),
+        ),
+        (["sub1"], ["ses1"], [], ["sub1"], ["ses1"]),
+        (
+            ["sub1", "sub2", "sub2"],
+            ["ses1", "ses1", "ses1"],
+            [("sub2", "ses1")],
+            ["sub1"],
+            ["ses1"],
+        ),
+    ],
 )
 def test_remove_sub_ses_from_list_success(
     input_subjects, input_sessions, to_remove, expected_subjects, expected_sessions
@@ -49,11 +42,6 @@ def test_remove_sub_ses_from_list_success(
     _remove_sub_ses_from_list(input_subjects, input_sessions, to_remove)
     assert input_subjects == expected_subjects
     assert input_sessions == expected_sessions
-
-
-def test_remove_sub_ses_from_list_error():
-    # todo
-    pass
 
 
 def test_get_parent_path(tmp_path):
@@ -536,6 +524,7 @@ def test_check_information():
 
 def test_format_errors():
     """Test utility function `_format_errors`."""
+    # todo : test
     from clinica.utils.inputs import _format_errors
 
     information = {"description": "foo bar baz"}
@@ -549,22 +538,25 @@ def test_format_errors():
         "Please note that the following clinica pipeline(s) must have "
         "run to obtain these files: ['pipeline_1', 'pipeline_3']\n"
     )
-    errors = ["error 1: foo", "error 2: bar", "error 3: baz"]
+    errors = [("sub1", "ses1"), ("sub2", "ses1"), ("sub3", "ses1")]
     assert _format_errors(errors, information) == (
         "Clinica encountered 3 problem(s) while getting foo bar baz:\n"
         "Please note that the following clinica pipeline(s) must have "
         "run to obtain these files: ['pipeline_1', 'pipeline_3']\n"
-        "error 1: foo\nerror 2: bar\nerror 3: baz"
+        "\t* (sub1 | ses1)\n\t* (sub2 | ses1)\n\t* (sub3 | ses1)\n"
+        "Clinica could not identify which file to use (missing or too many) for these sessions. They will not be processed."
     )
     information.pop("needed_pipeline")
     assert _format_errors(errors, information) == (
         "Clinica encountered 3 problem(s) while getting foo bar baz:\n"
-        "error 1: foo\nerror 2: bar\nerror 3: baz"
+        "\t* (sub1 | ses1)\n\t* (sub2 | ses1)\n\t* (sub3 | ses1)\n"
+        "Clinica could not identify which file to use (missing or too many) for these sessions. They will not be processed."
     )
 
 
 @pytest.mark.parametrize("data_type", ["T1w", "flair"])
 def test_clinica_file_reader_bids_directory(tmp_path, data_type):
+    # todo : test
     """Test reading from a BIDS directory with function `clinica_file_reader`."""
     from clinica.utils.inputs import clinica_file_reader
 
@@ -648,6 +640,7 @@ def test_clinica_file_reader_bids_directory(tmp_path, data_type):
 
 def test_clinica_file_reader_caps_directory(tmp_path):
     """Test reading from a CAPS directory with function `clinica_file_reader`."""
+    # todo : test
     from clinica.utils.inputs import clinica_file_reader
 
     config = {
@@ -739,6 +732,7 @@ def test_clinica_file_reader_caps_directory(tmp_path):
 
 
 def test_clinica_file_reader_dwi_dti_error(tmp_path):
+    # todo : test
     from clinica.utils.input_files import dwi_dti
     from clinica.utils.inputs import clinica_file_reader
 
@@ -750,6 +744,7 @@ def test_clinica_file_reader_dwi_dti_error(tmp_path):
 
 
 def test_clinica_file_reader_dwi_dti(tmp_path):
+    # todo : test
     from clinica.pipelines.dwi.dti.utils import DTIBasedMeasure
     from clinica.utils.input_files import dwi_dti
     from clinica.utils.inputs import clinica_file_reader, clinica_list_of_files_reader
@@ -791,6 +786,7 @@ def test_clinica_file_reader_dwi_dti(tmp_path):
 
 
 def test_clinica_list_of_files_reader(tmp_path):
+    # todo : test, why broken ?
     from clinica.utils.inputs import clinica_list_of_files_reader
 
     config = {

--- a/test/unittests/utils/test_utils_inputs.py
+++ b/test/unittests/utils/test_utils_inputs.py
@@ -14,6 +14,48 @@ from clinica.utils.testing_utils import (
 )
 
 
+@pytest.mark.parametrize(
+    "input_subjects, input_sessions, to_remove, expected_subjects, expected_sessions",
+    (
+        [
+            ["sub1", "sub1", "sub2"],
+            ["ses1", "ses2", "ses1"],
+            [("sub1", "ses1"), ("sub3", "ses1")],
+            ["sub1", "sub2"],
+            ["ses2", "ses1"],
+        ],
+        [
+            [
+                "sub1",
+            ],
+            [
+                "ses1",
+            ],
+            [],
+            [
+                "sub1",
+            ],
+            [
+                "ses1",
+            ],
+        ],
+    ),
+)
+def test_remove_sub_ses_from_list_success(
+    input_subjects, input_sessions, to_remove, expected_subjects, expected_sessions
+):
+    from clinica.utils.inputs import _remove_sub_ses_from_list
+
+    _remove_sub_ses_from_list(input_subjects, input_sessions, to_remove)
+    assert input_subjects == expected_subjects
+    assert input_sessions == expected_sessions
+
+
+def test_remove_sub_ses_from_list_error():
+    # todo
+    pass
+
+
 def test_get_parent_path(tmp_path):
     from clinica.utils.inputs import _get_parent_path
 
@@ -389,7 +431,7 @@ def test_find_sub_ses_pattern_path_error_no_file(tmp_path):
 
     assert len(results) == 0
     assert len(errors) == 1
-    assert errors[0] == "\t* (sub-01 | ses-M00): No file found\n"
+    assert errors[0] == ("sub-01", "ses-M00")
 
 
 def test_find_sub_ses_pattern_path_error_more_than_one_file(tmp_path):
@@ -410,7 +452,7 @@ def test_find_sub_ses_pattern_path_error_more_than_one_file(tmp_path):
 
     assert len(results) == 0
     assert len(errors) == 1
-    assert "\t*  (sub-01 | ses-M00): More than 1 file found:" in errors[0]
+    assert errors[0] == ("sub-01", "ses-M00")
 
 
 def test_find_sub_ses_pattern_path(tmp_path):
@@ -554,7 +596,7 @@ def test_clinica_file_reader_bids_directory(tmp_path, data_type):
         )
     assert clinica_file_reader(
         [], [], tmp_path, information, raise_exception=True, n_procs=1
-    ) == ([], "")
+    ) == ([], [])
     results, error_msg = clinica_file_reader(
         ["sub-01"], ["ses-M00"], tmp_path, information, raise_exception=True, n_procs=1
     )
@@ -640,7 +682,7 @@ def test_clinica_file_reader_caps_directory(tmp_path):
 
     assert clinica_file_reader(
         [], [], tmp_path, information, raise_exception=True, n_procs=1
-    ) == ([], "")
+    ) == ([], [])
 
     results, error_msg = clinica_file_reader(
         ["sub-01"], ["ses-M00"], tmp_path, information, raise_exception=True, n_procs=1

--- a/test/unittests/utils/test_utils_inputs.py
+++ b/test/unittests/utils/test_utils_inputs.py
@@ -411,14 +411,14 @@ def test_check_caps_folder(tmp_path):
         check_caps_folder(tmp_path)
 
 
-def test_find_sub_ses_pattern_path_error_no_file(tmp_path):
-    """Test function `find_sub_ses_pattern_path`."""
-    from clinica.utils.inputs import find_sub_ses_pattern_path
+def test_find_images_path_error_no_file(tmp_path):
+    """Test function `find_images_path`."""
+    from clinica.utils.inputs import find_images_path
 
     (tmp_path / "sub-01" / "ses-M00" / "anat").mkdir(parents=True)
     errors, results = [], []
 
-    find_sub_ses_pattern_path(
+    find_images_path(
         tmp_path, "sub-01", "ses-M00", errors, results, True, "sub-*_ses-*_t1w.nii*"
     )
 
@@ -427,9 +427,9 @@ def test_find_sub_ses_pattern_path_error_no_file(tmp_path):
     assert errors[0] == ("sub-01", "ses-M00")
 
 
-def test_find_sub_ses_pattern_path_error_more_than_one_file(tmp_path):
-    """Test function `find_sub_ses_pattern_path`."""
-    from clinica.utils.inputs import find_sub_ses_pattern_path
+def test_find_images_path_error_more_than_one_file(tmp_path):
+    """Test function `find_images_path`."""
+    from clinica.utils.inputs import find_images_path
 
     errors, results = [], []
     (tmp_path / "sub-01" / "ses-M00" / "anat" / "sub-01_ses-M00_T1w.nii.gz").mkdir(
@@ -439,7 +439,7 @@ def test_find_sub_ses_pattern_path_error_more_than_one_file(tmp_path):
         tmp_path / "sub-01" / "ses-M00" / "anat" / "sub-01_ses-M00_foo-bar_T1w.nii.gz"
     ).mkdir(parents=True)
 
-    find_sub_ses_pattern_path(
+    find_images_path(
         tmp_path, "sub-01", "ses-M00", errors, results, True, "sub-*_ses-*_t1w.nii*"
     )
 
@@ -448,16 +448,16 @@ def test_find_sub_ses_pattern_path_error_more_than_one_file(tmp_path):
     assert errors[0] == ("sub-01", "ses-M00")
 
 
-def test_find_sub_ses_pattern_path(tmp_path):
-    """Test function `find_sub_ses_pattern_path`."""
-    from clinica.utils.inputs import find_sub_ses_pattern_path
+def test_find_images_path(tmp_path):
+    """Test function `find_images_path`."""
+    from clinica.utils.inputs import find_images_path
 
     (tmp_path / "sub-01" / "ses-M00" / "anat" / "sub-01_ses-M00_T1w.nii.gz").mkdir(
         parents=True
     )
     errors, results = [], []
 
-    find_sub_ses_pattern_path(
+    find_images_path(
         tmp_path, "sub-01", "ses-M00", errors, results, True, "sub-*_ses-*_t1w.nii*"
     )
 
@@ -468,8 +468,8 @@ def test_find_sub_ses_pattern_path(tmp_path):
     )
 
 
-def test_find_sub_ses_pattern_path_multiple_runs(tmp_path):
-    from clinica.utils.inputs import find_sub_ses_pattern_path
+def test_find_images_path_multiple_runs(tmp_path):
+    from clinica.utils.inputs import find_images_path
 
     errors, results = [], []
     (
@@ -487,7 +487,7 @@ def test_find_sub_ses_pattern_path_multiple_runs(tmp_path):
         / "sub-01_ses-M06_run-02_foo-bar_T1w.nii.gz"
     ).mkdir(parents=True)
 
-    find_sub_ses_pattern_path(
+    find_images_path(
         tmp_path, "sub-01", "ses-M06", errors, results, True, "sub-*_ses-*_t1w.nii*"
     )
 
@@ -529,15 +529,15 @@ def test_check_information():
 
 def test_format_errors():
     """Test utility function `_format_errors`."""
-    from clinica.utils.inputs import _format_errors
+    from clinica.utils.inputs import format_clinica_file_reader_errors
 
     information = {"description": "foo bar baz"}
     assert (
-        _format_errors([], information)
+        format_clinica_file_reader_errors([], information)
         == "Clinica encountered 0 problem(s) while getting foo bar baz:\n"
     )
     information["needed_pipeline"] = ["pipeline_1", "pipeline_3"]
-    assert _format_errors([], information) == (
+    assert format_clinica_file_reader_errors([], information) == (
         "Clinica encountered 0 problem(s) while getting foo bar baz:\n"
         "Please note that the following clinica pipeline(s) must have "
         "run to obtain these files: ['pipeline_1', 'pipeline_3']\n"
@@ -547,7 +547,7 @@ def test_format_errors():
         InvalidSubjectSession("sub2", "ses1"),
         InvalidSubjectSession("sub3", "ses1"),
     ]
-    assert _format_errors(errors, information) == (
+    assert format_clinica_file_reader_errors(errors, information) == (
         "Clinica encountered 3 problem(s) while getting foo bar baz:\n"
         "Please note that the following clinica pipeline(s) must have "
         "run to obtain these files: ['pipeline_1', 'pipeline_3']\n"
@@ -555,7 +555,7 @@ def test_format_errors():
         "Clinica could not identify which file to use (missing or too many) for these sessions. They will not be processed."
     )
     information.pop("needed_pipeline")
-    assert _format_errors(errors, information) == (
+    assert format_clinica_file_reader_errors(errors, information) == (
         "Clinica encountered 3 problem(s) while getting foo bar baz:\n"
         "\t* (sub1 | ses1)\n\t* (sub2 | ses1)\n\t* (sub3 | ses1)\n"
         "Clinica could not identify which file to use (missing or too many) for these sessions. They will not be processed."

--- a/test/unittests/utils/test_utils_inputs.py
+++ b/test/unittests/utils/test_utils_inputs.py
@@ -802,7 +802,7 @@ def test_clinica_list_of_files_reader(tmp_path):
 
     assert len(results) == 2
     assert len(results[0]) == 3
-    assert len(results[1]) == 2
+    assert len(results[1]) == 0
 
 
 def test_clinica_group_reader(tmp_path):

--- a/test/unittests/utils/test_utils_inputs.py
+++ b/test/unittests/utils/test_utils_inputs.py
@@ -37,14 +37,16 @@ from clinica.utils.testing_utils import (
         ),
     ],
 )
-def test_remove_sub_ses_from_list_success(
+def test_remove_sub_ses_from_list(
     input_subjects, input_sessions, to_remove, expected_subjects, expected_sessions
 ):
     from clinica.utils.inputs import _remove_sub_ses_from_list
 
-    _remove_sub_ses_from_list(input_subjects, input_sessions, to_remove)
-    assert input_subjects == expected_subjects
-    assert input_sessions == expected_sessions
+    result_subjects, result_sessions = _remove_sub_ses_from_list(
+        input_subjects, input_sessions, to_remove
+    )
+    assert result_subjects == expected_subjects and result_sessions == expected_sessions
+    assert input_subjects == input_subjects and input_sessions == input_sessions
 
 
 def test_get_parent_path(tmp_path):


### PR DESCRIPTION
TO DISCUSS :  **change of a logic** for ```clinica_file_reader``` but also ```clinica_list_of_files_reader``` (DWI pipelines)

Currently ```clinica_file_reader``` returns a list of files and a list errors _messages/strings_. As such, complicated to retrieve what sub/ses is problematic + most of the time these are not used since function called like so ```files, _ = clinica_file_reader(...)```. Otherwise, used to stop the processing when a subject/session is missing files for ex. : a bit critical.

-> list of messages replaced by list of tuples with the actual problematic sessions
-> no more breaking when subject/session does not have files, they are removed from the lists of sub/sess
-> raise replaced by cprint. User informed that some files won't be processed instead so removed parameter/part
-> clinica_list_of_files impacted

Currently ```clinica_list_of_files_reader``` uses ```clinica_files_reader``` to retrieve files by batches. Does not consider a list of files if there is any errors in it instead of removing the error. 

-> not considering "errors" (file not found)

TO DO : 
- [x]  verify what happens when empty subject/sess list after cleaning
- [x]  correct typing
- [x]  Change function descriptions
- [x]  Do for all pipelines
- [ ]  Docs to change ?


From : 

```Click
(clinEnv) alice.joubert@ICM-COLLI-MP013 clinica % clinica run t1-linear BIDS CAPS

2024-09-19 15:21:13,301:WARNING:More than one run were found for subject sub-OAS31158 and session ses-M024 : 

- /Users/alice.joubert/clinicaQC/data/test_jump_subjects/bids/sub-OAS31158/ses-M024/anat/sub-OAS31158_ses-M024_run-01_T1w.nii.gz
- /Users/alice.joubert/clinicaQC/data/test_jump_subjects/bids/sub-OAS31158/ses-M024/anat/sub-OAS31158_ses-M024_run-02_T1w.nii.gz

Clinica will proceed with the latest run available, that is 

-/Users/alice.joubert/clinicaQC/data/test_jump_subjects/bids/sub-OAS31158/ses-M024/anat/sub-OAS31158_ses-M024_run-02_T1w.nii.gz.

2024-09-19 15:21:13,302:ERROR:Clinica faced error(s) while trying to read files in your BIDS directory.
Clinica encountered 2 problem(s) while getting T1w MRI:
        * (sub-OAS31158 | ses-M006): No file found
        * (sub-OAS31158 | ses-M078): No file found
 
-- end --
```

to : 

```Click
(clinEnv) alice.joubert@ICM-COLLI-MP013 clinica % clinica run t1-linear BIDS CAPS

2024-09-19 15:24:45,966:WARNING:More than one run were found for subject sub-OAS31158 and session ses-M024 : 

- /Users/alice.joubert/clinicaQC/data/test_jump_subjects/bids/sub-OAS31158/ses-M024/anat/sub-OAS31158_ses-M024_run-01_T1w.nii.gz
- /Users/alice.joubert/clinicaQC/data/test_jump_subjects/bids/sub-OAS31158/ses-M024/anat/sub-OAS31158_ses-M024_run-02_T1w.nii.gz

Clinica will proceed with the latest run available, that is 

-/Users/alice.joubert/clinicaQC/data/test_jump_subjects/bids/sub-OAS31158/ses-M024/anat/sub-OAS31158_ses-M024_run-02_T1w.nii.gz.

2024-09-19 15:24:45,967:WARNING:Clinica encountered 2 problem(s) while getting T1w MRI:
        * (sub-OAS31158 | ses-M006)
        * (sub-OAS31158 | ses-M078)
Clinica could not identify which file to use (missing or too many) for these sessions. They will not be processed.

2024-09-19 15:24:45,967:INFO:The pipeline will be run on the following 3 image(s):
2024-09-19 15:24:45,967:INFO:   sub-OAS31158 | ses-M000, ses-M024, ses-M084,
2024-09-19 15:24:45,967:INFO:The pipeline will last approximately 6 minutes per image.

-- ... --
```