### PR TITLE
[CI] Stop the macOS pipelines

### DIFF
--- a/.github/workflows/test_converters.yml
+++ b/.github/workflows/test_converters.yml
@@ -14,26 +14,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-converters-MacOS:
-    runs-on:
-      - self-hosted
-      - macOS
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run non-regression tests for converters
-        run: |
-          make env.conda
-          source ~/miniconda3/etc/profile.d/conda.sh
-          conda activate "${{ github.workspace }}"/env
-          make install
-          cd test
-          poetry run pytest --verbose \
-          --working_directory=/Volumes/data/working_dir_mac \
-          --input_data_directory=/Volumes/data_ci \
-          --basetemp=/Volumes/data/tmp \
-          --junitxml=./test-reports/run_converters_mac.xml \
-          --disable-warnings \
-          ./nonregression/iotools/test_run_converters.py
+#  test-converters-MacOS:
+#    runs-on:
+#      - self-hosted
+#      - macOS
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Run non-regression tests for converters
+#        run: |
+#          make env.conda
+#          source ~/miniconda3/etc/profile.d/conda.sh
+#          conda activate "${{ github.workspace }}"/env
+#          make install
+#          cd test
+#          poetry run pytest --verbose \
+#          --working_directory=/Volumes/data/working_dir_mac \
+#          --input_data_directory=/Volumes/data_ci \
+#          --basetemp=/Volumes/data/tmp \
+#          --junitxml=./test-reports/run_converters_mac.xml \
+#          --disable-warnings \
+#          ./nonregression/iotools/test_run_converters.py
 
   test-converters-Linux:
     runs-on:

--- a/.github/workflows/test_instantiation.yml
+++ b/.github/workflows/test_instantiation.yml
@@ -14,28 +14,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-instantiation-MacOS:
-    runs-on:
-      - self-hosted
-      - macOS
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run instantiation tests
-        run: |
-          make env.conda
-          source ~/miniconda3/etc/profile.d/conda.sh
-          conda activate "${{ github.workspace }}"/env
-          source "$(brew --prefix)/opt/modules/init/bash"
-          module load clinica.all
-          make install
-          cd test
-          poetry run pytest --verbose \
-          --working_directory=/Volumes/data/working_dir_mac \
-          --input_data_directory=/Volumes/data_ci \
-          --basetemp=/Volumes/data/tmp \
-          --junitxml=./test-reports/instantiation_mac.xml \
-          --disable-warnings \
-          ./instantiation/
+#  test-instantiation-MacOS:
+#    runs-on:
+#      - self-hosted
+#      - macOS
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Run instantiation tests
+#        run: |
+#          make env.conda
+#          source ~/miniconda3/etc/profile.d/conda.sh
+#          conda activate "${{ github.workspace }}"/env
+#          source "$(brew --prefix)/opt/modules/init/bash"
+#          module load clinica.all
+#          make install
+#          cd test
+#          poetry run pytest --verbose \
+#          --working_directory=/Volumes/data/working_dir_mac \
+#          --input_data_directory=/Volumes/data_ci \
+#          --basetemp=/Volumes/data/tmp \
+#          --junitxml=./test-reports/instantiation_mac.xml \
+#          --disable-warnings \
+#          ./instantiation/
 
   test-instantiation-Linux:
     runs-on:

--- a/.github/workflows/test_non_regression_fast.yml
+++ b/.github/workflows/test_non_regression_fast.yml
@@ -13,28 +13,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-non-regression-fast-MacOS:
-    runs-on:
-      - self-hosted
-      - macOS
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run fast non regression tests
-        run: |
-          make env.conda
-          source ~/miniconda3/etc/profile.d/conda.sh
-          conda activate "${{ github.workspace }}"/env
-          source "$(brew --prefix)/opt/modules/init/bash"
-          module load clinica.all
-          make install
-          cd test
-          poetry run pytest --verbose \
-          --working_directory=/Volumes/data/working_dir_mac \
-          --input_data_directory=/Volumes/data_ci \
-          --junitxml=./test-reports/non_regression_fast_mac.xml \
-          --disable-warnings \
-          -m "fast" \
-          ./nonregression/
+#  test-non-regression-fast-MacOS:
+#    runs-on:
+#      - self-hosted
+#      - macOS
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Run fast non regression tests
+#        run: |
+#          make env.conda
+#          source ~/miniconda3/etc/profile.d/conda.sh
+#          conda activate "${{ github.workspace }}"/env
+#          source "$(brew --prefix)/opt/modules/init/bash"
+#          module load clinica.all
+#          make install
+#          cd test
+#          poetry run pytest --verbose \
+#          --working_directory=/Volumes/data/working_dir_mac \
+#          --input_data_directory=/Volumes/data_ci \
+#          --junitxml=./test-reports/non_regression_fast_mac.xml \
+#          --disable-warnings \
+#          -m "fast" \
+#          ./nonregression/
 
   test-non-regression-fast-Linux:
     runs-on:

