### PR TITLE
[ENH] In `center-nifti`, give the option to the user to choose the centering threshold

### DIFF
--- a/clinica/iotools/utils/center_nifti.py
+++ b/clinica/iotools/utils/center_nifti.py
@@ -49,7 +49,10 @@ def center_nifti(
     )
     from clinica.utils.stream import cprint, log_and_raise
 
-    cprint("Clinica is now centering the requested images.", lvl="info")
+    cprint(
+        f"Clinica is now centering the requested images with a threshold of {centering_threshold} mm.",
+        lvl="info",
+    )
 
     centered_files = center_all_nifti(
         bids_directory,

--- a/clinica/iotools/utils/center_nifti.py
+++ b/clinica/iotools/utils/center_nifti.py
@@ -24,7 +24,7 @@ def center_nifti(
     modalities : Iterable of str, optional
         The modalities that will be processed.
 
-    centering_threshold : float, optional
+    centering_threshold : int, optional
         Threshold above which images are centered. See the documentation for the reason behind the default.
         Default=50 (mm).
 

--- a/clinica/iotools/utils/center_nifti.py
+++ b/clinica/iotools/utils/center_nifti.py
@@ -8,7 +8,7 @@ def center_nifti(
     bids_directory: Union[str, PathLike],
     output_bids_directory: Union[str, PathLike],
     modalities: Optional[Iterable[str]] = None,
-    center_all_files: bool = False,
+    centering_threshold: int = 50,
     overwrite_existing_files: bool = False,
 ):
     """Center NIfTI files in a BIDS dataset.
@@ -24,9 +24,9 @@ def center_nifti(
     modalities : Iterable of str, optional
         The modalities that will be processed.
 
-    center_all_files : bool, optional
-        Whether to center all file or not.
-        Default=False.
+    centering_threshold : float, optional
+        Threshold above which images are centered. See the documentation for the reason behind the default.
+        Default=50 (mm).
 
     overwrite_existing_files : bool, optional
         If True and if the output BIDS directory already contain files,
@@ -55,7 +55,7 @@ def center_nifti(
         bids_directory,
         output_bids_directory,
         modalities,
-        center_all_files,
+        centering_threshold,
         overwrite_existing_files,
     )
 

--- a/clinica/iotools/utils/cli.py
+++ b/clinica/iotools/utils/cli.py
@@ -43,10 +43,10 @@ def describe(dataset: Union[str, Path]):
 @click.option(
     "-t",
     "--threshold",
-    "threshold",
+    "centering_threshold",
     show_default=True,
     help="Centering threshold above which centering is performed.",
-    default=(50,),
+    default=50,
 )
 def center_nifti(
     bids_directory: str,

--- a/clinica/iotools/utils/cli.py
+++ b/clinica/iotools/utils/cli.py
@@ -45,14 +45,14 @@ def describe(dataset: Union[str, Path]):
     "--threshold",
     "centering_threshold",
     show_default=True,
-    help="Centering threshold above which centering is performed.",
+    help="Threshold above which centering is performed.",
     default=50,
 )
 def center_nifti(
     bids_directory: str,
     output_bids_directory: str,
     modalities: Optional[Iterable[str]] = None,
-    centering_threshold: Optional[int] = 50,
+    centering_threshold: int = 50,
 ) -> None:
     """Center NIfTI files in a BIDS dataset."""
     import sys

--- a/clinica/iotools/utils/cli.py
+++ b/clinica/iotools/utils/cli.py
@@ -37,14 +37,22 @@ def describe(dataset: Union[str, Path]):
     multiple=True,
     metavar="modalities",
     help="Process selected modalities.",
+    show_default=True,
     default=("T1w",),
 )
-@click.option("--center-all-files", is_flag=True, help="Force processing of all files.")
+@click.option(
+    "-t",
+    "--threshold",
+    "threshold",
+    show_default=True,
+    help="Centering threshold above which centering is performed.",
+    default=(50,),
+)
 def center_nifti(
     bids_directory: str,
     output_bids_directory: str,
     modalities: Optional[Iterable[str]] = None,
-    center_all_files: bool = False,
+    centering_threshold: Optional[int] = 50,
 ) -> None:
     """Center NIfTI files in a BIDS dataset."""
     import sys
@@ -58,7 +66,7 @@ def center_nifti(
             bids_directory,
             output_bids_directory,
             modalities=modalities,
-            center_all_files=center_all_files,
+            centering_threshold=centering_threshold,
         )
     except ClinicaExistingDatasetError:
         click.echo("Target BIDS directory is not empty. Existing files will disappear.")
@@ -67,7 +75,7 @@ def center_nifti(
                 bids_directory,
                 output_bids_directory,
                 modalities=modalities,
-                center_all_files=center_all_files,
+                centering_threshold=centering_threshold,
                 overwrite_existing_files=True,
             )
         else:

--- a/clinica/iotools/utils/data_handling/_centering.py
+++ b/clinica/iotools/utils/data_handling/_centering.py
@@ -317,7 +317,7 @@ def center_all_nifti(
     modalities : iterable of str, optional
         Process these modalities only. Process all modalities otherwise.
 
-    centering_threshold:  float, default=50
+    centering_threshold:  int, default=50
         Center files above this threshold.
 
     overwrite_existing_files : bool, optional

--- a/clinica/iotools/utils/data_handling/_centering.py
+++ b/clinica/iotools/utils/data_handling/_centering.py
@@ -298,7 +298,7 @@ def center_all_nifti(
     bids_dir: Union[str, PathLike],
     output_dir: Union[str, PathLike],
     modalities: Optional[Iterable[str]] = None,
-    center_all_files: bool = False,
+    centering_threshold: int = 50,
     overwrite_existing_files: bool = False,
 ) -> list[Path]:
     """Center all the NIfTI images of the input BIDS folder into the empty output_dir specified in argument.
@@ -317,8 +317,8 @@ def center_all_nifti(
     modalities : iterable of str, optional
         Process these modalities only. Process all modalities otherwise.
 
-    center_all_files:  bool, default=False
-        Center files that may cause problem for SPM if set to False, all files otherwise.
+    centering_threshold:  float, default=50
+        Center files above this threshold.
 
     overwrite_existing_files : bool, optional
         If True and if the output BIDS directory already contain files,
@@ -341,10 +341,11 @@ def center_all_nifti(
     copytree(bids_dir, output_dir, copy_function=copy2)
 
     nifti_files_filtered = _find_files_with_modality(output_dir, modalities)
-    if not center_all_files:
-        nifti_files_filtered = [
-            file for file in nifti_files_filtered if not _is_centered(file)
-        ]
+    nifti_files_filtered = [
+        file
+        for file in nifti_files_filtered
+        if not _is_centered(file, centering_threshold)
+    ]
     errors: list[str] = []
     for f in nifti_files_filtered:
         cprint(msg=f"Handling file {f}", lvl="debug")

--- a/clinica/iotools/utils/data_handling/_centering.py
+++ b/clinica/iotools/utils/data_handling/_centering.py
@@ -340,10 +340,9 @@ def center_all_nifti(
     _handle_output_existing_files(output_dir, overwrite_existing_files)
     copytree(bids_dir, output_dir, copy_function=copy2)
 
-    nifti_files_filtered = _find_files_with_modality(output_dir, modalities)
     nifti_files_filtered = [
         file
-        for file in nifti_files_filtered
+        for file in _find_files_with_modality(output_dir, modalities)
         if not _is_centered(file, centering_threshold)
     ]
     errors: list[str] = []
@@ -390,6 +389,10 @@ def _is_centered(nii_volume: Path, threshold_l2: int = 50) -> bool:
     the volume did not exceed 100 mm. Above this distance, either the volume is either not segmented (SPM error), or the
     produced segmentation is wrong (not the shape of a brain anymore)
     """
+    if threshold_l2 < 0:
+        raise ValueError(
+            f"The value of the threshold should be positive or null : t = {threshold_l2} is invalid."
+        )
     if (center := _get_world_coordinate_of_center(nii_volume)) is None:
         raise ValueError(
             f"Unable to compute the world coordinates of center for image {nii_volume}."

--- a/docs/IOTools/center_nifti.md
+++ b/docs/IOTools/center_nifti.md
@@ -4,10 +4,6 @@ Your [BIDS](http://bids.neuroimaging.io) dataset may contain NIfTI files where t
 [SPM](../Software/Third-party.md#spm12) is especially sensitive to this case and segmentation procedures may result in blank images or even fail.
 To mitigate this issue we offer a simple tool that generates from your BIDS a new dataset with centered NIfTI files for the selected modalities.
 
-!!! warning "By default :"
-
-    - This tool will only center **T1w** images.
-    - Only NIfTI volumes whose center is at **more than 50 mm** from the origin of the world coordinate system are centered. This threshold has been chosen empirically after a set of experiments to determine at which distance from the origin SPM segmentation and coregistration procedures stop working properly.
 
 ```shell
 clinica iotools center-nifti [OPTIONS] BIDS_DIRECTORY OUTPUT_BIDS_DIRECTORY
@@ -21,7 +17,7 @@ This folder can be empty or nonexistent.
 
 Optional arguments:
 
-- `--modality` is a case-insensitive parameter that defines which modalities are converted.
+- `-m/--modality` is a case-insensitive parameter that defines which modalities are converted. By default, the tool centers only **T1w** images.
 
     !!! tip "How to use :"
         - If you want to convert T1w images only, do not use the option.
@@ -31,9 +27,12 @@ Optional arguments:
 
         Basically, the software searches for the modality key inside the filename. Understanding this, you can now center any modality you want!
 
-- `--center_all_files` is an option that forces Clinica to center all the files of the modalities selected with the `--modality` flag.
+- `-t/--threshold` allows choosing the critical distance (mm) from the origin of the world coordinate system to an image center above which images will be centered. By default, this threshold is set to **50**. To center images regardless of their original distance to the center, set it to 0.
+
+    !!! info "Default centering threshold"
+        This threshold of 50 mm was tailored for SPM. It was chosen empirically after a set of experiments to determine at which distance from the origin SPM segmentation and coregistration procedures stop working properly.
+    
 
 !!! note
-    The images contained in the input `bids_directory` folder that do not need to be centered will also be copied to the output folder `new_bids_directory`.
-
-     The list of the converted files will appear in a text file in `new_bids_directory/centered_nifti_list_TIMESTAMP.txt`.
+    - The images contained in the input `bids_directory` folder that do not need to be centered will also be copied to the output folder `output_bids_directory`. 
+    - In this output directory, a text file named `centered_nifti_list_TIMESTAMP.txt` with the list of the converted files will also be created.


### PR DESCRIPTION
Closes #1413 following #1418 

Changes the option of `--center_all_files` to `--threshold` above which images are to be centered.

In other PR : 
- Add non regression tests that checks inside images and txt file
- Change CI data if necessary (might be interesting to have different thresholds/modalities to test)
- Use the new NiftiImage class in `_get_world_coordinate_of_center`
