### PR TITLE
[ENH] Add `clinica iotools describe`

### DIFF
--- a/clinica/iotools/utils/cli.py
+++ b/clinica/iotools/utils/cli.py
@@ -21,6 +21,7 @@ def cli() -> None:
 @cli.command()
 @click.argument("dataset", type=click.Path(resolve_path=True))
 def describe(dataset: Union[str, Path]):
+    """Describe a dataset in BIDS or CAPS format."""
     from .describe import describe as _describe
 
     _describe(dataset)

--- a/clinica/iotools/utils/cli.py
+++ b/clinica/iotools/utils/cli.py
@@ -1,4 +1,5 @@
-from typing import List, Optional
+from pathlib import Path
+from typing import List, Optional, Union
 
 import click
 
@@ -15,6 +16,14 @@ current_directory = click.argument(
 def cli() -> None:
     """Tools to handle BIDS/CAPS datasets."""
     pass
+
+
+@cli.command()
+@click.argument("dataset", type=click.Path(resolve_path=True))
+def describe(dataset: Union[str, Path]):
+    from .describe import describe as _describe
+
+    _describe(dataset)
 
 
 @cli.command()

--- a/clinica/iotools/utils/describe.py
+++ b/clinica/iotools/utils/describe.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+from typing import Union
+
+__all__ = ["describe"]
+
+
+def describe(dataset: Union[str, Path]):
+    """Describe a dataset in BIDS or CAPS format.
+
+    Parameters
+    ----------
+    dataset : str or Path
+        The path to the BIDS or CAPS dataset to describe.
+    """
+    import json
+
+    from rich import box
+    from rich.console import Console
+    from rich.table import Table
+
+    from clinica.utils.inputs import DatasetType
+
+    dataset_description = Path(dataset) / "dataset_description.json"
+    with open(dataset_description, "r") as fp:
+        metadata = json.load(fp)
+
+    is_caps = metadata["DatasetType"] == DatasetType.DERIVATIVE
+    dataset_table = Table(title="Dataset information", box=box.ROUNDED)
+    dataset_table.add_column("Name", justify="right", style="bright_cyan", no_wrap=True)
+    dataset_table.add_column("Type", justify="right", style="bright_yellow")
+    dataset_table.add_column("BIDS Specifications Version", style="bright_magenta")
+    if is_caps:
+        processing_metadata = metadata.pop("Processing")
+        dataset_table.add_column(
+            "CAPS Specifications Version", justify="right", style="bright_green"
+        )
+        dataset_table.add_row(
+            metadata["Name"],
+            metadata["DatasetType"],
+            metadata["BIDSVersion"],
+            metadata["CAPSVersion"],
+        )
+    else:
+        dataset_table.add_row(
+            metadata["Name"],
+            metadata["DatasetType"],
+            metadata["BIDSVersion"],
+        )
+    if is_caps:
+        processing_table = Table(title="Processing information", box=box.ROUNDED)
+        processing_table.add_column(
+            "Name", justify="right", style="bright_cyan", no_wrap=True
+        )
+        processing_table.add_column("Date", style="bright_yellow")
+        processing_table.add_column("Author", justify="right", style="bright_magenta")
+        processing_table.add_column("Machine", justify="right", style="bright_green")
+        processing_table.add_column("InputPath", justify="right", style="bright_red")
+        processing_table.add_column(
+            "ClinicaVersion", justify="right", style="bright_blue"
+        )
+        processing_table.add_column(
+            "Dependencies", justify="right", style="bright_green"
+        )
+
+        for processing in processing_metadata:
+            dependency_table = Table(title="Dependencies", box=box.ROUNDED)
+            dependency_table.add_column("Name", justify="right")
+            dependency_table.add_column("VersionConstraint", justify="right")
+            dependency_table.add_column("InstalledVersion", justify="right")
+
+            for dependency in processing["Dependencies"]:
+                dependency_table.add_row(
+                    dependency["Name"],
+                    dependency["VersionConstraint"],
+                    dependency["InstalledVersion"],
+                )
+            processing_table.add_row(
+                processing["Name"],
+                processing["Date"],
+                processing["Author"],
+                processing["Machine"],
+                processing["InputPath"],
+                processing["ClinicaVersion"],
+                dependency_table,
+            )
+    console = Console()
+    console.print(dataset_table)
+    if is_caps:
+        console.print(processing_table)

--- a/clinica/iotools/utils/describe.py
+++ b/clinica/iotools/utils/describe.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 from rich import box
+from rich.console import Console
 from rich.table import Table
 
 from clinica.iotools.bids_dataset_description import BIDSDatasetDescription
@@ -11,7 +12,7 @@ from clinica.utils.inputs import DatasetType
 __all__ = ["describe"]
 
 
-def describe(dataset: Union[str, Path]):
+def describe(dataset: Union[str, Path]) -> None:
     """Describe a dataset in BIDS or CAPS format.
 
     Parameters
@@ -19,8 +20,6 @@ def describe(dataset: Union[str, Path]):
     dataset : str or Path
         The path to the BIDS or CAPS dataset to describe.
     """
-    from rich.console import Console
-
     description = (
         CAPSDatasetDescription if _is_caps(dataset) else BIDSDatasetDescription
     ).from_file(Path(dataset) / "dataset_description.json")
@@ -46,9 +45,11 @@ def _build_dataset_table(
     description: Union[BIDSDatasetDescription, CAPSDatasetDescription],
 ) -> Table:
     dataset_table = Table(title="Dataset information", box=box.ROUNDED)
-    dataset_table.add_column("Name", justify="right", style="bright_cyan", no_wrap=True)
-    dataset_table.add_column("Type", justify="right", style="bright_yellow")
-    dataset_table.add_column("BIDS Specifications Version", style="bright_magenta")
+    for column, color in zip(
+        ["Name", "Type", "BIDS Specifications Version"],
+        ["bright_cyan", "bright_yellow", "bright_magenta"],
+    ):
+        dataset_table.add_column(column, justify="right", style=color)
     row = (description.name, description.dataset_type, str(description.bids_version))
     if description.dataset_type == DatasetType.DERIVATIVE:
         dataset_table.add_column(

--- a/clinica/iotools/utils/describe.py
+++ b/clinica/iotools/utils/describe.py
@@ -1,5 +1,12 @@
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
+
+from rich import box
+from rich.table import Table
+
+from clinica.iotools.bids_dataset_description import BIDSDatasetDescription
+from clinica.utils.caps import CAPSDatasetDescription
+from clinica.utils.inputs import DatasetType
 
 __all__ = ["describe"]
 
@@ -12,11 +19,19 @@ def describe(dataset: Union[str, Path]):
     dataset : str or Path
         The path to the BIDS or CAPS dataset to describe.
     """
-    import json
-
-    from rich import box
     from rich.console import Console
-    from rich.table import Table
+
+    description = (
+        CAPSDatasetDescription if _is_caps(dataset) else BIDSDatasetDescription
+    ).from_file(Path(dataset) / "dataset_description.json")
+    console = Console()
+    console.print(_build_dataset_table(description))
+    if (processing_table := _build_processing_table(description)) is not None:
+        console.print(processing_table)
+
+
+def _is_caps(dataset: Union[str, Path]) -> bool:
+    import json
 
     from clinica.utils.inputs import DatasetType
 
@@ -24,66 +39,76 @@ def describe(dataset: Union[str, Path]):
     with open(dataset_description, "r") as fp:
         metadata = json.load(fp)
 
-    is_caps = metadata["DatasetType"] == DatasetType.DERIVATIVE
+    return metadata["DatasetType"] == DatasetType.DERIVATIVE
+
+
+def _build_dataset_table(
+    description: Union[BIDSDatasetDescription, CAPSDatasetDescription],
+) -> Table:
     dataset_table = Table(title="Dataset information", box=box.ROUNDED)
     dataset_table.add_column("Name", justify="right", style="bright_cyan", no_wrap=True)
     dataset_table.add_column("Type", justify="right", style="bright_yellow")
     dataset_table.add_column("BIDS Specifications Version", style="bright_magenta")
-    if is_caps:
-        processing_metadata = metadata.pop("Processing")
+    row = (description.name, description.dataset_type, str(description.bids_version))
+    if description.dataset_type == DatasetType.DERIVATIVE:
         dataset_table.add_column(
             "CAPS Specifications Version", justify="right", style="bright_green"
         )
-        dataset_table.add_row(
-            metadata["Name"],
-            metadata["DatasetType"],
-            metadata["BIDSVersion"],
-            metadata["CAPSVersion"],
+        row = (
+            description.name,
+            description.dataset_type,
+            str(description.bids_version),
+            str(description.caps_version),
         )
-    else:
-        dataset_table.add_row(
-            metadata["Name"],
-            metadata["DatasetType"],
-            metadata["BIDSVersion"],
-        )
-    if is_caps:
-        processing_table = Table(title="Processing information", box=box.ROUNDED)
-        processing_table.add_column(
-            "Name", justify="right", style="bright_cyan", no_wrap=True
-        )
-        processing_table.add_column("Date", style="bright_yellow")
-        processing_table.add_column("Author", justify="right", style="bright_magenta")
-        processing_table.add_column("Machine", justify="right", style="bright_green")
-        processing_table.add_column("InputPath", justify="right", style="bright_red")
-        processing_table.add_column(
-            "ClinicaVersion", justify="right", style="bright_blue"
-        )
-        processing_table.add_column(
-            "Dependencies", justify="right", style="bright_green"
-        )
+    dataset_table.add_row(*row)
 
-        for processing in processing_metadata:
-            dependency_table = Table(title="Dependencies", box=box.ROUNDED)
-            dependency_table.add_column("Name", justify="right")
-            dependency_table.add_column("VersionConstraint", justify="right")
-            dependency_table.add_column("InstalledVersion", justify="right")
+    return dataset_table
 
-            for dependency in processing["Dependencies"]:
-                dependency_table.add_row(
-                    dependency["Name"],
-                    dependency["VersionConstraint"],
-                    dependency["InstalledVersion"],
-                )
-            processing_table.add_row(
-                processing["Name"],
-                processing["Date"],
-                processing["Author"],
-                processing["Machine"],
-                processing["InputPath"],
-                processing["ClinicaVersion"],
-                dependency_table,
+
+def _build_processing_table(
+    description: Union[BIDSDatasetDescription, CAPSDatasetDescription],
+) -> Optional[Table]:
+    if description.dataset_type == DatasetType.RAW:
+        return None
+    processing_table = Table(title="Processing information", box=box.ROUNDED)
+    for column, color in zip(
+        [
+            "Name",
+            "Date",
+            "Author",
+            "Machine",
+            "InputPath",
+            "ClinicaVersion",
+            "Dependencies",
+        ],
+        [
+            "bright_cyan",
+            "bright_yellow",
+            "bright_magenta",
+            "bright_green",
+            "bright_red",
+            "bright_blue",
+            "bright_green",
+        ],
+    ):
+        processing_table.add_column(column, justify="right", style=color)
+    for processing in description.processing:
+        dependency_table = Table(title="Dependencies", box=box.ROUNDED)
+        for column in ("Name", "VersionConstraint", "InstalledVersion"):
+            dependency_table.add_column(column, justify="right")
+        for dependency in processing.dependencies:
+            dependency_table.add_row(
+                dependency.name,
+                str(dependency.version_constraint),
+                str(dependency.installed_version),
             )
-    console = Console()
-    console.print(dataset_table)
-    if is_caps:
-        console.print(processing_table)
+        processing_table.add_row(
+            processing.name,
+            str(processing.date),
+            processing.author,
+            processing.machine,
+            processing.input_path,
+            str(processing.clinica_version),
+            dependency_table,
+        )
+    return processing_table

--- a/docs/IO.md
+++ b/docs/IO.md
@@ -24,7 +24,7 @@ where:
 With a BIDS dataset:
 
 ```shell
-clinica iotools describe ./bids                                                                                                  ✔  3507  18:10:39
+clinica iotools describe ./bids
                          Dataset information
 ╭───────────────────────────────┬──────┬─────────────────────────────╮
 │                          Name │ Type │ BIDS Specifications Version │

--- a/docs/IO.md
+++ b/docs/IO.md
@@ -4,6 +4,61 @@
 This page describes data handling tools provided by Clinica for [BIDS](http://bids.neuroimaging.io) and [CAPS](../CAPS/Introduction) compliant datasets.
 These tools provide easy interaction mechanisms with datasets, including generating subject lists or merging all tabular data into a single TSV for analysis with external statistical software tools.
 
+## `describe` - Describe a BIDS or CAPS dataset
+
+This tool describes a BIDS or CAPS dataset, basically parsing the `dataset_description.json` file and displaying the information in the console in a nice way.
+
+!!! note
+    This tool has been added in Clinica `0.9.0` and is not available in older versions.
+
+```shell
+clinica iotools describe DATASET_PATH
+```
+
+where:
+
+- `DATASET_PATH`: path to the BIDS or CAPS dataset to be described.
+
+**Examples:**
+
+With a BIDS dataset:
+
+```shell
+clinica iotools describe ./bids                                                                                                  ✔  3507  18:10:39
+                         Dataset information
+╭───────────────────────────────┬──────┬─────────────────────────────╮
+│                          Name │ Type │ BIDS Specifications Version │
+├───────────────────────────────┼──────┼─────────────────────────────┤
+│ The mother of all experiments │  raw │ 1.6.0                       │
+╰───────────────────────────────┴──────┴─────────────────────────────╯
+```
+
+With a CAPS dataset:
+
+```shell
+clinica iotools describe ./caps
+                                               Dataset information
+╭──────────────────────────────────────┬────────────┬─────────────────────────────┬─────────────────────────────╮
+│                                 Name │       Type │ BIDS Specifications Version │ CAPS Specifications Version │
+├──────────────────────────────────────┼────────────┼─────────────────────────────┼─────────────────────────────┤
+│ 05c5794b-2d20-4217-b727-c215d079ab35 │ derivative │ 1.9.0                       │                       1.0.0 │
+╰──────────────────────────────────────┴────────────┴─────────────────────────────┴─────────────────────────────╯
+                                                                                           Processing information
+╭────────────────────────────┬────────────────────────────┬───────────────────┬─────────────────┬────────────────────────────────────────────┬────────────────┬────────────────────────────────────────────╮
+│                       Name │                       Date │            Author │         Machine │                                  InputPath │ ClinicaVersion │                               Dependencies │
+├────────────────────────────┼────────────────────────────┼───────────────────┼─────────────────┼────────────────────────────────────────────┼────────────────┼────────────────────────────────────────────┤
+│ dwi-preprocessing-using-t1 │ 2024-09-01 13:41:05.529799 │ nicolas.gensollen │ UMR-COLLI-MP050 │ /Users/nicolas.gensollen/dwi_datasets/bids │          0.9.0 │                Dependencies                │
+│                            │                            │                   │                 │                                            │                │ ╭───────────┬──────────────┬─────────────╮ │
+│                            │                            │                   │                 │                                            │                │ │      Name │ VersionCons… │ InstalledV… │ │
+│                            │                            │                   │                 │                                            │                │ ├───────────┼──────────────┼─────────────┤ │
+│                            │                            │                   │                 │                                            │                │ │      ants │      >=2.3.0 │       2.5.0 │ │
+│                            │                            │                   │                 │                                            │                │ │       fsl │      >=6.0.1 │       6.0.2 │ │
+│                            │                            │                   │                 │                                            │                │ │    mrtrix │      >=0.0.0 │       3.0.3 │ │
+│                            │                            │                   │                 │                                            │                │ │ convert3d │      >=0.0.0 │       1.0.0 │ │
+│                            │                            │                   │                 │                                            │                │ ╰───────────┴──────────────┴─────────────╯ │
+╰────────────────────────────┴────────────────────────────┴───────────────────┴─────────────────┴────────────────────────────────────────────┴────────────────┴────────────────────────────────────────────╯
+```
+
 ## `create-subjects-visits` - Generate the list all subjects and visits of a given dataset
 
 A TSV file with two columns (`participant_id` and `session_id`) containing the list of visits for each subject can be created as follows:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
     - OASIS-3 to BIDS: Converters/OASIS3TOBIDS.md
     - UK Biobank to BIDS: Converters/UKBtoBIDS.md
   - I/O tools:
+    - describe: IO#describe-Describe-a-BIDS-or-CAPS-dataset
     - create-subjects-visits: IO#create-subjects-visits-generate-the-list-all-subjects-and-visits-of-a-given-dataset
     - check-missing-modalities: IO#check-missing-modalities-check-missing-modalities-for-each-subject
     - check-missing-processing: IO#check-missing-processing-check-missing-processing-in-a-caps-directory

--- a/poetry.lock
+++ b/poetry.lock
@@ -1626,6 +1626,30 @@ docs = ["mdx-gh-links (>=0.2)", "mkdocs (>=1.5)", "mkdocs-gen-files", "mkdocs-li
 testing = ["coverage", "pyyaml"]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
 name = "markupsafe"
 version = "2.1.5"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -1757,6 +1781,17 @@ python-dateutil = ">=2.7"
 
 [package.extras]
 dev = ["meson-python (>=0.13.1)", "numpy (>=1.25)", "pybind11 (>=2.6)", "setuptools (>=64)", "setuptools_scm (>=7)"]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
 
 [[package]]
 name = "mergedeep"
@@ -3075,6 +3110,24 @@ files = [
 six = ">=1.7.0"
 
 [[package]]
+name = "rich"
+version = "13.8.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "rich-13.8.0-py3-none-any.whl", hash = "sha256:2e85306a063b9492dffc86278197a60cbece75bcb766022f3436f567cae11bdc"},
+    {file = "rich-13.8.0.tar.gz", hash = "sha256:a5ac1f1cd448ade0d59cc3356f7db7a7ccda2c8cbae9c7a90c28ff463d3e91f4"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
 name = "rpds-py"
 version = "0.20.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
@@ -4089,4 +4142,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "2e7a9227ece75cd7216ace22f737f13cffb43fe92b8e2d6604e824af52e607da"
+content-hash = "3c70832d04eea028d5eff1b9f4219beef752bfd71a19916009dcfeb409584042"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ pydra-freesurfer = "^0.0.9"
 pydra-petpvc="^0.0.4"
 pydra-fsl = "^0.0.22"
 antspyx = "^0.4.2"
+rich = "^13.8.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"

--- a/test/unittests/iotools/utils/test_describe.py
+++ b/test/unittests/iotools/utils/test_describe.py
@@ -1,0 +1,142 @@
+import json
+from pathlib import Path
+
+
+def test_build_dataset_table():
+    from clinica.iotools.utils.describe import _build_dataset_table  # noqa
+    from clinica.iotools.bids_dataset_description import BIDSDatasetDescription
+
+    table = _build_dataset_table(BIDSDatasetDescription("Test dataset BIDS"))
+
+    assert table.title == "Dataset information"
+    assert len(table.columns) == 3
+    for i, value in enumerate(("Name", "Type", "BIDS Specifications Version")):
+        assert table.columns[i].header == value
+    for i, value in enumerate(("bright_cyan", "bright_yellow", "bright_magenta")):
+        assert table.columns[i].style == value
+    for i, value in enumerate(("Test dataset BIDS", "raw", "1.7.0")):
+        assert table.columns[i]._cells[0] == value
+
+
+def test_build_processing_table_bids():
+    from clinica.iotools.utils.describe import _build_processing_table  # noqa
+    from clinica.iotools.bids_dataset_description import BIDSDatasetDescription
+
+    assert _build_processing_table(BIDSDatasetDescription("Test dataset BIDS")) is None
+
+
+def build_test_dataset_caps(folder: Path):
+    metadata = {
+        "Name": "Test dataset CAPS",
+        "BIDSVersion": "1.9.0",
+        "CAPSVersion": "1.0.0",
+        "DatasetType": "derivative",
+        "Processing": [
+            {
+                "Name": "t1-linear",
+                "Date": "2024-08-30T13:41:05.529799",
+                "Author": "john.doe",
+                "Machine": "machine-name",
+                "InputPath": "/Users/john.doe/datasets/adni",
+                "ClinicaVersion": "0.9.0",
+                "Dependencies": [
+                    {
+                        "Name": "ants",
+                        "VersionConstraint": ">=2.2.0",
+                        "InstalledVersion": "2.3.5",
+                    }
+                ],
+            },
+            {
+                "Name": "pet-linear",
+                "Date": "2024-08-30T13:41:05.529799",
+                "Author": "sheldon.cooper",
+                "Machine": "sheldon-machine",
+                "InputPath": "/Users/sheldon.cooper/work/datasets/oasis",
+                "ClinicaVersion": "0.9.0",
+                "Dependencies": [
+                    {
+                        "Name": "ants",
+                        "VersionConstraint": ">=2.3.0",
+                        "InstalledVersion": "2.5.1",
+                    },
+                    {
+                        "Name": "spm",
+                        "VersionConstraint": ">=12",
+                        "InstalledVersion": "12.2.1",
+                    },
+                ],
+            },
+        ],
+    }
+    with open(folder / "dataset_description.json", "w") as fp:
+        json.dump(metadata, fp)
+
+
+def test_build_processing_table_caps(tmp_path):
+    from clinica.iotools.utils.describe import _build_processing_table  # noqa
+    from clinica.utils.caps import CAPSDatasetDescription
+
+    (tmp_path / "bids").mkdir()
+    build_test_dataset_caps(tmp_path / "bids")
+    description = CAPSDatasetDescription.from_file(
+        tmp_path / "bids" / "dataset_description.json"
+    )
+    table = _build_processing_table(description)
+
+    assert table.title == "Processing information"
+    assert len(table.columns) == 7
+    assert len(table.rows) == 2
+    for i, value in enumerate(
+        (
+            "Name",
+            "Date",
+            "Author",
+            "Machine",
+            "InputPath",
+            "ClinicaVersion",
+            "Dependencies",
+        )
+    ):
+        assert table.columns[i].header == value
+    for i, value in enumerate(
+        (
+            "bright_cyan",
+            "bright_yellow",
+            "bright_magenta",
+            "bright_green",
+            "bright_red",
+            "bright_blue",
+            "bright_green",
+        )
+    ):
+        assert table.columns[i].style == value
+    assert table.columns[0]._cells == ["t1-linear", "pet-linear"]
+    assert table.columns[1]._cells == [
+        "2024-08-30 13:41:05.529799",
+        "2024-08-30 13:41:05.529799",
+    ]
+    assert table.columns[2]._cells == ["john.doe", "sheldon.cooper"]
+    assert table.columns[3]._cells == ["machine-name", "sheldon-machine"]
+    assert table.columns[4]._cells == [
+        "/Users/john.doe/datasets/adni",
+        "/Users/sheldon.cooper/work/datasets/oasis",
+    ]
+    assert table.columns[5]._cells == ["0.9.0", "0.9.0"]
+    dependency_table_t1_linear, dependency_table_pet_linear = table.columns[6]._cells
+    assert (
+        len(dependency_table_t1_linear.columns)
+        == len(dependency_table_pet_linear.columns)
+        == 3
+    )
+    assert len(dependency_table_t1_linear.rows) == 1
+    assert len(dependency_table_pet_linear.rows) == 2
+    for dependency_table in table.columns[6]._cells:
+        for i, value in enumerate(("Name", "VersionConstraint", "InstalledVersion")):
+            assert dependency_table.columns[i].header == value
+    for i, value in enumerate(("ants", ">=2.2.0", "2.3.5")):
+        assert dependency_table_t1_linear.columns[i]._cells[0] == value
+    for i, value in enumerate(
+        (["ants", "spm"], [">=2.3.0", ">=12"], ["2.5.1", "12.2.1"])
+    ):
+        assert dependency_table_pet_linear.columns[i]._cells == value


### PR DESCRIPTION
This PR proposes to add the command:

```bash
clinica iotools describe DATASET_PATH
```

which will basically parse the `dataset_description.json` file describing the dataset provided in order to display the information in a nice user-friendly way.

Here is a toy example with a BIDS and CAPS dataset having only their respective `dataset_description.json` file:

```bash
tree
.
├── bids
│   └── dataset_description.json
├── caps
│   └── dataset_description.json
```

We can describe them with the added tool:

<img width="1433" alt="Capture d’écran 2024-09-06 à 18 19 52" src="https://github.com/user-attachments/assets/2ec660e5-e239-4b4a-aac2-061d0ac21bef">