--- a/.github/workflows/test_pipelines_anat.yml
+++ b/.github/workflows/test_pipelines_anat.yml
@@ -8,54 +8,54 @@ permissions:
   contents: read
 
 jobs:
-  test-t1-linear-MacOS:
-    runs-on:
-      - self-hosted
-      - macOS
-    timeout-minutes: 120
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run tests for t1 linear pipelines
-        run: |
-          make env.conda
-          source ~/miniconda3/etc/profile.d/conda.sh
-          conda activate "${{ github.workspace }}"/env
-          source "$(brew --prefix)/opt/modules/init/bash"
-          module load clinica/ants/2.4.4
-          make install
-          cd test
-          poetry run pytest --verbose \
-          --working_directory=/Volumes/data/working_dir_mac \
-          --input_data_directory=/Volumes/data_ci \
-          --basetemp=/Volumes/data/tmp \
-          --junitxml=./test-reports/non_regression_anat_t1_linear_mac.xml \
-          --disable-warnings \
-          ./nonregression/pipelines/anat/test_t1_linear.py
-
-  test-t1-volume-MacOS:
-    runs-on:
-      - self-hosted
-      - macOS
-    timeout-minutes: 720
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run tests for t1 volume pipelines
-        run: |
-          make env.conda
-          source ~/miniconda3/etc/profile.d/conda.sh
-          conda activate "${{ github.workspace }}"/env
-          source "$(brew --prefix)/opt/modules/init/bash"
-          module load clinica/matlab/2019b
-          module load clinica/spm12/r7771
-          make install
-          cd test
-          poetry run pytest --verbose \
-          --working_directory=/Volumes/data/working_dir_mac \
-          --input_data_directory=/Volumes/data_ci \
-          --basetemp=/Volumes/data/tmp \
-          --junitxml=./test-reports/non_regression_anat_t1_volume_mac.xml \
-          --disable-warnings \
-          ./nonregression/pipelines/anat/test_t1_volume.py
+#  test-t1-linear-MacOS:
+#    runs-on:
+#      - self-hosted
+#      - macOS
+#    timeout-minutes: 120
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Run tests for t1 linear pipelines
+#        run: |
+#          make env.conda
+#          source ~/miniconda3/etc/profile.d/conda.sh
+#          conda activate "${{ github.workspace }}"/env
+#          source "$(brew --prefix)/opt/modules/init/bash"
+#          module load clinica/ants/2.4.4
+#          make install
+#          cd test
+#          poetry run pytest --verbose \
+#          --working_directory=/Volumes/data/working_dir_mac \
+#          --input_data_directory=/Volumes/data_ci \
+#          --basetemp=/Volumes/data/tmp \
+#          --junitxml=./test-reports/non_regression_anat_t1_linear_mac.xml \
+#          --disable-warnings \
+#          ./nonregression/pipelines/anat/test_t1_linear.py
+#
+#  test-t1-volume-MacOS:
+#    runs-on:
+#      - self-hosted
+#      - macOS
+#    timeout-minutes: 720
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Run tests for t1 volume pipelines
+#        run: |
+#          make env.conda
+#          source ~/miniconda3/etc/profile.d/conda.sh
+#          conda activate "${{ github.workspace }}"/env
+#          source "$(brew --prefix)/opt/modules/init/bash"
+#          module load clinica/matlab/2019b
+#          module load clinica/spm12/r7771
+#          make install
+#          cd test
+#          poetry run pytest --verbose \
+#          --working_directory=/Volumes/data/working_dir_mac \
+#          --input_data_directory=/Volumes/data_ci \
+#          --basetemp=/Volumes/data/tmp \
+#          --junitxml=./test-reports/non_regression_anat_t1_volume_mac.xml \
+#          --disable-warnings \
+#          ./nonregression/pipelines/anat/test_t1_volume.py
 
   test-t1-linear-Linux:
     runs-on:

--- a/.github/workflows/test_pipelines_anat_freesurfer.yml
+++ b/.github/workflows/test_pipelines_anat_freesurfer.yml
@@ -8,29 +8,29 @@ permissions:
   contents: read
 
 jobs:
