### PR TITLE
[FIX] `Center_Nifti` should run by default on T1

### DIFF
--- a/clinica/iotools/utils/center_nifti.py
+++ b/clinica/iotools/utils/center_nifti.py
@@ -59,9 +59,7 @@ def center_nifti(
             if not file.name.startswith(".")
         ]
         if files and not overwrite_existing_files:
-            raise ClinicaExistingDatasetError(
-                output_bids_directory
-            )  # todo : triggered by .DS_Store
+            raise ClinicaExistingDatasetError(output_bids_directory)
     cprint("Clinica is now centering the requested images.", lvl="info")
 
     centered_files = center_all_nifti(
@@ -76,13 +74,13 @@ def center_nifti(
     if not write_list_of_files(centered_files, log_file):
         log_and_raise(f"Could not create log file {log_file}.", IOError)
 
-    # todo : better formatting for modalities print
-
     cprint(
-        f"{len(centered_files)} NIfTI files/images of BIDS folder:\n"
+        f"{len(centered_files)} NIfTI images of BIDS folder:\n"
         f"\t{bids_directory}\n"
-        f"for the modalities {modalities} have been centered in output folder:\n"
-        f"\t{output_bids_directory}",
+        f"have been centered in the output folder:\n"
+        f"\t{output_bids_directory}\n"
+        f"for modalities:\n"
+        f"\t{(', ').join(modalities)}",
         lvl="info",
     )
     if log_file.is_file():

--- a/clinica/iotools/utils/center_nifti.py
+++ b/clinica/iotools/utils/center_nifti.py
@@ -59,7 +59,9 @@ def center_nifti(
             if not file.name.startswith(".")
         ]
         if files and not overwrite_existing_files:
-            raise ClinicaExistingDatasetError(output_bids_directory)
+            raise ClinicaExistingDatasetError(
+                output_bids_directory
+            )  # todo : triggered by .DS_Store
     cprint("Clinica is now centering the requested images.", lvl="info")
 
     centered_files = center_all_nifti(
@@ -73,6 +75,8 @@ def center_nifti(
     log_file = output_bids_directory / f"centered_nifti_list_{timestamp}.txt"
     if not write_list_of_files(centered_files, log_file):
         log_and_raise(f"Could not create log file {log_file}.", IOError)
+
+    # todo : better formatting for modalities print
 
     cprint(
         f"{len(centered_files)} NIfTI files/images of BIDS folder:\n"

--- a/clinica/iotools/utils/center_nifti.py
+++ b/clinica/iotools/utils/center_nifti.py
@@ -68,11 +68,6 @@ def center_nifti(
         modalities,
         center_all_files,
     )
-    # Write list of created files
-    timestamp = time.strftime("%Y%m%d-%H%M%S", time.localtime(time.time()))
-    log_file = output_bids_directory / f"centered_nifti_list_{timestamp}.txt"
-    if not write_list_of_files(centered_files, log_file):
-        log_and_raise(f"Could not create log file {log_file}.", IOError)
 
     cprint(
         f"{len(centered_files)} NIfTI images of BIDS folder:\n"
@@ -80,15 +75,19 @@ def center_nifti(
         f"have been centered in the output folder:\n"
         f"\t{output_bids_directory}\n"
         f"for modalities:\n"
-        f"\t{(', ').join(modalities)}",
+        f"\t{modalities}\n"
+        f"Please note that the rest of the input BIDS folder has also been copied to the output folder.",
         lvl="info",
     )
+
+    # Write list of created files
+    timestamp = time.strftime("%Y%m%d-%H%M%S", time.localtime(time.time()))
+    log_file = output_bids_directory / f"centered_nifti_list_{timestamp}.txt"
+    if not write_list_of_files(centered_files, log_file):
+        log_and_raise(f"Could not create log file {log_file}.", IOError)
+
     if log_file.is_file():
         cprint(
             f"The list of centered NIfTI files is available here: {log_file}.",
             lvl="info",
         )
-    cprint(
-        "Please note that the rest of the input BIDS folder has also been copied to the output folder.",
-        lvl="info",
-    )

--- a/clinica/iotools/utils/cli.py
+++ b/clinica/iotools/utils/cli.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Iterable, List, Optional, Union
 
 import click
 
@@ -37,12 +37,13 @@ def describe(dataset: Union[str, Path]):
     multiple=True,
     metavar="modalities",
     help="Process selected modalities.",
+    default=("T1w",),
 )
 @click.option("--center-all-files", is_flag=True, help="Force processing of all files.")
 def center_nifti(
     bids_directory: str,
     output_bids_directory: str,
-    modalities: Optional[List[str]] = None,
+    modalities: Optional[Iterable[str]] = None,
     center_all_files: bool = False,
 ) -> None:
     """Center NIfTI files in a BIDS dataset."""
@@ -58,7 +59,7 @@ def center_nifti(
             output_bids_directory,
             modalities=modalities,
             center_all_files=center_all_files,
-            overwrite_existing_files=False,
+            overwrite_existing_files=False,  # todo : technically can remove this one
         )
     except ClinicaExistingDatasetError:
         click.echo(

--- a/clinica/iotools/utils/data_handling/_centering.py
+++ b/clinica/iotools/utils/data_handling/_centering.py
@@ -274,7 +274,7 @@ def _compute_l2_norm(file_couples: List[Tuple[Path, Path]]) -> List[float]:
 def _find_files_with_modality(
     files_dir: PathLike, modalities: Optional[Iterable[str]] = None
 ) -> List[Path]:
-    nifti_files = files_dir.glob("*.nii*")
+    nifti_files = files_dir.rglob("*.nii*")
     nifti_files_filtered = []
 
     if modalities is None:

--- a/clinica/iotools/utils/data_handling/_centering.py
+++ b/clinica/iotools/utils/data_handling/_centering.py
@@ -272,7 +272,7 @@ def _compute_l2_norm(file_couples: List[Tuple[Path, Path]]) -> List[float]:
 
 
 def _find_files_with_modality(
-    files_dir: PathLike, modalities: Optional[Iterable[str]] = None
+    files_dir: Path, modalities: Optional[Iterable[str]] = None
 ) -> List[Path]:
     nifti_files = files_dir.rglob("*.nii*")
     nifti_files_filtered = []
@@ -280,7 +280,7 @@ def _find_files_with_modality(
     if modalities is None:
         return nifti_files
     for f in nifti_files:
-        if any(elem.lower() in f.name.lower() for elem in modalities):
+        if any(modality.lower() in f.name.lower() for modality in modalities):
             nifti_files_filtered.append(f)
     return nifti_files_filtered
 

--- a/clinica/iotools/utils/data_handling/_centering.py
+++ b/clinica/iotools/utils/data_handling/_centering.py
@@ -271,6 +271,20 @@ def _compute_l2_norm(file_couples: List[Tuple[Path, Path]]) -> List[float]:
     return [np.linalg.norm(center[0] - center[1]) for center in center_coordinates]
 
 
+def _find_files_with_modality(
+    files_dir: PathLike, modalities: Optional[Iterable[str]] = None
+) -> List[Path]:
+    nifti_files = files_dir.glob("*.nii*")
+    nifti_files_filtered = []
+
+    if modalities is None:
+        return nifti_files
+    for f in nifti_files:
+        if any(elem.lower() in f.name.lower() for elem in modalities):
+            nifti_files_filtered.append(f)
+    return nifti_files_filtered
+
+
 def center_all_nifti(
     bids_dir: PathLike,
     output_dir: PathLike,
@@ -311,12 +325,7 @@ def center_all_nifti(
             copytree(f, output_dir / f.name, copy_function=copy)
         elif f.is_file() and not (output_dir / f.name).is_file():
             copy(f, output_dir / f.name)
-    nifti_files_filtered: List[Path] = []
-    for f in output_dir.glob("**/*.nii*"):
-        if modalities is None or any(
-            elem.lower() in f.name.lower() for elem in modalities
-        ):
-            nifti_files_filtered.append(f)
+    nifti_files_filtered = _find_files_with_modality(output_dir, modalities)
     if not center_all_files:
         nifti_files_filtered = [
             file for file in nifti_files_filtered if not _is_centered(file)

--- a/docs/IO.md
+++ b/docs/IO.md
@@ -245,31 +245,15 @@ This folder can be empty or nonexistent.
 
 Optional arguments:
 
-- `--modality` is a parameter that defines which modalities are converted.
+- `--modality` is a case-insensitive parameter that defines which modalities are converted.
 
-    !!! tip
-    If you want to convert FDG PET images (e.g. with `_trc-18FFDG` key/value in PET filename), use:
+    !!! tip "How to use :"
+        - If you want to convert T1w images only, do not use the option.
+        - If you want to convert all types of pet, use `--modality pet` or `-m pet`
+        - If you want to convert 18FFDG_PET, use `-m 18ffdg_pet`
+        - If you want to convert both pet and T1, use `-m T1 -m pet`
 
-    ```shell
-    clinica iotools center-nifti bids_directory new_bids_directory --modality "18ffdg_pet"
-    ```
-
-    If you want to convert AV45 PET images and T1w:
-
-    ```shell
-    clinica iotools center-nifti bids_directory new_bids_directory --modality "18fav45_pet t1w"
-    ```
-
-    To know if a NIfTI image must be centered, the algorithm checks the filenames of the NIfTI images.
-    For example, regarding the file `bids/sub-01/ses-M000/anat/sub-01_ses-M000_T1w.nii`:
-
-     - The filename is `sub-01_ses-M000_T1w.nii`.
-     - The algorithm tests (in a case insensitive way) if the string `18ffdg_pet` is in the filename: False.
-     - The algorithm tests (in a case insensitive way) if the string `t1w` is in the filename: True!
-     - The algorithm tests if the volume has its center at more than 50 mm (Euclidean distance) from the origin: True.
-     - This file will be centered by the algorithm.
-
-     Understanding this, you can now center any modality you want! If your files are named following this pattern : `sub-X_ses-Y_magnitude1.nii.gz`, specify the modality as follows:`--modality "magnitude1"`.
+        Basically, the software searches for the modality key inside the filename. Understanding this, you can now center any modality you want!
 
 - `--center_all_files` is an option that forces Clinica to center all the files of the modalities selected with the `--modality` flag.
 

--- a/docs/IO.md
+++ b/docs/IO.md
@@ -224,14 +224,14 @@ A complete list of optional arguments can be obtained with the command line `cli
 
 ## `center-nifti` - Center NIfTI files of a BIDS directory
 
-Your [BIDS](http://bids.neuroimaging.io) dataset may contain NIfTI files whose origin does not correspond to the center of the image (i.e. the anterior commissure).
-SPM is especially sensitive to this case, and segmentation procedures may result in blank images, or even fail.
-To mitigate this issue, we propose a simple tool that convert your BIDS dataset into a dataset with centered NIfTI files for the selected modalities.
+Your [BIDS](http://bids.neuroimaging.io) dataset may contain NIfTI files where the origin does not correspond to the center of the image (i.e. the anterior commissure).
+SPM is especially sensitive to this case and segmentation procedures may result in blank images or even fail.
+To mitigate this issue we offer a simple tool that converts generates from your BIDS a new dataset with centered NIfTI files for the selected modalities.
 
 !!! warning "By default :"
 
-    - This tool will only center T1w images.
-    - Only NIfTI volumes whose center is at more than 50 mm from the origin of the world coordinate system are centered. This threshold has been chosen empirically after a set of experiments to determine at which distance from the origin SPM segmentation and coregistration procedures stop working properly.
+    - This tool will only center **T1w** images.
+    - Only NIfTI volumes whose center is at **more than 50 mm** from the origin of the world coordinate system are centered. This threshold has been chosen empirically after a set of experiments to determine at which distance from the origin SPM segmentation and coregistration procedures stop working properly.
 
 ```shell
 clinica iotools center-nifti [OPTIONS] BIDS_DIRECTORY OUTPUT_BIDS_DIRECTORY
@@ -240,8 +240,15 @@ clinica iotools center-nifti [OPTIONS] BIDS_DIRECTORY OUTPUT_BIDS_DIRECTORY
 where:
 
 - `BIDS_DIRECTORY` is the input folder containing the dataset in a [BIDS](http://bids.neuroimaging.io) hierarchy.
+- `OUTPUT_BIDS_DIRECTORY` is the output path to the new version of your BIDS dataset, with faulty NIfTI centered.
+This folder can be empty or nonexistent.
+
+Optional arguments:
+
+- `--modality` is a parameter that defines which modalities are converted.
+
     !!! tip
-            If you want to convert FDG PET images (e.g. with `_trc-18FFDG` key/value in PET filename), use:
+    If you want to convert FDG PET images (e.g. with `_trc-18FFDG` key/value in PET filename), use:
 
     ```shell
     clinica iotools center-nifti bids_directory new_bids_directory --modality "18ffdg_pet"
@@ -264,12 +271,6 @@ where:
 
      Understanding this, you can now center any modality you want! If your files are named following this pattern : `sub-X_ses-Y_magnitude1.nii.gz`, specify the modality as follows:`--modality "magnitude1"`.
 
-- `OUTPUT_BIDS_DIRECTORY` is the output path to the new version of your BIDS dataset, with faulty NIfTI centered.
-This folder can be empty or nonexistent.
-
-Optional arguments:
-
-- `--modality` is a parameter that defines which modalities are converted.
 - `--center_all_files` is an option that forces Clinica to center all the files of the modalities selected with the `--modality` flag.
 
 !!! note

--- a/docs/IO.md
+++ b/docs/IO.md
@@ -226,7 +226,7 @@ A complete list of optional arguments can be obtained with the command line `cli
 
 Your [BIDS](http://bids.neuroimaging.io) dataset may contain NIfTI files where the origin does not correspond to the center of the image (i.e. the anterior commissure).
 SPM is especially sensitive to this case and segmentation procedures may result in blank images or even fail.
-To mitigate this issue we offer a simple tool that converts generates from your BIDS a new dataset with centered NIfTI files for the selected modalities.
+To mitigate this issue we offer a simple tool that generates from your BIDS a new dataset with centered NIfTI files for the selected modalities.
 
 !!! warning "By default :"
 

--- a/docs/IO.md
+++ b/docs/IO.md
@@ -227,9 +227,11 @@ A complete list of optional arguments can be obtained with the command line `cli
 Your [BIDS](http://bids.neuroimaging.io) dataset may contain NIfTI files whose origin does not correspond to the center of the image (i.e. the anterior commissure).
 SPM is especially sensitive to this case, and segmentation procedures may result in blank images, or even fail.
 To mitigate this issue, we propose a simple tool that convert your BIDS dataset into a dataset with centered NIfTI files for the selected modalities.
-Only NIfTI volumes whose center is at more than 50 mm from the origin of the world coordinate system are centered (this can be changed by the `--center_all_files` flag).
-This threshold has been chosen empirically after a set of experiments to determine at which distance from the origin SPM segmentation and coregistration procedures stop working properly.
-By default, this tool will only center T1w images but you can specify other modalities.
+
+!!! warning "By default :"
+
+    - This tool will only center T1w images.
+    - Only NIfTI volumes whose center is at more than 50 mm from the origin of the world coordinate system are centered. This threshold has been chosen empirically after a set of experiments to determine at which distance from the origin SPM segmentation and coregistration procedures stop working properly.
 
 ```shell
 clinica iotools center-nifti [OPTIONS] BIDS_DIRECTORY OUTPUT_BIDS_DIRECTORY
@@ -238,18 +240,8 @@ clinica iotools center-nifti [OPTIONS] BIDS_DIRECTORY OUTPUT_BIDS_DIRECTORY
 where:
 
 - `BIDS_DIRECTORY` is the input folder containing the dataset in a [BIDS](http://bids.neuroimaging.io) hierarchy.
-- `OUTPUT_BIDS_DIRECTORY` is the output path to the new version of your BIDS dataset, with faulty NIfTI centered.
-This folder can be empty or nonexistent.
-
-Optional arguments:
-
-- `--modality` is a parameter that defines which modalities are converted (only T1w images are centered by default).
-- `--center_all_files` is an option that forces Clinica to center all the files of the modalities selected with the `--modality` flag.
-
-!!! note
-    The images contained in the input `bids_directory` folder that do not need to be centered will also be copied to the output folder `new_bids_directory`.
-
-    If you want to convert FDG PET images (e.g. with `_trc-18FFDG` key/value in PET filename), use:
+    !!! tip
+            If you want to convert FDG PET images (e.g. with `_trc-18FFDG` key/value in PET filename), use:
 
     ```shell
     clinica iotools center-nifti bids_directory new_bids_directory --modality "18ffdg_pet"
@@ -271,5 +263,16 @@ Optional arguments:
      - This file will be centered by the algorithm.
 
      Understanding this, you can now center any modality you want! If your files are named following this pattern : `sub-X_ses-Y_magnitude1.nii.gz`, specify the modality as follows:`--modality "magnitude1"`.
+
+- `OUTPUT_BIDS_DIRECTORY` is the output path to the new version of your BIDS dataset, with faulty NIfTI centered.
+This folder can be empty or nonexistent.
+
+Optional arguments:
+
+- `--modality` is a parameter that defines which modalities are converted.
+- `--center_all_files` is an option that forces Clinica to center all the files of the modalities selected with the `--modality` flag.
+
+!!! note
+    The images contained in the input `bids_directory` folder that do not need to be centered will also be copied to the output folder `new_bids_directory`.
 
      The list of the converted files will appear in a text file in `new_bids_directory/centered_nifti_list_TIMESTAMP.txt`.


### PR DESCRIPTION
Adresses part of #1413

The modalities to center were set as described in the documentation. By default, `center_nifti` will only process T1w images. It is possible to change this by using the `--modality` option and you can process several modalities at the same time. 

Modalities are not restricted to a set of known modalities on our side to give the user more freedom. That means the user could enter `-m TOTO` if they wanted to, however the implementation is at the moment not very robust. **This can be changed.**


For follow-up PR : 
- Review the CI data et non regression tests to handle more cases (command line tested?)
- Review logic to check for files since split in 2 functions. Might be more practical to move the logic for it to be tested and completed (issue if output folder does not exist yet).
- Check behavior for writing over
- Review threshold logic (see discussion below)

### What is left to discuss : 

From the documentation, this tool is used in clinica if the data should at some point be processed by SPM (hence the discussion from #1412 on T1-Freesurfer). As of now, `center-nifti` processes by default only files that are more than 50 mm away from the center. The threshold was empirically established specifically for SPM by previous users. It is definitely not intuitive if someone uses `center-nifti` for any other purpose than SPM processing. We could : 
- get rid of the threshold altogether and process all images (🥇 in my opinion)
- change the default behavior to processing all images and use an option to accelerate the processing by allowing the user to choose the treshold