### PR TITLE
[CI] Clean CI workflows

### DIFF
--- a/.github/workflows/test_converters.yml
+++ b/.github/workflows/test_converters.yml
@@ -13,10 +13,6 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
-env:
-  POETRY_VERSION: '1.6.1'
-  PYTHON_VERSION: '3.10'
-
 jobs:
   test-converters-MacOS:
     runs-on:
@@ -24,10 +20,6 @@ jobs:
       - macOS
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: false
       - name: Run non-regression tests for converters
         run: |
           make env.conda
@@ -42,10 +34,6 @@ jobs:
           --junitxml=./test-reports/run_converters_mac.xml \
           --disable-warnings \
           ./nonregression/iotools/test_run_converters.py
-      - name: Clean
-        run: |
-          rm -rf /Volumes/data/tmp
-          rm -rf /Volumes/data/working_dir_mac
 
   test-converters-Linux:
     runs-on:
@@ -54,14 +42,6 @@ jobs:
       - test-runner
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
       - name: Run non-regression tests for converters
         run: |
           make env.conda
@@ -76,7 +56,3 @@ jobs:
           --junitxml=./test-reports/run_converters_linux.xml \
           --disable-warnings \
           ./nonregression/iotools/test_run_converters.py
-      - name: Clean
-        run: |
-          rm -rf /mnt/data/ci/tmp
-          rm -rf /mnt/data/ci/working_dir_linux

--- a/.github/workflows/test_instantiation.yml
+++ b/.github/workflows/test_instantiation.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  POETRY_VERSION: '1.6.1'
+  POETRY_VERSION: '1.8.3'
 
 jobs:
   test-instantiation-MacOS:

--- a/.github/workflows/test_instantiation.yml
+++ b/.github/workflows/test_instantiation.yml
@@ -13,10 +13,6 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
-env:
-  POETRY_VERSION: '1.6.1'
-  PYTHON_VERSION: '3.10'
-
 jobs:
   test-instantiation-MacOS:
     runs-on:
@@ -24,10 +20,6 @@ jobs:
       - macOS
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: false
       - name: Run instantiation tests
         run: |
           make env.conda
@@ -52,14 +44,6 @@ jobs:
       - test-runner
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
       - name: Run instantiation tests
         run: |
           make env.conda

--- a/.github/workflows/test_instantiation.yml
+++ b/.github/workflows/test_instantiation.yml
@@ -13,6 +13,9 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+env:
+  POETRY_VERSION: '1.6.1'
+
 jobs:
   test-instantiation-MacOS:
     runs-on:
@@ -44,6 +47,13 @@ jobs:
       - test-runner
     steps:
       - uses: actions/checkout@v4
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
+      - name: print poetry version number
+        run: |
+          which poetry
+          poetry --version
       - name: Run instantiation tests
         run: |
           make env.conda

--- a/.github/workflows/test_instantiation.yml
+++ b/.github/workflows/test_instantiation.yml
@@ -13,9 +13,6 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
-env:
-  POETRY_VERSION: '1.8.3'
-
 jobs:
   test-instantiation-MacOS:
     runs-on:
@@ -47,13 +44,6 @@ jobs:
       - test-runner
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-      - name: print poetry version number
-        run: |
-          which poetry
-          poetry --version
       - name: Run instantiation tests
         run: |
           make env.conda

--- a/.github/workflows/test_non_regression_fast.yml
+++ b/.github/workflows/test_non_regression_fast.yml
@@ -12,10 +12,6 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
-env:
-  POETRY_VERSION: '1.6.1'
-  PYTHON_VERSION: '3.10'
-
 jobs:
   test-non-regression-fast-MacOS:
     runs-on:
@@ -23,10 +19,6 @@ jobs:
       - macOS
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: false
       - name: Run fast non regression tests
         run: |
           make env.conda
@@ -51,14 +43,6 @@ jobs:
       - test-runner
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
       - name: Run fast non regression tests
         run: |
           make env.conda