-  test-pipelines-anat-freesurfer-MacOS:
-    runs-on:
-      - self-hosted
-      - macOS
-    timeout-minutes: 1440
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run tests for anat pipelines using freesurfer
-        run: |
-          make env.conda
-          source ~/miniconda3/etc/profile.d/conda.sh
-          conda activate "${{ github.workspace }}"/env
-          source "$(brew --prefix)/opt/modules/init/bash"
-          module load clinica/freesurfer/6.0.0
-          make install
-          cd test
-          poetry run pytest --verbose \
-          --working_directory=/Volumes/data/working_dir_mac \
-          --input_data_directory=/Volumes/data_ci \
-          --basetemp=/Volumes/data/tmp \
-          --junitxml=./test-reports/non_regression_anat_t1_freesurfer_mac.xml \
-          --disable-warnings \
-          ./nonregression/pipelines/anat/test_t1_freesurfer.py
+#  test-pipelines-anat-freesurfer-MacOS:
+#    runs-on:
+#      - self-hosted
+#      - macOS
+#    timeout-minutes: 1440
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Run tests for anat pipelines using freesurfer
+#        run: |
+#          make env.conda
+#          source ~/miniconda3/etc/profile.d/conda.sh
+#          conda activate "${{ github.workspace }}"/env
+#          source "$(brew --prefix)/opt/modules/init/bash"
+#          module load clinica/freesurfer/6.0.0
+#          make install
+#          cd test
+#          poetry run pytest --verbose \
+#          --working_directory=/Volumes/data/working_dir_mac \
+#          --input_data_directory=/Volumes/data_ci \
+#          --basetemp=/Volumes/data/tmp \
+#          --junitxml=./test-reports/non_regression_anat_t1_freesurfer_mac.xml \
+#          --disable-warnings \
+#          ./nonregression/pipelines/anat/test_t1_freesurfer.py
 
   test-pipelines-anat-freesurfer-Linux:
     runs-on:

--- a/.github/workflows/test_pipelines_dwi.yml
+++ b/.github/workflows/test_pipelines_dwi.yml
@@ -8,31 +8,31 @@ permissions:
   contents: read
 
 jobs:
-  test-dwi-MacOS:
-    runs-on:
-      - self-hosted
-      - macOS
-    timeout-minutes: 720
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run tests for dwi pipelines
-        run: |
-          make env.conda
-          source ~/miniconda3/etc/profile.d/conda.sh
-          conda activate "${{ github.workspace }}"/env
-          source "$(brew --prefix)/opt/modules/init/bash"
-          module load clinica/fsl/6.0.5
-          module load clinica/ants/2.4.4
-          module load clinica/freesurfer/6.0.0
-          make install
-          cd test
-          poetry run pytest --verbose \
-          --working_directory=/Volumes/data/working_dir_mac \
-          --input_data_directory=/Volumes/data_ci \
-          --basetemp=/Volumes/data/tmp \
-          --junitxml=./test-reports/non_regression_dwi_mac.xml \
-          --disable-warnings \
-          ./nonregression/pipelines/dwi/test_pipelines.py
+#  test-dwi-MacOS:
+#    runs-on:
+#      - self-hosted
+#      - macOS
+#    timeout-minutes: 720
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Run tests for dwi pipelines
+#        run: |
+#          make env.conda
+#          source ~/miniconda3/etc/profile.d/conda.sh
+#          conda activate "${{ github.workspace }}"/env
+#          source "$(brew --prefix)/opt/modules/init/bash"
+#          module load clinica/fsl/6.0.5
+#          module load clinica/ants/2.4.4
+#          module load clinica/freesurfer/6.0.0
+#          make install
+#          cd test
+#          poetry run pytest --verbose \
+#          --working_directory=/Volumes/data/working_dir_mac \
+#          --input_data_directory=/Volumes/data_ci \
+#          --basetemp=/Volumes/data/tmp \
+#          --junitxml=./test-reports/non_regression_dwi_mac.xml \
+#          --disable-warnings \
+#          ./nonregression/pipelines/dwi/test_pipelines.py
 
   test-dwi-Linux:
     runs-on:

--- a/.github/workflows/test_pipelines_dwi_preprocessing.yml
+++ b/.github/workflows/test_pipelines_dwi_preprocessing.yml
@@ -8,53 +8,53 @@ permissions:
   contents: read
 
 jobs:
-  test-dwi-preproc-t1-MacOS:
-    runs-on:
-      - self-hosted
-      - macOS
-    timeout-minutes: 720
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run tests for dwi pre-processing using t1 pipelines
-        run: |
-          make env.conda
-          source ~/miniconda3/etc/profile.d/conda.sh
-          conda activate "${{ github.workspace }}"/env
-          source "$(brew --prefix)/opt/modules/init/bash"
-          module load clinica.all
-          make install
-          cd test
-          poetry run pytest --verbose \
-          --working_directory=/Volumes/data/working_dir_mac \
-          --input_data_directory=/Volumes/data_ci \
-          --basetemp=/Volumes/data/tmp \
-          --junitxml=./test-reports/non_regression_dwi_preproc_using_t1_mac.xml \
-          --disable-warnings \
-          ./nonregression/pipelines/dwi/preprocessing/test_t1.py
-
-  test-dwi-preproc-phasediff-MacOS:
-    runs-on:
-      - self-hosted
-      - macOS
-    timeout-minutes: 720
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run tests for dwi pre-processing using phasediff pipelines
-        run: |
-          make env.conda
-          source ~/miniconda3/etc/profile.d/conda.sh
-          conda activate "${{ github.workspace }}"/env
-          source "$(brew --prefix)/opt/modules/init/bash"
-          module load clinica.all
-          make install
-          cd test
-          poetry run pytest --verbose \
-          --working_directory=/Volumes/data/working_dir_mac \
-          --input_data_directory=/Volumes/data_ci \
-          --basetemp=/Volumes/data/tmp \
-          --junitxml=./test-reports/non_regression_dwi_preproc_using_phasediff_mac.xml \
-          --disable-warnings \
-          ./nonregression/pipelines/dwi/preprocessing/test_phase_diff.py
+#  test-dwi-preproc-t1-MacOS:
+#    runs-on:
+#      - self-hosted
+#      - macOS
+#    timeout-minutes: 720
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Run tests for dwi pre-processing using t1 pipelines
+#        run: |
+#          make env.conda
+#          source ~/miniconda3/etc/profile.d/conda.sh
+#          conda activate "${{ github.workspace }}"/env
+#          source "$(brew --prefix)/opt/modules/init/bash"
+#          module load clinica.all
+#          make install
+#          cd test
+#          poetry run pytest --verbose \
+#          --working_directory=/Volumes/data/working_dir_mac \
+#          --input_data_directory=/Volumes/data_ci \
+#          --basetemp=/Volumes/data/tmp \
+#          --junitxml=./test-reports/non_regression_dwi_preproc_using_t1_mac.xml \
+#          --disable-warnings \
+#          ./nonregression/pipelines/dwi/preprocessing/test_t1.py
+#
+#  test-dwi-preproc-phasediff-MacOS:
+#    runs-on:
+#      - self-hosted
+#      - macOS
+#    timeout-minutes: 720
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Run tests for dwi pre-processing using phasediff pipelines
+#        run: |
+#          make env.conda
+#          source ~/miniconda3/etc/profile.d/conda.sh
+#          conda activate "${{ github.workspace }}"/env
+#          source "$(brew --prefix)/opt/modules/init/bash"
+#          module load clinica.all
+#          make install
+#          cd test
+#          poetry run pytest --verbose \
+#          --working_directory=/Volumes/data/working_dir_mac \
+#          --input_data_directory=/Volumes/data_ci \
+#          --basetemp=/Volumes/data/tmp \
+#          --junitxml=./test-reports/non_regression_dwi_preproc_using_phasediff_mac.xml \
+#          --disable-warnings \
+#          ./nonregression/pipelines/dwi/preprocessing/test_phase_diff.py
 
   test-dwi-preproc-t1-Linux:
     runs-on:

--- a/.github/workflows/test_pipelines_pet.yml
+++ b/.github/workflows/test_pipelines_pet.yml
@@ -8,29 +8,29 @@ permissions:
   contents: read
 
 jobs:
-  test-pipelines-pet-MacOS:
-    runs-on:
-      - self-hosted
-      - macOS
-    timeout-minutes: 720
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run tests for pet pipelines
-        run: |
-          make env.conda
-          source ~/miniconda3/etc/profile.d/conda.sh
-          conda activate "${{ github.workspace }}"/env
-          source "$(brew --prefix)/opt/modules/init/bash"
-          module load clinica.all
-          make install
-          cd test
-          poetry run pytest --verbose \
-          --working_directory=/Volumes/data/working_dir_mac \
-          --input_data_directory=/Volumes/data_ci \
-          --basetemp=/Volumes/data/tmp \
-          --junitxml=./test-reports/non_regression_pet_mac.xml \
-          --disable-warnings \
-          ./nonregression/pipelines/pet
+#  test-pipelines-pet-MacOS:
+#    runs-on:
+#      - self-hosted
+#      - macOS
+#    timeout-minutes: 720
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Run tests for pet pipelines
+#        run: |
+#          make env.conda
+#          source ~/miniconda3/etc/profile.d/conda.sh
+#          conda activate "${{ github.workspace }}"/env
+#          source "$(brew --prefix)/opt/modules/init/bash"
+#          module load clinica.all
+#          make install
+#          cd test
+#          poetry run pytest --verbose \
+#          --working_directory=/Volumes/data/working_dir_mac \
+#          --input_data_directory=/Volumes/data_ci \
+#          --basetemp=/Volumes/data/tmp \
+#          --junitxml=./test-reports/non_regression_pet_mac.xml \
+#          --disable-warnings \
+#          ./nonregression/pipelines/pet
 
   test-pipelines-pet-Linux:
     runs-on:


### PR DESCRIPTION
Since the MacOS self-hosted runner is not working properly as a service, let's comment the related pipelines and avoid the consistently broken CI.