### PR TITLE
[ENH] Skip visits for which processed images exist

### DIFF
--- a/clinica/pipelines/anatomical/freesurfer/longitudinal/correction/pipeline.py
+++ b/clinica/pipelines/anatomical/freesurfer/longitudinal/correction/pipeline.py
@@ -1,4 +1,5 @@
 from clinica.pipelines.engine import Pipeline
+from clinica.utils.bids import Visit
 
 
 class T1FreeSurferLongitudinalCorrection(Pipeline):

--- a/clinica/pipelines/anatomical/freesurfer/longitudinal/correction/pipeline.py
+++ b/clinica/pipelines/anatomical/freesurfer/longitudinal/correction/pipeline.py
@@ -1,5 +1,4 @@
 from clinica.pipelines.engine import Pipeline
-from clinica.utils.bids import Visit
 
 
 class T1FreeSurferLongitudinalCorrection(Pipeline):

--- a/clinica/pipelines/engine.py
+++ b/clinica/pipelines/engine.py
@@ -622,7 +622,7 @@ class Pipeline(Workflow):
         """
         from clinica.utils.stream import log_and_warn
 
-        visits_already_processed = self.get_processed_images()
+        visits_already_processed = self.get_processed_visits()
         if len(visits_already_processed) == 0:
             return
         message = (
@@ -636,10 +636,9 @@ class Pipeline(Workflow):
             visit for visit in self.visits if visit not in visits_already_processed
         ]
 
-    @abc.abstractmethod
-    def get_processed_images(self) -> list[Visit]:
-        """Extract processed image IDs in `caps_directory` based on `subjects`_`sessions`."""
-        raise NotImplemented
+    def get_processed_visits(self) -> list[Visit]:
+        """Examine the files present in the CAPS output folder and return the visits for which processing has already been done."""
+        return []
 
     def _init_nodes(self) -> None:
         """Init the basic workflow and I/O nodes necessary before build."""

--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -46,7 +46,7 @@ class PETLinear(PETPipeline):
                 pet_linear_nii(
                     acq_label=self.parameters["acq_label"],
                     suvr_reference_region=self.parameters["suvr_reference_region"],
-                    uncropped_image=self.parameters["uncropped_image"],
+                    uncropped_image=self.parameters.get("uncropped_image", False),
                 ),
             )
             processed_visits.extend(extract_visits(cropped_files))

--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -32,7 +32,7 @@ class PETLinear(PETPipeline):
         """Check dependencies that can not be listed in the `info.json` file."""
         pass
 
-    def get_processed_images(self) -> list[Visit]:
+    def get_processed_visits(self) -> list[Visit]:
         from clinica.utils.filemanip import extract_visits
         from clinica.utils.input_files import pet_linear_nii
         from clinica.utils.inputs import clinica_file_reader

--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -68,7 +68,7 @@ class AnatLinear(Pipeline):
             caps_name=caps_name,
         )
 
-    def get_processed_images(self) -> list[Visit]:
+    def get_processed_visits(self) -> list[Visit]:
         from clinica.utils.filemanip import extract_visits
         from clinica.utils.input_files import T1W_LINEAR, T1W_LINEAR_CROPPED
         from clinica.utils.inputs import clinica_file_reader

--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -70,7 +70,7 @@ class AnatLinear(Pipeline):
 
     def get_processed_images(self) -> list[Visit]:
         from clinica.utils.filemanip import extract_visits
-        from clinica.utils.input_files import T1W_LINEAR_CROPPED
+        from clinica.utils.input_files import T1W_LINEAR, T1W_LINEAR_CROPPED
         from clinica.utils.inputs import clinica_file_reader
 
         processed_visits: list[Visit] = []
@@ -79,7 +79,9 @@ class AnatLinear(Pipeline):
                 self.subjects,
                 self.sessions,
                 self.caps_directory,
-                T1W_LINEAR_CROPPED,
+                T1W_LINEAR
+                if self.parameters.get("uncropped_image", False)
+                else T1W_LINEAR_CROPPED,
             )
             processed_visits.extend(extract_visits(cropped_files))
         return processed_visits

--- a/clinica/utils/bids.py
+++ b/clinica/utils/bids.py
@@ -12,9 +12,19 @@ __all__ = [
     "BIDS_VERSION",
     "Extension",
     "Suffix",
+    "Visit",
 ]
 
 BIDS_VERSION = Version("1.7.0")
+
+
+@dataclass
+class Visit:
+    subject: str
+    session: str
+
+    def __str__(self) -> str:
+        return f"{self.subject} {self.session}"
 
 
 class Extension(str, Enum):

--- a/clinica/utils/bids.py
+++ b/clinica/utils/bids.py
@@ -18,10 +18,20 @@ __all__ = [
 BIDS_VERSION = Version("1.7.0")
 
 
-@dataclass
+@dataclass(frozen=True)
 class Visit:
     subject: str
     session: str
+
+    def __lt__(self, obj):
+        return (self.subject < obj.subject) or (
+            self.subject == obj.subject and self.session < obj.session
+        )
+
+    def __gt__(self, obj):
+        return (self.subject > obj.subject) or (
+            self.subject == obj.subject and self.session > obj.session
+        )
 
     def __str__(self) -> str:
         return f"{self.subject} {self.session}"

--- a/clinica/utils/filemanip.py
+++ b/clinica/utils/filemanip.py
@@ -2,12 +2,15 @@ from os import PathLike
 from pathlib import Path
 from typing import Callable, List, Optional, Union
 
+from .bids import Visit
+
 __all__ = [
     "UserProvidedPath",
     "delete_directories",
     "delete_directories_task",
     "extract_crash_files_from_log_file",
     "extract_image_ids",
+    "extract_visits",
     "extract_metadata_from_json",
     "extract_subjects_sessions_from_filename",
     "get_filename_no_ext",
@@ -363,6 +366,13 @@ def extract_image_ids(bids_or_caps_files: list[str]) -> list[str]:
         id_bids_or_caps_files.append(match.group())
 
     return id_bids_or_caps_files
+
+
+def extract_visits(bids_or_caps_files: list[str]) -> list[Visit]:
+    return [
+        Visit(*image_id.split("_"))
+        for image_id in extract_image_ids(bids_or_caps_files)
+    ]
 
 
 def extract_subjects_sessions_from_filename(

--- a/clinica/utils/input_files.py
+++ b/clinica/utils/input_files.py
@@ -704,6 +704,18 @@ def pet_linear_nii(
     return information
 
 
+def pet_linear_transformation_matrix(tracer: Union[str, Tracer]) -> dict:
+    from pathlib import Path
+
+    tracer = Tracer(tracer)
+
+    return {
+        "pattern": Path("pet_linear") / f"*_trc-{tracer.value}_pet_space-T1w_rigid.mat",
+        "description": "Rigid transformation matrix between the PET and T1w images estimated with ANTs.",
+        "needed_pipeline": "pet-linear",
+    }
+
+
 # CUSTOM
 def custom_pipeline(pattern, description):
     information = {"pattern": pattern, "description": description}

--- a/clinica/utils/input_files.py
+++ b/clinica/utils/input_files.py
@@ -724,7 +724,7 @@ def pet_linear_nii(
     information = {
         "pattern": Path("pet_linear")
         / _clean_pattern(
-            f"*{tracer_filter}_pet{space_filer}{description}{resolution_filter}{region_filter}_pet.nii.gz"
+            f"*{tracer_filter}{space_filer}{description}{resolution_filter}{region_filter}_pet.nii.gz"
         ),
         "description": (
             f"{'Cropped ' if space == 'mni' and not uncropped_image else ''}PET nifti image{resolution_description}"
@@ -741,7 +741,7 @@ def pet_linear_transformation_matrix(tracer: Union[str, Tracer]) -> dict:
     tracer = Tracer(tracer)
 
     return {
-        "pattern": Path("pet_linear") / f"*_trc-{tracer.value}_pet_space-T1w_rigid.mat",
+        "pattern": Path("pet_linear") / f"*_trc-{tracer.value}_space-T1w_rigid.mat",
         "description": "Rigid transformation matrix between the PET and T1w images estimated with ANTs.",
         "needed_pipeline": "pet-linear",
     }

--- a/clinica/utils/input_files.py
+++ b/clinica/utils/input_files.py
@@ -680,25 +680,56 @@ def pet_volume_normalized_suvr_pet(
     return information
 
 
+def _clean_pattern(pattern: str, character: str = "*") -> str:
+    """Removes multiple '*' wildcards in provided pattern."""
+    cleaned = []
+    for c in pattern:
+        if not cleaned or not cleaned[-1] == c == character:
+            cleaned.append(c)
+    return "".join(cleaned)
+
+
 def pet_linear_nii(
-    acq_label: Union[str, Tracer],
-    suvr_reference_region: Union[str, SUVRReferenceRegion],
-    uncropped_image: bool,
+    acq_label: Optional[Union[str, Tracer]] = None,
+    suvr_reference_region: Optional[Union[str, SUVRReferenceRegion]] = None,
+    uncropped_image: bool = False,
+    space: str = "mni",
+    resolution: Optional[int] = None,
 ) -> dict:
     from pathlib import Path
 
-    acq_label = Tracer(acq_label)
-    region = SUVRReferenceRegion(suvr_reference_region)
-
-    if uncropped_image:
-        description = ""
-    else:
+    tracer_filter = "*"
+    tracer_description = ""
+    if acq_label:
+        acq_label = Tracer(acq_label)
+        tracer_filter = f"_trc-{acq_label.value}"
+        tracer_description = f" obtained with tracer {acq_label.value}"
+    region_filter = "*"
+    region_description = ""
+    if suvr_reference_region:
+        region = SUVRReferenceRegion(suvr_reference_region)
+        region_filter = f"_suvr-{region.value}"
+        region_description = f" for SUVR region {region.value}"
+    space_filer = f"_space-{'MNI152NLin2009cSym' if space == 'mni' else 'T1w'}"
+    space_description = f" affinely registered to the {'MNI152NLin2009cSym template' if space == 'mni' else 'associated T1w image'}"
+    description = "*"
+    if space == "mni" and not uncropped_image:
         description = "_desc-Crop"
-
+    resolution_filter = "*"
+    resolution_description = ""
+    if resolution:
+        resolution_explicit = f"{resolution}x{resolution}x{resolution}"
+        resolution_filter = f"_res-{resolution_explicit}"
+        resolution_description = f" of resolution {resolution_explicit}"
     information = {
         "pattern": Path("pet_linear")
-        / f"*_trc-{acq_label.value}_pet_space-MNI152NLin2009cSym{description}_res-1x1x1_suvr-{region.value}_pet.nii.gz",
-        "description": "",
+        / _clean_pattern(
+            f"*{tracer_filter}_pet{space_filer}{description}{resolution_filter}{region_filter}_pet.nii.gz"
+        ),
+        "description": (
+            f"{'Cropped ' if space == 'mni' and not uncropped_image else ''}PET nifti image{resolution_description}"
+            f"{tracer_description}{region_description}{space_description} resulting from the pet-linear pipeline"
+        ),
         "needed_pipeline": "pet-linear",
     }
     return information

--- a/clinica/utils/testing_utils.py
+++ b/clinica/utils/testing_utils.py
@@ -223,14 +223,11 @@ def _build_subjects(directory: Path, configuration: dict) -> None:
 def _build_t1_linear(directory: Path, sub: str, ses: str, config: dict) -> None:
     """Build a fake t1-linear file structure in a CAPS directory."""
     uncropped = config.get("uncropped_image", False)
-    (
-        directory
-        / "subjects"
-        / sub
-        / ses
-        / "t1_linear"
-        / f"{sub}_{ses}_space-MNI152NLin2009cSym{'' if uncropped else '_desc-Crop'}_res-1x1x1_T1w.nii.gz"
-    ).touch()
+    for filename in (
+        f"{sub}_{ses}_space-MNI152NLin2009cSym{'' if uncropped else '_desc-Crop'}_res-1x1x1_T1w.nii.gz",
+        f"{sub}_{ses}_space-MNI152NLin2009cSym_res-1x1x1_affine.mat",
+    ):
+        (directory / "subjects" / sub / ses / "t1_linear" / filename).touch()
 
 
 def _build_pet_linear(directory: Path, sub: str, ses: str, config: dict) -> None:

--- a/clinica/utils/testing_utils.py
+++ b/clinica/utils/testing_utils.py
@@ -243,11 +243,11 @@ def _build_pet_linear(directory: Path, sub: str, ses: str, config: dict) -> None
             / sub
             / ses
             / "pet_linear"
-            / f"{sub}_{ses}_trc-{tracer.value}_pet_space-T1w_pet.nii.gz"
+            / f"{sub}_{ses}_trc-{tracer.value}_space-T1w_pet.nii.gz"
         ).touch()
     for filename in (
-        f"{sub}_{ses}_trc-{tracer.value}_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-{suvr.value}_pet.nii.gz",
-        f"{sub}_{ses}_trc-{tracer.value}_pet_space-T1w_rigid.mat",
+        f"{sub}_{ses}_trc-{tracer.value}_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-{suvr.value}_pet.nii.gz",
+        f"{sub}_{ses}_trc-{tracer.value}_space-T1w_rigid.mat",
     ):
         (directory / "subjects" / sub / ses / "pet_linear" / filename).touch()
 

--- a/clinica/utils/testing_utils.py
+++ b/clinica/utils/testing_utils.py
@@ -236,6 +236,15 @@ def _build_pet_linear(directory: Path, sub: str, ses: str, config: dict) -> None
 
     tracer = Tracer(config["acq_label"])
     suvr = SUVRReferenceRegion(config["suvr_reference_region"])
+    if config.get("save_PETinT1w", False):
+        (
+            directory
+            / "subjects"
+            / sub
+            / ses
+            / "pet_linear"
+            / f"{sub}_{ses}_trc-{tracer.value}_pet_space-T1w_pet.nii.gz"
+        ).touch()
     for filename in (
         f"{sub}_{ses}_trc-{tracer.value}_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-{suvr.value}_pet.nii.gz",
         f"{sub}_{ses}_trc-{tracer.value}_pet_space-T1w_rigid.mat",

--- a/clinica/utils/testing_utils.py
+++ b/clinica/utils/testing_utils.py
@@ -150,7 +150,8 @@ def build_caps_directory(directory: Path, configuration: dict) -> Path:
         Dictionary containing the configuration for building the fake CAPS
         directory. It should have the following structure:
             - "groups": ["group_labels"...]
-            - "pipelines": ["pipeline_names"...]
+            - "pipelines": {"pipeline_names": config}, where config is a dictionary
+              specifying more details for the files that should be written.
             - "subjects": {"subject_labels": ["session_labels"...]}.
 
     Returns

--- a/clinica/utils/testing_utils.py
+++ b/clinica/utils/testing_utils.py
@@ -186,13 +186,13 @@ def _build_groups(directory: Path, configuration: dict) -> None:
         (directory / "groups").mkdir()
         for group_label in configuration["groups"]:
             (directory / "groups" / f"group-{group_label}").mkdir()
-            for pipeline in configuration["pipelines"]:
-                (directory / "groups" / f"group-{group_label}" / pipeline).mkdir()
+            for pipeline_name, pipeline_config in configuration["pipelines"].items():
+                (directory / "groups" / f"group-{group_label}" / pipeline_name).mkdir()
                 (
                     directory
                     / "groups"
                     / f"group-{group_label}"
-                    / pipeline
+                    / pipeline_name
                     / f"group-{group_label}_template.nii.gz"
                 ).touch()
 
@@ -205,23 +205,26 @@ def _build_subjects(directory: Path, configuration: dict) -> None:
             (directory / "subjects" / sub).mkdir()
             for ses in sessions:
                 (directory / "subjects" / sub / ses).mkdir()
-                for pipeline in configuration["pipelines"]:
-                    (directory / "subjects" / sub / ses / pipeline).mkdir()
-                    if pipeline == "t1_linear":
-                        _build_t1_linear(directory, sub, ses)
-                    if pipeline == "t1":
+                for pipeline_name, pipeline_config in configuration[
+                    "pipelines"
+                ].items():
+                    (directory / "subjects" / sub / ses / pipeline_name).mkdir()
+                    if pipeline_name == "t1_linear":
+                        _build_t1_linear(directory, sub, ses, pipeline_config)
+                    if pipeline_name == "t1":
                         _build_t1(directory, sub, ses, configuration)
 
 
-def _build_t1_linear(directory: Path, sub: str, ses: str) -> None:
+def _build_t1_linear(directory: Path, sub: str, ses: str, config: dict) -> None:
     """Build a fake t1-linear file structure in a CAPS directory."""
+    uncropped = config.get("uncropped_image", False)
     (
         directory
         / "subjects"
         / sub
         / ses
         / "t1_linear"
-        / f"{sub}_{ses}_T1w_space-MNI152NLin2009cSym_res-1x1x1_T1w.nii.gz"
+        / f"{sub}_{ses}_space-MNI152NLin2009cSym{'' if uncropped else '_desc-Crop'}_res-1x1x1_T1w.nii.gz"
     ).touch()
 
 

--- a/test/unittests/pipelines/anatomical/freesurfer/atlas/test_t1_freesurfer_atlas_pipeline.py
+++ b/test/unittests/pipelines/anatomical/freesurfer/atlas/test_t1_freesurfer_atlas_pipeline.py
@@ -6,7 +6,7 @@ def test_t1_freesurfer_atlas_info_loading(tmp_path):
 
     caps = build_caps_directory(
         tmp_path / "caps",
-        {"pipelines": ["compute-atlas"], "subjects": {"sub-01": ["ses-M000"]}},
+        {"pipelines": {"compute-atlas": {}}, "subjects": {"sub-01": ["ses-M000"]}},
     )
     pipeline = T1FreeSurferAtlas(caps_directory=str(caps))
 
@@ -35,7 +35,7 @@ def test_t1_freesurfer_atlas_dependencies(tmp_path, mocker):
     )
     caps = build_caps_directory(
         tmp_path / "caps",
-        {"pipelines": ["compute-atlas"], "subjects": {"sub-01": ["ses-M000"]}},
+        {"pipelines": {"compute-atlas": {}}, "subjects": {"sub-01": ["ses-M000"]}},
     )
     pipeline = T1FreeSurferAtlas(caps_directory=str(caps))
 

--- a/test/unittests/pipelines/anatomical/freesurfer/longitudinal/correction/test_t1_freesurfer_longitudinal_correction_pipeline.py
+++ b/test/unittests/pipelines/anatomical/freesurfer/longitudinal/correction/test_t1_freesurfer_longitudinal_correction_pipeline.py
@@ -8,7 +8,7 @@ def test_t1_freesurfer_longitudinal_correction_info_loading(tmp_path):
 
     caps = build_caps_directory(
         tmp_path / "caps",
-        {"pipelines": ["compute-atlas"], "subjects": {"sub-01": ["ses-M000"]}},
+        {"pipelines": {"compute-atlas": {}}, "subjects": {"sub-01": ["ses-M000"]}},
     )
     pipeline = T1FreeSurferLongitudinalCorrection(caps_directory=str(caps))
 
@@ -40,7 +40,7 @@ def test_t1_freesurfer_longitudinal_correction_dependencies(tmp_path, mocker):
     caps = build_caps_directory(
         tmp_path / "caps",
         {
-            "pipelines": ["t1-freesurfer-longitudinal-correction"],
+            "pipelines": {"t1-freesurfer-longitudinal-correction": {}},
             "subjects": {"sub-01": ["ses-M000"]},
         },
     )

--- a/test/unittests/pipelines/anatomical/freesurfer/longitudinal/template/test_t1_freesurfer_longitudinal_template_pipeline.py
+++ b/test/unittests/pipelines/anatomical/freesurfer/longitudinal/template/test_t1_freesurfer_longitudinal_template_pipeline.py
@@ -8,7 +8,7 @@ def test_t1_freesurfer_longitudinal_template_info_loading(tmp_path):
 
     caps = build_caps_directory(
         tmp_path / "caps",
-        {"pipelines": ["compute-atlas"], "subjects": {"sub-01": ["ses-M000"]}},
+        {"pipelines": {"compute-atlas": {}}, "subjects": {"sub-01": ["ses-M000"]}},
     )
     pipeline = T1FreeSurferTemplate(caps_directory=str(caps))
 
@@ -39,7 +39,10 @@ def test_t1_freesurfer_longitudinal_template_dependencies(tmp_path, mocker):
     )
     caps = build_caps_directory(
         tmp_path / "caps",
-        {"pipelines": ["t1-freesurfer-template"], "subjects": {"sub-01": ["ses-M000"]}},
+        {
+            "pipelines": {"t1-freesurfer-template": {}},
+            "subjects": {"sub-01": ["ses-M000"]},
+        },
     )
     pipeline = T1FreeSurferTemplate(caps_directory=str(caps))
 

--- a/test/unittests/pipelines/dwi/connectome/test_dwi_connectome_pipeline.py
+++ b/test/unittests/pipelines/dwi/connectome/test_dwi_connectome_pipeline.py
@@ -6,7 +6,7 @@ def test_dwi_connectome_info_loading(tmp_path):
 
     caps = build_caps_directory(
         tmp_path / "caps",
-        {"pipelines": ["dwi-connectome"], "subjects": {"sub-01": ["ses-M000"]}},
+        {"pipelines": {"dwi-connectome": {}}, "subjects": {"sub-01": ["ses-M000"]}},
     )
     pipeline = DwiConnectome(caps_directory=str(caps))
 
@@ -45,7 +45,7 @@ def test_dwi_connectome_dependencies(tmp_path, mocker):
     )
     caps = build_caps_directory(
         tmp_path / "caps",
-        {"pipelines": ["dwi-connectome"], "subjects": {"sub-01": ["ses-M000"]}},
+        {"pipelines": {"dwi-connectome": {}}, "subjects": {"sub-01": ["ses-M000"]}},
     )
     pipeline = DwiConnectome(caps_directory=str(caps))
 

--- a/test/unittests/pipelines/dwi/dti/test_dwi_dti_pipeline.py
+++ b/test/unittests/pipelines/dwi/dti/test_dwi_dti_pipeline.py
@@ -6,7 +6,7 @@ def test_dwi_dti_info_loading(tmp_path):
 
     caps = build_caps_directory(
         tmp_path / "caps",
-        {"pipelines": ["dwi-dti"], "subjects": {"sub-01": ["ses-M000"]}},
+        {"pipelines": {"dwi-dti": {}}, "subjects": {"sub-01": ["ses-M000"]}},
     )
     pipeline = DwiDti(caps_directory=str(caps))
 
@@ -45,7 +45,7 @@ def test_dwi_dti_dependencies(tmp_path, mocker):
     )
     caps = build_caps_directory(
         tmp_path / "caps",
-        {"pipelines": ["dwi-dti"], "subjects": {"sub-01": ["ses-M000"]}},
+        {"pipelines": {"dwi-dti": {}}, "subjects": {"sub-01": ["ses-M000"]}},
     )
     pipeline = DwiDti(caps_directory=str(caps))
 

--- a/test/unittests/pipelines/dwi/preprocessing/test_dwi_preprocessing_using_fmap_pipeline.py
+++ b/test/unittests/pipelines/dwi/preprocessing/test_dwi_preprocessing_using_fmap_pipeline.py
@@ -9,7 +9,7 @@ def test_dwi_preprocessing_using_fmap_info_loading(tmp_path):
     caps = build_caps_directory(
         tmp_path / "caps",
         {
-            "pipelines": ["dwi-preprocessing-using-phasediff-fmap"],
+            "pipelines": {"dwi-preprocessing-using-phasediff-fmap": {}},
             "subjects": {"sub-01": ["ses-M000"]},
         },
     )
@@ -54,7 +54,7 @@ def test_dwi_preprocessing_using_fmap_dependencies(tmp_path, mocker):
     caps = build_caps_directory(
         tmp_path / "caps",
         {
-            "pipelines": ["dwi-preprocessing-using-phasediff-fmap"],
+            "pipelines": {"dwi-preprocessing-using-phasediff-fmap": {}},
             "subjects": {"sub-01": ["ses-M000"]},
         },
     )

--- a/test/unittests/pipelines/dwi/preprocessing/test_dwi_preprocessing_using_t1_pipeline.py
+++ b/test/unittests/pipelines/dwi/preprocessing/test_dwi_preprocessing_using_t1_pipeline.py
@@ -13,7 +13,7 @@ def test_dwi_preprocessing_using_t1_info_loading(tmp_path):
     caps = build_caps_directory(
         tmp_path / "caps",
         {
-            "pipelines": ["dwi-preprocessing-using-t1"],
+            "pipelines": {"dwi-preprocessing-using-t1": {}},
             "subjects": {"sub-01": ["ses-M000"]},
         },
     )
@@ -66,7 +66,7 @@ def test_dwi_preprocessing_using_t1_dependencies(tmp_path, mocker):
     caps = build_caps_directory(
         tmp_path / "caps",
         {
-            "pipelines": ["dwi-preprocessing-using-t1"],
+            "pipelines": {"dwi-preprocessing-using-t1": {}},
             "subjects": {"sub-01": ["ses-M000"]},
         },
     )

--- a/test/unittests/pipelines/pet/test_pet_linear_pipeline.py
+++ b/test/unittests/pipelines/pet/test_pet_linear_pipeline.py
@@ -76,24 +76,24 @@ def test_pet_linear_get_processed_visits(tmp_path, mocker):
         ├── sub-01
         │         ├── ses-M000
         │         │         └── pet_linear
-        │         │             ├── sub-01_ses-M000_trc-18FAV45_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons2_pet.nii.gz
-        │         │             └── sub-01_ses-M000_trc-18FAV45_pet_space-T1w_rigid.mat
+        │         │             ├── sub-01_ses-M000_trc-18FAV45_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons2_pet.nii.gz
+        │         │             └── sub-01_ses-M000_trc-18FAV45_space-T1w_rigid.mat
         │         └── ses-M006
         │             └── pet_linear
-        │                 ├── sub-01_ses-M006_trc-18FAV45_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons2_pet.nii.gz
-        │                 ├── sub-01_ses-M006_trc-18FAV45_pet_space-T1w_rigid.mat
-        │                 ├── sub-01_ses-M006_trc-18FFDG_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons_pet.nii.gz
-        │                 └── sub-01_ses-M006_trc-18FFDG_pet_space-T1w_rigid.mat
+        │                 ├── sub-01_ses-M006_trc-18FAV45_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons2_pet.nii.gz
+        │                 ├── sub-01_ses-M006_trc-18FAV45_space-T1w_rigid.mat
+        │                 ├── sub-01_ses-M006_trc-18FFDG_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons_pet.nii.gz
+        │                 └── sub-01_ses-M006_trc-18FFDG_space-T1w_rigid.mat
         └── sub-02
             ├── ses-M000
             │         └── pet_linear
-            │             ├── sub-02_ses-M000_trc-18FFDG_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons_pet.nii.gz
-            │             ├── sub-02_ses-M000_trc-18FFDG_pet_space-T1w_pet.nii.gz
-            │             └── sub-02_ses-M000_trc-18FFDG_pet_space-T1w_rigid.mat
+            │             ├── sub-02_ses-M000_trc-18FFDG_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons_pet.nii.gz
+            │             ├── sub-02_ses-M000_trc-18FFDG_space-T1w_pet.nii.gz
+            │             └── sub-02_ses-M000_trc-18FFDG_space-T1w_rigid.mat
             └── ses-M006
                 └── pet_linear
-                    ├── sub-02_ses-M006_trc-18FAV45_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons2_pet.nii.gz
-                    └── sub-02_ses-M006_trc-18FAV45_pet_space-T1w_rigid.mat
+                    ├── sub-02_ses-M006_trc-18FAV45_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons2_pet.nii.gz
+                    └── sub-02_ses-M006_trc-18FAV45_space-T1w_rigid.mat
 
     And make sure that a PETLinear pipeline with tracer 18FFDG et pons SUVR will only consider
     (sub-01, ses-M006) and (sub-02, ses-M000) as already processed. The other folders contain
@@ -149,7 +149,7 @@ def test_pet_linear_get_processed_visits(tmp_path, mocker):
         / "sub-01"
         / "ses-M006"
         / "pet_linear"
-        / "sub-01_ses-M006_trc-18FFDG_pet_space-T1w_pet.nii.gz"
+        / "sub-01_ses-M006_trc-18FFDG_space-T1w_pet.nii.gz"
     ).unlink()
     pipeline = PETLinear(
         bids_directory=str(bids),
@@ -186,7 +186,7 @@ def test_pet_linear_get_processed_visits(tmp_path, mocker):
         / "sub-01"
         / "ses-M006"
         / "pet_linear"
-        / "sub-01_ses-M006_trc-18FFDG_pet_space-T1w_rigid.mat"
+        / "sub-01_ses-M006_trc-18FFDG_space-T1w_rigid.mat"
     ).unlink()
 
     # The corresponding visit is not considered as "processed" anymore because the transformation is

--- a/test/unittests/pipelines/pet/test_pet_linear_pipeline.py
+++ b/test/unittests/pipelines/pet/test_pet_linear_pipeline.py
@@ -155,3 +155,17 @@ def test_pet_linear_get_processed_visits(tmp_path, mocker):
         Visit("sub-01", "ses-M006"),
         Visit("sub-02", "ses-M000"),
     ]
+
+    # We remove the transformation matrix of the tracer of interest for sub-01 and session M006
+    (
+        caps
+        / "subjects"
+        / "sub-01"
+        / "ses-M006"
+        / "pet_linear"
+        / "sub-01_ses-M006_trc-18FFDG_pet_space-T1w_rigid.mat"
+    ).unlink()
+
+    # The corresponding visit is not considered as "processed" anymore because the transformation is
+    # missing (even though the pet image is still here...)
+    assert pipeline.get_processed_visits() == [Visit("sub-02", "ses-M000")]

--- a/test/unittests/pipelines/pet/test_pet_linear_pipeline.py
+++ b/test/unittests/pipelines/pet/test_pet_linear_pipeline.py
@@ -62,7 +62,7 @@ def test_pet_linear_get_processed_visits_empty(tmp_path, mocker):
             "uncropped_image": False,
         },
     )
-    assert pipeline.get_processed_images() == []
+    assert pipeline.get_processed_visits() == []
 
 
 def test_pet_linear_get_processed_visits(tmp_path, mocker):
@@ -151,7 +151,7 @@ def test_pet_linear_get_processed_visits(tmp_path, mocker):
         },
     )
 
-    assert pipeline.get_processed_images() == [
+    assert pipeline.get_processed_visits() == [
         Visit("sub-01", "ses-M006"),
         Visit("sub-02", "ses-M000"),
     ]

--- a/test/unittests/pipelines/pet/test_pet_linear_pipeline.py
+++ b/test/unittests/pipelines/pet/test_pet_linear_pipeline.py
@@ -88,6 +88,7 @@ def test_pet_linear_get_processed_visits(tmp_path, mocker):
             ├── ses-M000
             │         └── pet_linear
             │             ├── sub-02_ses-M000_trc-18FFDG_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons_pet.nii.gz
+            │             ├── sub-02_ses-M000_trc-18FFDG_pet_space-T1w_pet.nii.gz
             │             └── sub-02_ses-M000_trc-18FFDG_pet_space-T1w_rigid.mat
             └── ses-M006
                 └── pet_linear
@@ -116,6 +117,7 @@ def test_pet_linear_get_processed_visits(tmp_path, mocker):
                     "acq_label": Tracer.FDG,
                     "suvr_reference_region": SUVRReferenceRegion.PONS,
                     "uncropped_image": False,
+                    "save_PETinT1w": True,
                 }
             },
             "subjects": {
@@ -140,6 +142,26 @@ def test_pet_linear_get_processed_visits(tmp_path, mocker):
             },
         },
     )
+    # We remove the pet image registered on the T1w image for sub-01 and session M006
+    (
+        caps
+        / "subjects"
+        / "sub-01"
+        / "ses-M006"
+        / "pet_linear"
+        / "sub-01_ses-M006_trc-18FFDG_pet_space-T1w_pet.nii.gz"
+    ).unlink()
+    pipeline = PETLinear(
+        bids_directory=str(bids),
+        caps_directory=str(caps),
+        parameters={
+            "acq_label": Tracer.FDG,
+            "suvr_reference_region": SUVRReferenceRegion.PONS,
+            "uncropped_image": False,
+            "save_PETinT1w": True,
+        },
+    )
+    assert pipeline.get_processed_visits() == [Visit("sub-02", "ses-M000")]
 
     pipeline = PETLinear(
         bids_directory=str(bids),
@@ -148,6 +170,7 @@ def test_pet_linear_get_processed_visits(tmp_path, mocker):
             "acq_label": Tracer.FDG,
             "suvr_reference_region": SUVRReferenceRegion.PONS,
             "uncropped_image": False,
+            "save_PETinT1w": False,
         },
     )
 

--- a/test/unittests/pipelines/pet/test_pet_linear_pipeline.py
+++ b/test/unittests/pipelines/pet/test_pet_linear_pipeline.py
@@ -1,4 +1,7 @@
-from clinica.utils.testing_utils import build_bids_directory
+from packaging.version import Version
+
+from clinica.utils.bids import Visit
+from clinica.utils.testing_utils import build_bids_directory, build_caps_directory
 
 
 def test_pet_linear_info_loading(tmp_path):
@@ -19,7 +22,6 @@ def test_pet_linear_info_loading(tmp_path):
 
 def test_pet_linear_dependencies(tmp_path, mocker):
     from packaging.specifiers import SpecifierSet
-    from packaging.version import Version
 
     from clinica.pipelines.pet.linear.pipeline import PETLinear
     from clinica.utils.check_dependency import SoftwareDependency, ThirdPartySoftware
@@ -35,4 +37,121 @@ def test_pet_linear_dependencies(tmp_path, mocker):
         SoftwareDependency(
             ThirdPartySoftware.ANTS, SpecifierSet(">=2.2.0"), Version("2.3.1")
         )
+    ]
+
+
+def test_pet_linear_get_processed_visits_empty(tmp_path, mocker):
+    from clinica.pipelines.pet.linear.pipeline import PETLinear
+    from clinica.utils.pet import SUVRReferenceRegion, Tracer
+
+    mocker.patch(
+        "clinica.utils.check_dependency._get_ants_version",
+        return_value=Version("2.3.1"),
+    )
+    bids = build_bids_directory(
+        tmp_path / "bids", {"sub-01": ["ses-M000", "ses-M006"], "sub-02": ["ses-M000"]}
+    )
+    caps = build_caps_directory(tmp_path / "caps", {})
+
+    pipeline = PETLinear(
+        bids_directory=str(bids),
+        caps_directory=str(caps),
+        parameters={
+            "acq_label": Tracer.FDG,
+            "suvr_reference_region": SUVRReferenceRegion.PONS,
+            "uncropped_image": False,
+        },
+    )
+    assert pipeline.get_processed_images() == []
+
+
+def test_pet_linear_get_processed_visits(tmp_path, mocker):
+    """Test the get_processed_visits for PETLinear.
+
+    We build the following CAPS dataset:
+
+    caps
+    ├── dataset_description.json
+    └── subjects
+        ├── sub-01
+        │         ├── ses-M000
+        │         │         └── pet_linear
+        │         │             ├── sub-01_ses-M000_trc-18FAV45_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons2_pet.nii.gz
+        │         │             └── sub-01_ses-M000_trc-18FAV45_pet_space-T1w_rigid.mat
+        │         └── ses-M006
+        │             └── pet_linear
+        │                 ├── sub-01_ses-M006_trc-18FAV45_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons2_pet.nii.gz
+        │                 ├── sub-01_ses-M006_trc-18FAV45_pet_space-T1w_rigid.mat
+        │                 ├── sub-01_ses-M006_trc-18FFDG_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons_pet.nii.gz
+        │                 └── sub-01_ses-M006_trc-18FFDG_pet_space-T1w_rigid.mat
+        └── sub-02
+            ├── ses-M000
+            │         └── pet_linear
+            │             ├── sub-02_ses-M000_trc-18FFDG_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons_pet.nii.gz
+            │             └── sub-02_ses-M000_trc-18FFDG_pet_space-T1w_rigid.mat
+            └── ses-M006
+                └── pet_linear
+                    ├── sub-02_ses-M006_trc-18FAV45_pet_space-MNI152NLin2009cSym_desc-Crop_res-1x1x1_suvr-pons2_pet.nii.gz
+                    └── sub-02_ses-M006_trc-18FAV45_pet_space-T1w_rigid.mat
+
+    And make sure that a PETLinear pipeline with tracer 18FFDG et pons SUVR will only consider
+    (sub-01, ses-M006) and (sub-02, ses-M000) as already processed. The other folders contain
+    PET images for the pet-linear pipeline but they were obtained with different tracers and SUVR.
+    """
+    from clinica.pipelines.pet.linear.pipeline import PETLinear
+    from clinica.utils.pet import SUVRReferenceRegion, Tracer
+
+    mocker.patch(
+        "clinica.utils.check_dependency._get_ants_version",
+        return_value=Version("2.3.1"),
+    )
+    bids = build_bids_directory(
+        tmp_path / "bids", {"sub-01": ["ses-M000", "ses-M006"], "sub-02": ["ses-M000"]}
+    )
+    caps = build_caps_directory(
+        tmp_path / "caps",
+        {
+            "pipelines": {
+                "pet_linear": {
+                    "acq_label": Tracer.FDG,
+                    "suvr_reference_region": SUVRReferenceRegion.PONS,
+                    "uncropped_image": False,
+                }
+            },
+            "subjects": {
+                "sub-01": ["ses-M006"],
+                "sub-02": ["ses-M000"],
+            },
+        },
+    )
+    caps = build_caps_directory(
+        tmp_path / "caps",
+        {
+            "pipelines": {
+                "pet_linear": {
+                    "acq_label": Tracer.AV45,
+                    "suvr_reference_region": SUVRReferenceRegion.PONS2,
+                    "uncropped_image": False,
+                }
+            },
+            "subjects": {
+                "sub-01": ["ses-M000", "ses-M006"],
+                "sub-02": ["ses-M006"],
+            },
+        },
+    )
+
+    pipeline = PETLinear(
+        bids_directory=str(bids),
+        caps_directory=str(caps),
+        parameters={
+            "acq_label": Tracer.FDG,
+            "suvr_reference_region": SUVRReferenceRegion.PONS,
+            "uncropped_image": False,
+        },
+    )
+
+    assert pipeline.get_processed_images() == [
+        Visit("sub-01", "ses-M006"),
+        Visit("sub-02", "ses-M000"),
     ]

--- a/test/unittests/pipelines/t1_linear/test_anat_linear_pipeline.py
+++ b/test/unittests/pipelines/t1_linear/test_anat_linear_pipeline.py
@@ -244,3 +244,123 @@ def test_anat_linear_get_processed_visits_cropped_images(
     # pipeline always find an empty list of processed images because we want cropped images
     # and the CAPS folder only contains un-cropped images
     assert pipeline.get_processed_images() == []
+
+
+@pytest.mark.parametrize(
+    "config,remaining_subjects,remaining_sessions",
+    [
+        ({}, ["sub-01", "sub-01", "sub-02"], ["ses-M000", "ses-M006", "ses-M000"]),
+        (
+            {
+                "pipelines": {"t1_linear": {"uncropped_image": False}},
+                "subjects": {"sub-01": ["ses-M006"]},
+            },
+            ["sub-01", "sub-02"],
+            ["ses-M000", "ses-M000"],
+        ),
+        (
+            {
+                "pipelines": {"t1_linear": {"uncropped_image": False}},
+                "subjects": {"sub-01": ["ses-M000", "ses-M006"]},
+            },
+            ["sub-02"],
+            ["ses-M000"],
+        ),
+        (
+            {
+                "pipelines": {"t1_linear": {"uncropped_image": False}},
+                "subjects": {
+                    "sub-01": ["ses-M000", "ses-M006"],
+                    "sub-02": ["ses-M000"],
+                },
+            },
+            [],
+            [],
+        ),
+    ],
+)
+def test_determine_subject_and_session_to_process(
+    tmp_path, mocker, config, remaining_subjects, remaining_sessions
+):
+    from clinica.pipelines.t1_linear.anat_linear_pipeline import AnatLinear
+
+    mocker.patch(
+        "clinica.utils.check_dependency._get_ants_version",
+        return_value=Version("2.2.1"),
+    )
+    bids = build_bids_directory(
+        tmp_path / "bids", {"sub-01": ["ses-M000", "ses-M006"], "sub-02": ["ses-M000"]}
+    )
+    caps = build_caps_directory(tmp_path / "caps", config)
+    pipeline = AnatLinear(
+        bids_directory=str(bids),
+        caps_directory=str(caps),
+        parameters={"uncropped_image": False},
+    )
+    pipeline.determine_subject_and_session_to_process()
+    pipeline2 = AnatLinear(
+        bids_directory=str(bids),
+        caps_directory=str(caps),
+        parameters={"uncropped_image": True},
+    )
+    pipeline2.determine_subject_and_session_to_process()
+
+    assert pipeline.subjects == remaining_subjects
+    assert pipeline.sessions == remaining_sessions
+    assert pipeline2.subjects == ["sub-01", "sub-01", "sub-02"]
+    assert pipeline2.sessions == ["ses-M000", "ses-M006", "ses-M000"]
+
+
+@pytest.mark.parametrize(
+    "configuration,expected_message",
+    [
+        (
+            {
+                "pipelines": {"t1_linear": {"uncropped_image": False}},
+                "subjects": {
+                    "sub-01": ["ses-M000", "ses-M006"],
+                    "sub-02": ["ses-M000"],
+                },
+            },
+            (
+                "Clinica found already processed images for 3 visit(s):"
+                "\n- sub-01 ses-M000\n- sub-01 ses-M006\n- sub-02 ses-M000"
+                "\nThose visits will be ignored by Clinica."
+            ),
+        ),
+        (
+            {
+                "pipelines": {"t1_linear": {"uncropped_image": False}},
+                "subjects": {"sub-01": ["ses-M000", "ses-M006"]},
+            },
+            (
+                "Clinica found already processed images for 2 visit(s):"
+                "\n- sub-01 ses-M000\n- sub-01 ses-M006"
+                "\nThose visits will be ignored by Clinica."
+            ),
+        ),
+    ],
+)
+def test_determine_subject_and_session_to_process_warning(
+    tmp_path, mocker, configuration, expected_message
+):
+    from clinica.pipelines.t1_linear.anat_linear_pipeline import AnatLinear
+
+    mocker.patch(
+        "clinica.utils.check_dependency._get_ants_version",
+        return_value=Version("2.2.1"),
+    )
+    bids = build_bids_directory(
+        tmp_path / "bids", {"sub-01": ["ses-M000", "ses-M006"], "sub-02": ["ses-M000"]}
+    )
+    caps = build_caps_directory(tmp_path / "caps", configuration)
+    pipeline = AnatLinear(
+        bids_directory=str(bids),
+        caps_directory=str(caps),
+        parameters={"uncropped_image": False},
+    )
+    with pytest.warns(
+        UserWarning,
+        match=re.escape(f"In the provided CAPS folder {caps}, {expected_message}"),
+    ):
+        pipeline.determine_subject_and_session_to_process()

--- a/test/unittests/pipelines/t1_linear/test_anat_linear_pipeline.py
+++ b/test/unittests/pipelines/t1_linear/test_anat_linear_pipeline.py
@@ -176,10 +176,10 @@ def test_anat_linear_get_processed_visits_uncropped_images(
         parameters={"uncropped_image": True},
     )
 
-    assert pipeline.get_processed_images() == expected
+    assert pipeline.get_processed_visits() == expected
     # pipeline2 always find an empty list of processed images because we want un-cropped images
     # and the CAPS folder only contains cropped images
-    assert pipeline2.get_processed_images() == []
+    assert pipeline2.get_processed_visits() == []
 
 
 @pytest.mark.parametrize(
@@ -240,10 +240,10 @@ def test_anat_linear_get_processed_visits_cropped_images(
         parameters={"uncropped_image": True},
     )
 
-    assert pipeline2.get_processed_images() == expected
+    assert pipeline2.get_processed_visits() == expected
     # pipeline always find an empty list of processed images because we want cropped images
     # and the CAPS folder only contains un-cropped images
-    assert pipeline.get_processed_images() == []
+    assert pipeline.get_processed_visits() == []
 
 
 @pytest.mark.parametrize(

--- a/test/unittests/pipelines/t1_volume_create_dartel/test_t1_volume_create_dartel_pipeline.py
+++ b/test/unittests/pipelines/t1_volume_create_dartel/test_t1_volume_create_dartel_pipeline.py
@@ -9,7 +9,7 @@ def test_t1_volume_create_dartel_info_loading(tmp_path):
     caps = build_caps_directory(
         tmp_path / "caps",
         {
-            "pipelines": ["t1-volume-create-dartel"],
+            "pipelines": {"t1-volume-create-dartel": {}},
             "subjects": {"sub-01": ["ses-M000"]},
         },
     )
@@ -41,7 +41,7 @@ def test_t1_volume_create_dartel_dependencies(tmp_path, mocker):
     caps = build_caps_directory(
         tmp_path / "caps",
         {
-            "pipelines": ["t1-volume-create-dartel"],
+            "pipelines": {"t1-volume-create-dartel": {}},
             "subjects": {"sub-01": ["ses-M000"]},
         },
     )

--- a/test/unittests/pipelines/t1_volume_dartel2mni/test_t1_volume_dartel2mni_pipeline.py
+++ b/test/unittests/pipelines/t1_volume_dartel2mni/test_t1_volume_dartel2mni_pipeline.py
@@ -8,7 +8,10 @@ def test_t1_volume_dartel2mni_info_loading(tmp_path):
 
     caps = build_caps_directory(
         tmp_path / "caps",
-        {"pipelines": ["t1-volume-dartel2mni"], "subjects": {"sub-01": ["ses-M000"]}},
+        {
+            "pipelines": {"t1-volume-dartel2mni": {}},
+            "subjects": {"sub-01": ["ses-M000"]},
+        },
     )
     pipeline = T1VolumeDartel2MNI(caps_directory=str(caps), group_label="test")
 
@@ -37,7 +40,10 @@ def test_t1_volume_dartel2mni_dependencies(tmp_path, mocker):
     )
     caps = build_caps_directory(
         tmp_path / "caps",
-        {"pipelines": ["t1-volume-dartel2mni"], "subjects": {"sub-01": ["ses-M000"]}},
+        {
+            "pipelines": {"t1-volume-dartel2mni": {}},
+            "subjects": {"sub-01": ["ses-M000"]},
+        },
     )
     pipeline = T1VolumeDartel2MNI(caps_directory=str(caps), group_label="test")
 

--- a/test/unittests/pipelines/t1_volume_parcellation/test_t1_volume_parcellation_pipeline.py
+++ b/test/unittests/pipelines/t1_volume_parcellation/test_t1_volume_parcellation_pipeline.py
@@ -8,7 +8,10 @@ def test_t1_volume_parcellation_info_loading(tmp_path):
 
     caps = build_caps_directory(
         tmp_path / "caps",
-        {"pipelines": ["t1-volume-parcellation"], "subjects": {"sub-01": ["ses-M000"]}},
+        {
+            "pipelines": {"t1-volume-parcellation": {}},
+            "subjects": {"sub-01": ["ses-M000"]},
+        },
     )
     pipeline = T1VolumeParcellation(caps_directory=str(caps), group_label="test")
 
@@ -29,7 +32,10 @@ def test_t1_volume_parcellation_dependencies(tmp_path):
 
     caps = build_caps_directory(
         tmp_path / "caps",
-        {"pipelines": ["t1-volume-parcellation"], "subjects": {"sub-01": ["ses-M000"]}},
+        {
+            "pipelines": {"t1-volume-parcellation": {}},
+            "subjects": {"sub-01": ["ses-M000"]},
+        },
     )
     pipeline = T1VolumeParcellation(caps_directory=str(caps), group_label="test")
 

--- a/test/unittests/pipelines/t1_volume_register_dartel/test_t1_volume_register_dartel_pipeline.py
+++ b/test/unittests/pipelines/t1_volume_register_dartel/test_t1_volume_register_dartel_pipeline.py
@@ -9,7 +9,7 @@ def test_t1_volume_register_dartel_info_loading(tmp_path):
     caps = build_caps_directory(
         tmp_path / "caps",
         {
-            "pipelines": ["t1-volume-register-dartel"],
+            "pipelines": {"t1-volume-register-dartel": {}},
             "subjects": {"sub-01": ["ses-M000"]},
         },
     )
@@ -41,7 +41,7 @@ def test_t1_volume_register_dartel_dependencies(tmp_path, mocker):
     caps = build_caps_directory(
         tmp_path / "caps",
         {
-            "pipelines": ["t1-volume-register-dartel"],
+            "pipelines": {"t1-volume-register-dartel": {}},
             "subjects": {"sub-01": ["ses-M000"]},
         },
     )

--- a/test/unittests/pipelines/t1_volume_tissue_segmentation/test_t1_volume_tissue_segmentation_pipeline.py
+++ b/test/unittests/pipelines/t1_volume_tissue_segmentation/test_t1_volume_tissue_segmentation_pipeline.py
@@ -9,7 +9,7 @@ def test_t1_volume_tissue_segmentation_info_loading(tmp_path):
     caps = build_caps_directory(
         tmp_path / "caps",
         {
-            "pipelines": ["t1-volume-tissue-segmentation"],
+            "pipelines": {"t1-volume-tissue-segmentation": {}},
             "subjects": {"sub-01": ["ses-M000"]},
         },
     )
@@ -42,7 +42,7 @@ def test_t1_volume_tissue_segmentation_dependencies(tmp_path, mocker):
     caps = build_caps_directory(
         tmp_path / "caps",
         {
-            "pipelines": ["t1-volume-tissue-segmentation"],
+            "pipelines": {"t1-volume-tissue-segmentation": {}},
             "subjects": {"sub-01": ["ses-M000"]},
         },
     )

--- a/test/unittests/pydra/test_interfaces.py
+++ b/test/unittests/pydra/test_interfaces.py
@@ -63,7 +63,7 @@ def test_caps_reader(tmp_path):
 
     structure = {
         "groups": ["UnitTest"],
-        "pipelines": ["t1"],
+        "pipelines": {"t1": {}},
         "subjects": {
             "sub-01": ["ses-M00", "ses-M06"],
             "sub-03": ["ses-M00"],

--- a/test/unittests/utils/test_input_files.py
+++ b/test/unittests/utils/test_input_files.py
@@ -98,7 +98,7 @@ def test_dwi_dti_query_error():
                 "Cropped PET nifti image affinely registered to the MNI152NLin2009cSym "
                 "template resulting from the pet-linear pipeline"
             ),
-            "pet_linear/*_pet_space-MNI152NLin2009cSym_desc-Crop*_pet.nii.gz",
+            "pet_linear/*_space-MNI152NLin2009cSym_desc-Crop*_pet.nii.gz",
         ),
         (
             {
@@ -108,7 +108,7 @@ def test_dwi_dti_query_error():
                 "Cropped PET nifti image obtained with tracer 18FFDG affinely registered to the "
                 "MNI152NLin2009cSym template resulting from the pet-linear pipeline"
             ),
-            "pet_linear/*_trc-18FFDG_pet_space-MNI152NLin2009cSym_desc-Crop*_pet.nii.gz",
+            "pet_linear/*_trc-18FFDG_space-MNI152NLin2009cSym_desc-Crop*_pet.nii.gz",
         ),
         (
             {
@@ -121,7 +121,7 @@ def test_dwi_dti_query_error():
                 "PET nifti image of resolution 2x2x2 obtained with tracer 18FAV45 for SUVR region "
                 "pons affinely registered to the MNI152NLin2009cSym template resulting from the pet-linear pipeline"
             ),
-            "pet_linear/*_trc-18FAV45_pet_space-MNI152NLin2009cSym*_res-2x2x2_suvr-pons_pet.nii.gz",
+            "pet_linear/*_trc-18FAV45_space-MNI152NLin2009cSym*_res-2x2x2_suvr-pons_pet.nii.gz",
         ),
         (
             {
@@ -133,7 +133,7 @@ def test_dwi_dti_query_error():
                 "PET nifti image of resolution 2x2x2 for SUVR region pons2 affinely "
                 "registered to the associated T1w image resulting from the pet-linear pipeline"
             ),
-            "pet_linear/*_pet_space-T1w*_res-2x2x2_suvr-pons2_pet.nii.gz",
+            "pet_linear/*_space-T1w*_res-2x2x2_suvr-pons2_pet.nii.gz",
         ),
         (
             {
@@ -144,7 +144,7 @@ def test_dwi_dti_query_error():
                 "PET nifti image obtained with tracer 18FFDG affinely registered to the "
                 "associated T1w image resulting from the pet-linear pipeline"
             ),
-            "pet_linear/*_trc-18FFDG_pet_space-T1w*_pet.nii.gz",
+            "pet_linear/*_trc-18FFDG_space-T1w*_pet.nii.gz",
         ),
     ],
 )

--- a/test/unittests/utils/test_input_files.py
+++ b/test/unittests/utils/test_input_files.py
@@ -87,3 +87,72 @@ def test_dwi_dti_query_error():
         match="'foo' is not a valid DTIBasedMeasure",
     ):
         dwi_dti("foo")
+
+
+@pytest.mark.parametrize(
+    "input_parameters,expected_description,expected_pattern",
+    [
+        (
+            {},
+            (
+                "Cropped PET nifti image affinely registered to the MNI152NLin2009cSym "
+                "template resulting from the pet-linear pipeline"
+            ),
+            "pet_linear/*_pet_space-MNI152NLin2009cSym_desc-Crop*_pet.nii.gz",
+        ),
+        (
+            {
+                "acq_label": "18FFDG",
+            },
+            (
+                "Cropped PET nifti image obtained with tracer 18FFDG affinely registered to the "
+                "MNI152NLin2009cSym template resulting from the pet-linear pipeline"
+            ),
+            "pet_linear/*_trc-18FFDG_pet_space-MNI152NLin2009cSym_desc-Crop*_pet.nii.gz",
+        ),
+        (
+            {
+                "acq_label": "18FAV45",
+                "suvr_reference_region": "pons",
+                "uncropped_image": True,
+                "resolution": 2,
+            },
+            (
+                "PET nifti image of resolution 2x2x2 obtained with tracer 18FAV45 for SUVR region "
+                "pons affinely registered to the MNI152NLin2009cSym template resulting from the pet-linear pipeline"
+            ),
+            "pet_linear/*_trc-18FAV45_pet_space-MNI152NLin2009cSym*_res-2x2x2_suvr-pons_pet.nii.gz",
+        ),
+        (
+            {
+                "suvr_reference_region": "pons2",
+                "resolution": 2,
+                "space": "T1w",
+            },
+            (
+                "PET nifti image of resolution 2x2x2 for SUVR region pons2 affinely "
+                "registered to the associated T1w image resulting from the pet-linear pipeline"
+            ),
+            "pet_linear/*_pet_space-T1w*_res-2x2x2_suvr-pons2_pet.nii.gz",
+        ),
+        (
+            {
+                "acq_label": "18FFDG",
+                "space": "T1w",
+            },
+            (
+                "PET nifti image obtained with tracer 18FFDG affinely registered to the "
+                "associated T1w image resulting from the pet-linear pipeline"
+            ),
+            "pet_linear/*_trc-18FFDG_pet_space-T1w*_pet.nii.gz",
+        ),
+    ],
+)
+def test_pet_linear_nii(input_parameters, expected_description, expected_pattern):
+    from clinica.utils.input_files import pet_linear_nii
+
+    query = pet_linear_nii(**input_parameters)
+
+    assert query["description"] == expected_description
+    assert query["needed_pipeline"] == "pet-linear"
+    assert str(query["pattern"]) == expected_pattern

--- a/test/unittests/utils/test_utils_inputs.py
+++ b/test/unittests/utils/test_utils_inputs.py
@@ -631,7 +631,7 @@ def test_clinica_file_reader_caps_directory(tmp_path):
     from clinica.utils.inputs import clinica_file_reader
 
     config = {
-        "pipelines": ["t1_linear"],
+        "pipelines": {"t1_linear": {"uncropped_image": True}},
         "subjects": {
             "sub-01": ["ses-M00"],
             "sub-02": ["ses-M00", "ses-M06"],


### PR DESCRIPTION
Closes #1079 

This PR proposes to improve how pipelines determine which subject-session to skip. 

### Context 

The base idea is to analyze the provided CAPS folder before running the processing pipeline and look for the expected output files. If those files are present for a given subject-session, then it won't be processed by the pipeline. This can save quite some time when re-running a pipeline.

This idea is definitely not new and some pipelines are already doing that (`T1Linear` and some Freesurfer longitudinal pipelines). Concretely, this is done in this method where the files are searched in the CAPS output folder:

https://github.com/aramis-lab/clinica/blob/7436f440a335794ffd1315c0936b797e7b11bca8/clinica/pipelines/t1_linear/anat_linear_pipeline.py#L71-L87

The initial feature request of #1079 was to implement this logic for `PETLinear` too.

The method above considers that, whatever the user is asking, if the cropped image is found for a subject-session, then it will be skipped. In other words, if the user is asking for the un-cropped image, or if interested in the transformation matrix rather than the image, then the pipeline will still skip the subject-session, which isn't great.

Instead, the method should look for both the transformation and the image corresponding to the user-provided parameters, and only skip the subject-session if both are present.

For `PETLinear` the idea is the same except that we need to take more parameters into account (tracer, SUVR...).

### Implementation

The diff is a bit long (sorry about that...), so here are the main ideas and implementation decisions:

There is a new dataclass called `Visit`, which is only a convenient way to represent a subject-session. I could also have used a NamedTuple but went for a frozen dataclass instead. Lists of `Visit` objects can be turned into sets (because they are frozen) and sorted (because they implement ordering): for example `("sub-02", "ses-M006") > ("sub-01", "ses-M100")` or `("sub-01", "ses-M006") > ("sub-01", "ses-M000")`. This class is in `clinica.utils.bids` but might better fit somewhere else ?

The previous method `get_processed_images` was renamed `get_processed_visits` and returns a list of `Visit` for which processing is assumed to have been done.

The skipping logic was moved from the concrete pipeline class to the base class (i.e. in the base `Pipeline` class in `engine.py`). It is done in the `determine_subject_and_session_to_process` method, which calls the `get_processed_visits` abstract method to know what subjects and sessions to remove. `get_processed_visits` has to be implemented in child classes as it is pipeline-specific.
The PR proposes the implementation of this method for `T1Linear` and `PETLinear`. Some "pattern builders" had to be implemented in `clinica.utils.input_files` in order to be able to query new types of files (for example the transformation matrices in the pet-linear outputs, see function `pet_linear_transformation_matrix`).

Most of the other changes are due to the implementation of the unit tests.

I had to modify a bit the CAPS generator to:

- generate pet-linear folders
- generate more than the nifti images (transformation matrices)
- accept more parameters to write the appropriate files (tracer, SUVR, cropped vs. uncropped, ...)

Because of the last point, the API of the CAPS generator had to change a bit (the desired pipelines to generate is not a list of strings anymore, but a dictionary mapping pipeline names to a dictionary of parameters). A lot of test files were only changed to use the new API.

### Usage

Basically, through the CLI, when passing a CAPS folder with existing files, the user should get a warning displaying the visits that will be skipped:

```bash
$ clinica run pet-linear ./in/bids ./ref/caps 18FFDG pons
2024-11-27 15:42:31,431:INFO:Found installation of ants with version 2.3.5, satisfying >=2.2.0.
2024-11-27 15:42:31,462:WARNING:In the provided CAPS folder /Users/nicolas.gensollen/GitRepos/clinica_data_ci/data_ci/PETLinear/ref/caps, Clinica found already processed images for 3 visit(s):
- sub-ADNI029S1384 ses-M000
- sub-ADNI029S1384 ses-M006
- sub-ADNI037S4015 ses-M000
Those visits will be ignored by Clinica.
```