### PR TITLE
[TEST] Refactor and test function `print_images_to_process`

### DIFF
--- a/clinica/utils/participant.py
+++ b/clinica/utils/participant.py
@@ -2,8 +2,9 @@
 
 See CAPS specifications for details about long ID.
 """
+from collections.abc import Sequence
 from os import PathLike
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 
 def get_unique_subjects(

--- a/clinica/utils/participant.py
+++ b/clinica/utils/participant.py
@@ -3,22 +3,22 @@
 See CAPS specifications for details about long ID.
 """
 from os import PathLike
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 
 def get_unique_subjects(
-    subjects: List[str], sessions: List[str]
-) -> Tuple[List[str], List[List[str]]]:
+    subjects: Sequence[str], sessions: Sequence[str]
+) -> tuple[list[str], list[list[str]]]:
     """Get unique participant IDs with their sessions.
 
     This function generates a list of unique participant IDs from `in_subject_list` with their sessions.
 
     Parameters
     ----------
-    subjects : list of str
+    subjects : Sequence of str
         List of participant IDs.
 
-    sessions : list of str
+    sessions : Sequence of str
         List of session IDs.
 
     Returns

--- a/clinica/utils/ux.py
+++ b/clinica/utils/ux.py
@@ -3,8 +3,8 @@
 These functions are mainly called by the pipelines.
 """
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 LINES_TO_DISPLAY = 25
 

--- a/clinica/utils/ux.py
+++ b/clinica/utils/ux.py
@@ -4,35 +4,74 @@ These functions are mainly called by the pipelines.
 """
 
 from pathlib import Path
+from typing import Sequence
 
 LINES_TO_DISPLAY = 25
 
 
-def print_images_to_process(list_participant_id, list_session_id):
-    """Print which images will be processed by the pipeline."""
-    from clinica.utils.participant import get_unique_subjects
+def print_images_to_process(
+    participant_ids: Sequence[str],
+    session_ids: Sequence[str],
+    logging_level: str = "info",
+):
+    """Print which images will be processed by the pipeline.
 
