### PR TITLE
[TEST] Add nifti comparison to FLAIR linear pipeline

### DIFF
--- a/test/nonregression/pipelines/anat/test_t1_linear.py
+++ b/test/nonregression/pipelines/anat/test_t1_linear.py
@@ -65,4 +65,4 @@ def run_flair_linear(
     pipeline.run(plugin="MultiProc", plugin_args={"n_procs": 4}, bypass_check=True)
 
     compare_folders(out_caps, ref_caps, output_dir)
-    compare_niftis(out_caps, ref_caps)
+    compare_niftis(out_caps, ref_caps, threshold=0.9)

--- a/test/nonregression/pipelines/anat/test_t1_linear.py
+++ b/test/nonregression/pipelines/anat/test_t1_linear.py
@@ -52,13 +52,17 @@ def run_flair_linear(
 ) -> None:
     from clinica.pipelines.t1_linear.anat_linear_pipeline import AnatLinear
 
+    out_caps = output_dir / "caps"
+    ref_caps = ref_dir / "caps"
+
     pipeline = AnatLinear(
         bids_directory=fspath(input_dir / "bids"),
-        caps_directory=fspath(output_dir / "caps"),
+        caps_directory=fspath(out_caps),
         base_dir=fspath(working_dir),
         parameters={"uncropped_image": False},
         name="flair-linear",
     )
     pipeline.run(plugin="MultiProc", plugin_args={"n_procs": 4}, bypass_check=True)
 
-    compare_folders(output_dir / "caps", ref_dir / "caps", output_dir)
+    compare_folders(out_caps, ref_caps, output_dir)
+    compare_niftis(out_caps, ref_caps)

--- a/test/nonregression/pipelines/anat/test_t1_linear.py
+++ b/test/nonregression/pipelines/anat/test_t1_linear.py
@@ -65,4 +65,4 @@ def run_flair_linear(
     pipeline.run(plugin="MultiProc", plugin_args={"n_procs": 4}, bypass_check=True)
 
     compare_folders(out_caps, ref_caps, output_dir)
-    compare_niftis(out_caps, ref_caps, threshold=0.9)
+    compare_niftis(out_caps, ref_caps)

--- a/test/nonregression/testing_tools.py
+++ b/test/nonregression/testing_tools.py
@@ -550,11 +550,11 @@ def compare_bids_tsv(bids_out: Path, bids_ref: Path):
         raise AssertionError("\n\n".join(errors))
 
 
-def compare_niftis(out_path: Path, ref_path: Path):
+def compare_niftis(out_path: Path, ref_path: Path, threshold: float = 0.95):
     errors = []
     for out_file_path in out_path.rglob("*.nii.gz"):
         ref_file_path = ref_path / out_file_path.relative_to(out_path)
-        if not similarity_measure(out_file_path, ref_file_path, 0.95):
+        if not similarity_measure(out_file_path, ref_file_path, threshold):
             errors += [out_file_path.name]
     if errors:
         newline = "\n"

--- a/test/nonregression/testing_tools.py
+++ b/test/nonregression/testing_tools.py
@@ -559,5 +559,5 @@ def compare_niftis(out_path: Path, ref_path: Path, threshold: float = 0.95):
     if errors:
         newline = "\n"
         raise AssertionError(
-            f"Following images do not meet the similarity criteria : \n\n {newline.join(errors)}"
+            f"Following images do not meet the similarity criteria : \n\n{newline.join(errors)}"
         )

--- a/test/unittests/test_testing_tools.py
+++ b/test/unittests/test_testing_tools.py
@@ -366,7 +366,7 @@ def test_compare_niftis_success(tmp_path):
 def test_compare_niftis_error(tmp_path):
     with pytest.raises(
         AssertionError,
-        match="Following images do not meet the similarity criteria : \n\n nifti.nii.gz",
+        match="Following images do not meet the similarity criteria : \n\nnifti.nii.gz",
     ):
         rds = np.random.RandomState(42)
         compare_niftis(


### PR DESCRIPTION
- Uses function `compare_niftis` in the FLAIR linear pipeline.
- `compare_niftis` was made a little more flexible by giving access to the metric threshold used as a requirement for similarity validation


### To discuss
We have images that don't pass the test right now. This might be partly due to the recent changes in the cropping function but some uncropped images tests aren't validated either. The threshold for the similarity metric is 0.9, I don't know if it makes sense to go lower or if we would need to update all the faulty images.