### PR TITLE
[FIX] Update the version of dcm2niix required to run clinica converters

### DIFF
--- a/docs/Software/Third-party.md
+++ b/docs/Software/Third-party.md
@@ -42,7 +42,7 @@ Some converters require **dcm2niix** to transform DICOM files into NIfTI :
 ### DCM2NIX
 
 !!! warning "Version required"
-    Clinica requires dcm2niix version `1.0.20190902` or later.
+    Clinica requires dcm2niix version `1.0.20230411` or later.
 
 Please check the installation instructions for all platforms on [dcm2niix Git repository](https://github.com/rordenlab/dcm2niix#install).
 


### PR DESCRIPTION
Following users issues and some tests, it seems the version of dcm2niix can cause trouble when converting some images. We should recommend a more recent version of dcm2niix in our documentation. WDYT @NicolasGensollen ?