### PR TITLE
[FIX] Fix pet-linear with option `--save_pet_in_t1w_space`

### DIFF
--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -500,7 +500,12 @@ class PETLinear(PETPipeline):
                     (
                         clipping_node,
                         ants_applytransform_optional_node,
-                        [("output_image", "input_image"), ("t1w", "reference_image")],
+                        [("output_image", "input_image")],
+                    ),
+                    (
+                        self.input_node,
+                        ants_applytransform_optional_node,
+                        [("t1w", "reference_image")],
                     ),
                     (
                         ants_registration_node,

--- a/test/nonregression/pipelines/pet/test_pet_linear.py
+++ b/test/nonregression/pipelines/pet/test_pet_linear.py
@@ -23,6 +23,7 @@ def run_pet_linear(
     parameters = {
         "acq_label": Tracer.FDG,
         "suvr_reference_region": SUVRReferenceRegion.PONS,
+        "save_PETinT1w": True,
     }
 
     pipeline = PETLinear(


### PR DESCRIPTION
Closes #1401 

Requires data PR https://github.com/aramis-lab/clinica_data_ci/pull/79 for the non regression tests to pass with the added option.