### PR TITLE
[ENH] Improve the `crop_nifti`

### DIFF
--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -315,7 +315,7 @@ class PETLinear(PETPipeline):
         import nipype.pipeline.engine as npe
         from nipype.interfaces import ants
 
-        from clinica.pipelines.tasks import crop_nifti_task
+        from clinica.pipelines.tasks import crop_nifti_using_t1_mni_template_task
 
         from .tasks import (
             clip_task,
@@ -417,7 +417,7 @@ class PETLinear(PETPipeline):
         crop_nifti_node = npe.Node(
             name="cropNifti",
             interface=nutil.Function(
-                function=crop_nifti_task,
+                function=crop_nifti_using_t1_mni_template_task,
                 input_names=["input_image", "output_path"],
                 output_names=["output_image"],
             ),

--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -261,7 +261,10 @@ class AnatLinear(Pipeline):
             run_ants_registration_task,
             run_n4biasfieldcorrection_task,
         )
-        from clinica.pipelines.tasks import crop_nifti_task, get_filename_no_ext_task
+        from clinica.pipelines.tasks import (
+            crop_nifti_using_t1_mni_template_task,
+            get_filename_no_ext_task,
+        )
 
         from .anat_linear_utils import print_end_pipeline
 
@@ -335,7 +338,7 @@ class AnatLinear(Pipeline):
         cropnifti = npe.Node(
             name="cropnifti",
             interface=nutil.Function(
-                function=crop_nifti_task,
+                function=crop_nifti_using_t1_mni_template_task,
                 input_names=["input_image", "output_path"],
                 output_names=["output_img"],
             ),

--- a/clinica/pipelines/tasks.py
+++ b/clinica/pipelines/tasks.py
@@ -1,12 +1,12 @@
 """This module contains Nipype tasks used in several pipelines."""
 
 
-def crop_nifti_task(input_image: str, output_path: str) -> str:
+def crop_nifti_using_t1_mni_template_task(input_image: str, output_path: str) -> str:
     from pathlib import Path
 
-    from clinica.utils.image import crop_nifti
+    from clinica.utils.image import crop_nifti_using_t1_mni_template
 
-    return str(crop_nifti(Path(input_image), Path(output_path)))
+    return str(crop_nifti_using_t1_mni_template(Path(input_image), Path(output_path)))
 
 
 def get_filename_no_ext_task(filename: str) -> str:

--- a/clinica/utils/image.py
+++ b/clinica/utils/image.py
@@ -434,12 +434,6 @@ class NiftiImage:
         return self.load().shape
 
     @property
-    def bbox(self) -> Bbox3D:
-        return Bbox3D.from_coordinates(
-            0, self.shape[0], 0, self.shape[1], 0, self.shape[2]
-        )
-
-    @property
     def data(self) -> np.ndarray:
         return self.load().get_fdata()
 
@@ -462,6 +456,12 @@ class NiftiImage3D(NiftiImage):
         super().__init__(image_path)
         if len(self.shape) != 3:
             raise ClinicaImageDimensionError(f"The image in {self.path} is not 3D.")
+
+    @property
+    def bbox(self) -> Bbox3D:
+        return Bbox3D.from_coordinates(
+            0, self.shape[0], 0, self.shape[1], 0, self.shape[2]
+        )
 
 
 def crop_nifti(

--- a/test/unittests/utils/test_image.py
+++ b/test/unittests/utils/test_image.py
@@ -384,3 +384,50 @@ def test_clip_nifti(
     ).to_filename(tmp_path / "expected.nii.gz")
 
     assert_nifti_equal(clipped, tmp_path / "expected.nii.gz")
+
+
+def test_nifti_image_file_not_exist_error(tmp_path):
+    from clinica.utils.image import NiftiImage
+
+    with pytest.raises(
+        FileNotFoundError,
+        match=f"File {tmp_path / 'image.nii.gz'} does not exist.",
+    ):
+        NiftiImage(tmp_path / "image.nii.gz")
+
+
+def test_nifti_image_file_corrupted_error(tmp_path):
+    from clinica.utils.image import NiftiImage
+
+    (tmp_path / "image.nii.gz").touch()
+
+    with pytest.raises(
+        IOError,
+        match=f"File {tmp_path / 'image.nii.gz'} is not a nifti image or is corrupted.",
+    ):
+        NiftiImage(tmp_path / "image.nii.gz")
+
+
+def test_nifti_image_get_filename(tmp_path):
+    from clinica.utils.image import NiftiImage
+
+    image = nib.Nifti1Image(np.random.random((10, 10, 10)), np.eye(4))
+    nib.save(image, tmp_path / "image.nii.gz")
+    image_instance = NiftiImage(tmp_path / "image.nii.gz")
+
+    assert image_instance.get_filename() == "image.nii.gz"
+    assert image_instance.get_filename(with_extension=False) == "image"
+
+
+def test_nifti_image_3d_error(tmp_path):
+    from clinica.utils.exceptions import ClinicaImageDimensionError
+    from clinica.utils.image import NiftiImage3D
+
+    image = nib.Nifti1Image(np.random.random((10, 10, 10, 10)), np.eye(4))
+    nib.save(image, tmp_path / "image.nii.gz")
+
+    with pytest.raises(
+        ClinicaImageDimensionError,
+        match=f"The image in {tmp_path / 'image.nii.gz'} is not 3D.",
+    ):
+        NiftiImage3D(tmp_path / "image.nii.gz")


### PR DESCRIPTION
Following #1426, this PR proposes to improve the `crop_nifti` function.

Currently the function behaves in a very specific way, by cropping the provided image with a hardcoded bounding box that we defined for a specific use case (T1 images with MNI reference template). Therefore, I think the name is misleading and we could make use of a more generic function.

This PR proposes to make `crop_nifti` more generic by letting users provide both the bounding box and the reference image. If no bounding box is provided, then no cropping is performed. If no reference image is provided, the input image is used as a reference. In other words `crop_nifti(img)` with no other argument is the identity function.

The old `crop_nifti` has been renamed `crop_nifti_using_t1_mni_template` and is nothing more than a partial function on the new `crop_nifti`, calling it with the MNI_BBOX and the MNI cropped template. 

Implementation details: I introduced two classes called `NiftiImage` and `NiftiImage3D` which behave as wrappers around a path to a nifti image. I'm still unsure whether we should keep them or not, but I think it could help us reduce boilerplate code we have in various places to check that a nifti is 3D, or that a nifti file exists, and so on.