### PR TITLE
[REF] Refactor function `clip_img`

### DIFF
--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -298,10 +298,11 @@ class PETLinear(PETPipeline):
             name="clipping",
             interface=nutil.Function(
                 function=clip_task,
-                input_names=["input_pet"],
+                input_names=["input_pet", "output_dir"],
                 output_names=["output_image"],
             ),
         )
+        clipping_node.inputs.output_dir = self.base_dir
 
         # 2. `RegistrationSynQuick` by *ANTS*. It uses nipype interface.
         ants_registration_node = npe.Node(

--- a/clinica/pipelines/pet/linear/tasks.py
+++ b/clinica/pipelines/pet/linear/tasks.py
@@ -18,12 +18,16 @@ def perform_suvr_normalization_task(
 
 def clip_task(
     input_pet: str,
+    output_dir: str = None,
 ) -> str:
     from pathlib import Path
 
     from clinica.pipelines.pet.linear.utils import clip_img
 
-    return str(clip_img(Path(input_pet)))
+    if output_dir:
+        output_dir = Path(output_dir)
+
+    return str(clip_img(Path(input_pet), output_dir=output_dir))
 
 
 def rename_into_caps_task(

--- a/clinica/pipelines/pet/linear/utils.py
+++ b/clinica/pipelines/pet/linear/utils.py
@@ -9,6 +9,7 @@ _all__ = [
     "perform_suvr_normalization",
     "rename_into_caps",
     "print_end_pipeline",
+    "clip_img",
 ]
 
 
@@ -108,15 +109,17 @@ def perform_suvr_normalization(
     return output_image
 
 
-def clip_img(
-    pet_image_path: Path,
-) -> Path:
-    """Clip PET images to remove preprocessing artifacts leading to negative values
+def clip_img(pet_image_path: Path, output_dir: Optional[Path] = None) -> Path:
+    """Clip PET images to remove preprocessing artifacts leading to negative values.
 
     Parameters
     ----------
     pet_image_path : Path
         The path to the image to be processed.
+
+    output_dir : Path, optional
+        The path to the folder in which the output image should be written.
+        If None, the image will be written in the current directory.
 
     Returns
     -------
@@ -126,24 +129,14 @@ def clip_img(
     import nibabel as nib
     import numpy as np
 
-    from clinica.utils.filemanip import get_filename_no_ext
-
-    pet_image = nib.load(pet_image_path)
+    from clinica.utils.image import clip_nifti
 
     unique, counts = np.unique(
-        pet_image.get_fdata().reshape(-1), axis=0, return_counts=True
+        nib.load(pet_image_path).get_fdata().reshape(-1), axis=0, return_counts=True
     )
     clip_threshold = max(0.0, unique[np.argmax(counts)])
 
-    data = np.clip(
-        pet_image.get_fdata(dtype="float32"), a_min=clip_threshold, a_max=None
-    )
-
-    output_image = Path.cwd() / f"{get_filename_no_ext(pet_image_path)}_clipped.nii.gz"
-    clipped_pet = nib.Nifti1Image(data, pet_image.affine, header=pet_image.header)
-    clipped_pet.to_filename(output_image)
-
-    return output_image
+    return clip_nifti(pet_image_path, low=clip_threshold, output_dir=output_dir)
 
 
 def rename_into_caps(

--- a/clinica/pipelines/pet/linear/utils.py
+++ b/clinica/pipelines/pet/linear/utils.py
@@ -126,17 +126,24 @@ def clip_img(pet_image_path: Path, output_dir: Optional[Path] = None) -> Path:
     output_img : Path
         The path to the normalized nifti image.
     """
+    from clinica.utils.image import clip_nifti
+
+    return clip_nifti(
+        pet_image_path,
+        low=_compute_clipping_threshold(pet_image_path),
+        output_dir=output_dir,
+    )
+
+
+def _compute_clipping_threshold(pet_image_path: Path) -> float:
+    """Compute the clipping threshold for PET images background cleaning."""
     import nibabel as nib
     import numpy as np
-
-    from clinica.utils.image import clip_nifti
 
     unique, counts = np.unique(
         nib.load(pet_image_path).get_fdata().reshape(-1), axis=0, return_counts=True
     )
-    clip_threshold = max(0.0, unique[np.argmax(counts)])
-
-    return clip_nifti(pet_image_path, low=clip_threshold, output_dir=output_dir)
+    return max(0.0, unique[np.argmax(counts)])
 
 
 def rename_into_caps(


### PR DESCRIPTION
Follow-up PR of #1355 

This PR proposes to:

- Add a new `clip_nifti` function to `clinica.utils.image` for generic clipping of nifty images
- Refactor `clip_img` to use `clip_nifti` with the computed threshold
- Provide the pipeline base directory as the `output_dir` of the clipping task such that clipped images aren't written in the current folder.
- Add unit tests for function `clip_nifti` and `clip_img`