+    Parameters
+    ----------
+    participant_ids : Sequence of str
+        The IDs of the participants.
+
+    session_ids : Sequence of str
+        The IDs of the corresponding sessions.
+
+    logging_level : str, optional
+        The logging level to use for displaying this information.
+        Default="info".
+    """
     from .stream import cprint
 
-    unique_participants, sessions_per_participant = get_unique_subjects(
-        list_participant_id, list_session_id
-    )
-
     cprint(
-        f"The pipeline will be run on the following {len(list_participant_id)} image(s):"
+        _get_message_images_to_process(
+            participant_ids, session_ids, max_number_of_lines=LINES_TO_DISPLAY
+        ),
+        lvl=logging_level,
     )
-    for i in range(0, min(len(unique_participants), LINES_TO_DISPLAY)):
-        sessions_i_th_participant = ", ".join(
-            s_id for s_id in sessions_per_participant[i]
-        )
-        cprint(f"\t{unique_participants[i]} | {sessions_i_th_participant},")
 
-    if len(unique_participants) > LINES_TO_DISPLAY:
-        cprint("\t...")
-        sessions_last_participant = ", ".join(
-            s_id for s_id in sessions_per_participant[-1]
+
+def _get_message_images_to_process(
+    participant_ids: Sequence[str],
+    session_ids: Sequence[str],
+    max_number_of_lines: int = 25,
+) -> str:
+    """Build the message displaying the images to process."""
+    from collections import defaultdict
+
+    subject_to_sessions = defaultdict(list)
+    for participant, session in zip(participant_ids, session_ids):
+        subject_to_sessions[participant].append(session)
+    # If there is no image or if the maximum number of lines is too short to print
+    # a meaningful list, then return a simple message
+    if len(subject_to_sessions) == 0 or max_number_of_lines <= 2:
+        return f"The pipeline will be run on {len(participant_ids)} image(s)."
+    message = (
+        f"The pipeline will be run on the following {len(participant_ids)} image(s):"
+    )
+    lines = [
+        f"{subject} | {', '.join(session)}"
+        for subject, session in subject_to_sessions.items()
+    ]
+    # If there is a single line we need to format it properly
+    if len(subject_to_sessions) == 1:
+        return message + "\n\t- " + "\n\t- ".join(lines)
+    # If the number of lines is larger than the maximum number,
+    # then use ... to mask subjects in the middle of the list
+    if len(lines) > max_number_of_lines:
+        return (
+            f"{message}\n\t- "
+            + "\n\t- ".join(lines[: max_number_of_lines - 2])
+            + f"\n\t\t...\n\t- {lines[-1]}"
         )
-        cprint(f"\t{unique_participants[-1]} | {sessions_last_participant},")
+    return f"{message}\n\t- " + "\n\t- ".join(lines)
 
 
 def print_begin_image(image_id, list_keys=None, list_values=None):

--- a/test/unittests/utils/test_ux.py
+++ b/test/unittests/utils/test_ux.py
@@ -49,7 +49,7 @@ def test_get_message_images_to_process(subjects, sessions, expected_message):
 @pytest.mark.parametrize("max_number_of_lines", [0, 1, 2])
 def test_get_message_images_to_process_custom_max_number_of_lines_too_small(
     max_number_of_lines,
-):  
+):
     from clinica.utils.ux import _get_message_images_to_process
 
     assert (

--- a/test/unittests/utils/test_ux.py
+++ b/test/unittests/utils/test_ux.py
@@ -1,3 +1,112 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "subjects,sessions,expected_message",
+    [
+        ((), (), "The pipeline will be run on 0 image(s)."),
+        (
+            ("sub-01",),
+            ("ses-M000",),
+            "The pipeline will be run on the following 1 image(s):\n\t- sub-01 | ses-M000",
+        ),
+        (
+            ("sub-01", "sub-01"),
+            ("ses-M000", "ses-M006"),
+            "The pipeline will be run on the following 2 image(s):\n\t- sub-01 | ses-M000, ses-M006",
+        ),
+        (
+            ("sub-01", "sub-01", "sub-02"),
+            ("ses-M000", "ses-M006", "ses-M000"),
+            "The pipeline will be run on the following 3 image(s):\n\t- sub-01 | ses-M000, ses-M006\n\t- sub-02 | ses-M000",
+        ),
+        (
+            ("sub-01", "sub-01", "sub-02", "sub-03", "sub-03", "sub-03"),
+            ("ses-M000", "ses-M006", "ses-M000", "ses-M006", "ses-M012", "ses-M024"),
+            "The pipeline will be run on the following 6 image(s):\n\t- sub-01 | ses-M000, ses-M006\n\t- sub-02 | ses-M000\n\t- sub-03 | ses-M006, ses-M012, ses-M024",
+        ),
+        (
+            ("sub-01", "sub-01", "sub-02", "sub-03", "sub-04", "sub-05", "sub-06"),
+            (
+                "ses-M000",
+                "ses-M006",
+                "ses-M000",
+                "ses-M000",
+                "ses-M000",
+                "ses-M000",
+                "ses-M000",
+            ),
+            "The pipeline will be run on the following 7 image(s):\n\t- sub-01 | ses-M000, ses-M006\n\t- sub-02 | ses-M000\n\t- sub-03 | ses-M000\n\t- sub-04 | ses-M000\n\t- sub-05 | ses-M000\n\t- sub-06 | ses-M000",
+        ),
+    ],
+)
+def test_get_message_images_to_process(subjects, sessions, expected_message):
+    from clinica.utils.ux import _get_message_images_to_process
+
+    assert _get_message_images_to_process(subjects, sessions) == expected_message
+
+
+@pytest.mark.parametrize("max_number_of_lines", [0, 1, 2])
+def test_get_message_images_to_process_custom_max_number_of_lines_too_small(
+    max_number_of_lines,
+):  # subjects, sessions, expected_message):
+    from clinica.utils.ux import _get_message_images_to_process
+
+    assert (
+        _get_message_images_to_process(
+            ("sub-01", "sub-01", "sub-02"),
+            ("ses-M000", "ses-M006", "ses-M000"),
+            max_number_of_lines=max_number_of_lines,
+        )
+        == "The pipeline will be run on 3 image(s)."
+    )
+
+
+@pytest.mark.parametrize(
+    "subjects,sessions,max_number_of_lines,expected_message",
+    [
+        (
+            ("sub-01", "sub-01", "sub-02"),
+            ("ses-M000", "ses-M006", "ses-M000"),
+            4,
+            (
+                "The pipeline will be run on the following 3 image(s):"
+                "\n\t- sub-01 | ses-M000, ses-M006\n\t- sub-02 | ses-M000"
+            ),
+        ),
+        (
+            ("sub-01", "sub-01", "sub-02", "sub-03", "sub-04", "sub-05", "sub-06"),
+            (
+                "ses-M000",
+                "ses-M006",
+                "ses-M000",
+                "ses-M000",
+                "ses-M000",
+                "ses-M000",
+                "ses-M000",
+            ),
+            4,
+            (
+                "The pipeline will be run on the following 7 image(s):"
+                "\n\t- sub-01 | ses-M000, ses-M006\n\t- sub-02 | ses-M000"
+                "\n\t\t...\n\t- sub-06 | ses-M000"
+            ),
+        ),
+    ],
+)
+def test_get_message_images_to_process_custom_max_number_of_lines(
+    subjects, sessions, max_number_of_lines, expected_message
+):
+    from clinica.utils.ux import _get_message_images_to_process
+
+    assert (
+        _get_message_images_to_process(
+            subjects, sessions, max_number_of_lines=max_number_of_lines
+        )
+        == expected_message
+    )
+
+
 def test_get_group_message_empty(tmp_path):
     from clinica.utils.ux import _get_group_message
 

--- a/test/unittests/utils/test_ux.py
+++ b/test/unittests/utils/test_ux.py
@@ -49,7 +49,7 @@ def test_get_message_images_to_process(subjects, sessions, expected_message):
 @pytest.mark.parametrize("max_number_of_lines", [0, 1, 2])
 def test_get_message_images_to_process_custom_max_number_of_lines_too_small(
     max_number_of_lines,
-):  # subjects, sessions, expected_message):
+):  
     from clinica.utils.ux import _get_message_images_to_process
 
     assert (


### PR DESCRIPTION
The function `print_images_to_process`:

https://github.com/aramis-lab/clinica/blob/d505ac2f23119856844fef9b285cf47e774ceb94/clinica/utils/ux.py#L11-L35

is used in various pipelines but was not tested in isolation.
This PR proposes:

- to add these unit tests
- simpler implementation relying on the builtin `defaultdict` instead of `get_unique_subjects`
- to give more possibilities for customization (logging level and maximum number of lines)