--- a/.github/workflows/test_pipelines_anat.yml
+++ b/.github/workflows/test_pipelines_anat.yml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: read
 
-env:
-  POETRY_VERSION: '1.6.1'
-  PYTHON_VERSION: '3.10'
-
 jobs:
   test-t1-linear-MacOS:
     runs-on:
@@ -19,7 +15,6 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
       - name: Run tests for t1 linear pipelines
         run: |
           make env.conda
@@ -44,7 +39,6 @@ jobs:
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
       - name: Run tests for t1 volume pipelines
         run: |
           make env.conda
@@ -71,14 +65,6 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
       - name: Run tests for t1 linear pipelines
         run: |
           make env.conda
@@ -104,14 +90,6 @@ jobs:
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
       - name: Run tests for t1 volume pipelines
         run: |
           make env.conda

--- a/.github/workflows/test_pipelines_anat_freesurfer.yml
+++ b/.github/workflows/test_pipelines_anat_freesurfer.yml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: read
 
-env:
-  POETRY_VERSION: '1.6.1'
-  PYTHON_VERSION: '3.10'
-
 jobs:
   test-pipelines-anat-freesurfer-MacOS:
     runs-on:
@@ -19,7 +15,6 @@ jobs:
     timeout-minutes: 1440
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
       - name: Run tests for anat pipelines using freesurfer
         run: |
           make env.conda
@@ -45,14 +40,6 @@ jobs:
     timeout-minutes: 1440
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
       - name: Run tests for anat pipelines using freesurfer
         run: |
           make env.conda

--- a/.github/workflows/test_pipelines_dwi.yml
+++ b/.github/workflows/test_pipelines_dwi.yml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: read
 
-env:
-  POETRY_VERSION: '1.6.1'
-  PYTHON_VERSION: '3.10'
-
 jobs:
   test-dwi-MacOS:
     runs-on:
@@ -19,7 +15,6 @@ jobs:
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
       - name: Run tests for dwi pipelines
         run: |
           make env.conda
@@ -47,14 +42,6 @@ jobs:
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
       - name: Run tests for dwi pipelines
         run: |
           make env.conda

--- a/.github/workflows/test_pipelines_dwi_preprocessing.yml
+++ b/.github/workflows/test_pipelines_dwi_preprocessing.yml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: read
 
-env:
-  POETRY_VERSION: '1.6.1'
-  PYTHON_VERSION: '3.10'
-
 jobs:
   test-dwi-preproc-t1-MacOS:
     runs-on:
@@ -19,7 +15,6 @@ jobs:
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
       - name: Run tests for dwi pre-processing using t1 pipelines
         run: |
           make env.conda
@@ -44,7 +39,6 @@ jobs:
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
       - name: Run tests for dwi pre-processing using phasediff pipelines
         run: |
           make env.conda
@@ -70,14 +64,6 @@ jobs:
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
       - name: Run tests for dwi pre-processing using t1 pipelines
         run: |
           make env.conda
@@ -103,14 +89,6 @@ jobs:
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY_VERSION }}
-          virtualenvs-create: false
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: poetry
       - name: Run tests for dwi pre-processing using phasediff pipelines
         run: |
           make env.conda

--- a/.github/workflows/test_pipelines_pet.yml
+++ b/.github/workflows/test_pipelines_pet.yml
@@ -15,7 +15,6 @@ jobs:
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
       - name: Run tests for pet pipelines
         run: |
           make env.conda
@@ -41,7 +40,6 @@ jobs:
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@v4
-      - uses: snok/install-poetry@v1
       - name: Run tests for pet pipelines
         run: |
           make env.conda

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - mrtrix3
 dependencies:
-  - python=3.10
+  - python=3.11
   - dcm2niix
   - petpvc
   - convert3d


### PR DESCRIPTION
- Remove the auto-installation of Poetry in the pipelines (maintainers install and upgrade poetry directly on the VMs when needed)
- Bump poetry from 1.6.1 to 1.8.3
- Clean all virtual environments to start afresh
- Bump the Python version in the `environment.yml` from 3.10 to 3.11