### PR TITLE
[TEST] Change function tested in non-regression for center-nifti

### DIFF
--- a/clinica/iotools/utils/center_nifti.py
+++ b/clinica/iotools/utils/center_nifti.py
@@ -76,7 +76,9 @@ def center_nifti(
     # Write list of created files
     timestamp = time.strftime("%Y%m%d-%H%M%S", time.localtime(time.time()))
     log_file = Path(output_bids_directory) / f"centered_nifti_list_{timestamp}.txt"
-    if not write_list_of_files(centered_files, log_file):
+    if not write_list_of_files(
+        [f.relative_to(output_bids_directory) for f in centered_files], log_file
+    ):
         log_and_raise(f"Could not create log file {log_file}.", IOError)
 
     if log_file.is_file():

--- a/test/nonregression/iotools/test_run_utils.py
+++ b/test/nonregression/iotools/test_run_utils.py
@@ -89,13 +89,13 @@ def test_compute_missing_modalities(cmdopt, tmp_path):
 def test_center_nifti(cmdopt, tmp_path):
     from test.nonregression.testing_tools import compare_niftis, create_list_hashes
 
-    from clinica.iotools.utils.data_handling import center_all_nifti
+    from clinica.iotools.utils import center_nifti
 
     base_dir = Path(cmdopt["input"])
     output_dir = tmp_path / "bids_centered"
     ref_dir = base_dir / "CenterNifti" / "ref"
 
-    center_all_nifti(
+    center_nifti(
         str(base_dir / "CenterNifti" / "in" / "bids"),
         output_dir,
         centering_threshold=0,
@@ -111,3 +111,6 @@ def test_center_nifti(cmdopt, tmp_path):
         raise RuntimeError("Hashes of nii* files are different between out and ref")
 
     compare_niftis(output_dir, ref_dir / "bids_centered")
+    # todo : compare txt
+
+    # todo : test with text file in data_ci then CI PR

--- a/test/nonregression/iotools/test_run_utils.py
+++ b/test/nonregression/iotools/test_run_utils.py
@@ -91,7 +91,9 @@ def test_center_nifti(cmdopt, tmp_path):
         compare_niftis,
         compare_txt_files,
         create_list_hashes,
+        strftime_mock,
     )
+    from unittest.mock import patch
 
     from clinica.iotools.utils import center_nifti
 
@@ -99,11 +101,14 @@ def test_center_nifti(cmdopt, tmp_path):
     output_dir = tmp_path / "bids_centered"
     ref_dir = base_dir / "CenterNifti" / "ref" / "bids_centered"
 
-    center_nifti(
-        str(base_dir / "CenterNifti" / "in" / "bids"),
-        output_dir,
-        centering_threshold=0,
-    )
+    with patch("time.strftime", wraps=strftime_mock) as time_mock:
+        center_nifti(
+            str(base_dir / "CenterNifti" / "in" / "bids"),
+            output_dir,
+            centering_threshold=0,
+        )
+        time_mock.assert_called_once()
+
     hashes_out = create_list_hashes(output_dir, extensions_to_keep=(".nii.gz", ".nii"))
     hashes_ref = create_list_hashes(ref_dir, extensions_to_keep=(".nii.gz", ".nii"))
 

--- a/test/nonregression/iotools/test_run_utils.py
+++ b/test/nonregression/iotools/test_run_utils.py
@@ -97,7 +97,7 @@ def test_center_nifti(cmdopt, tmp_path):
 
     base_dir = Path(cmdopt["input"])
     output_dir = tmp_path / "bids_centered"
-    ref_dir = base_dir / "CenterNifti" / "ref"
+    ref_dir = base_dir / "CenterNifti" / "ref" / "bids_centered"
 
     center_nifti(
         str(base_dir / "CenterNifti" / "in" / "bids"),
@@ -105,14 +105,12 @@ def test_center_nifti(cmdopt, tmp_path):
         centering_threshold=0,
     )
     hashes_out = create_list_hashes(output_dir, extensions_to_keep=(".nii.gz", ".nii"))
-    hashes_ref = create_list_hashes(
-        ref_dir / "bids_centered", extensions_to_keep=(".nii.gz", ".nii")
-    )
+    hashes_ref = create_list_hashes(ref_dir, extensions_to_keep=(".nii.gz", ".nii"))
 
     assert hashes_out == hashes_ref
 
     if hashes_out != hashes_ref:
         raise RuntimeError("Hashes of nii* files are different between out and ref")
 
-    compare_niftis(output_dir, ref_dir / "bids_centered")
-    compare_txt_files(output_dir, ref_dir / "bids_centered")
+    compare_niftis(output_dir, ref_dir)
+    compare_txt_files(output_dir, ref_dir)

--- a/test/nonregression/iotools/test_run_utils.py
+++ b/test/nonregression/iotools/test_run_utils.py
@@ -87,7 +87,11 @@ def test_compute_missing_modalities(cmdopt, tmp_path):
 
 @pytest.mark.fast
 def test_center_nifti(cmdopt, tmp_path):
-    from test.nonregression.testing_tools import compare_niftis, create_list_hashes
+    from test.nonregression.testing_tools import (
+        compare_niftis,
+        compare_txt_files,
+        create_list_hashes,
+    )
 
     from clinica.iotools.utils import center_nifti
 
@@ -111,6 +115,4 @@ def test_center_nifti(cmdopt, tmp_path):
         raise RuntimeError("Hashes of nii* files are different between out and ref")
 
     compare_niftis(output_dir, ref_dir / "bids_centered")
-    # todo : compare txt
-
-    # todo : test with text file in data_ci then CI PR
+    compare_txt_files(output_dir, ref_dir / "bids_centered")

--- a/test/nonregression/iotools/test_run_utils.py
+++ b/test/nonregression/iotools/test_run_utils.py
@@ -85,13 +85,17 @@ def test_compute_missing_modalities(cmdopt, tmp_path):
         assert compare_missing_modality_tsv(out_name, ref_name)
 
 
+def _strftime_mock(format: str, struct_time: tuple) -> str:
+    """The mock returns the timestamp of the reference file in the CI data."""
+    return "20250225-151004"
+
+
 @pytest.mark.fast
 def test_center_nifti(cmdopt, tmp_path):
     from test.nonregression.testing_tools import (
         compare_niftis,
         compare_txt_files,
         create_list_hashes,
-        strftime_mock,
     )
     from unittest.mock import patch
 
@@ -101,7 +105,7 @@ def test_center_nifti(cmdopt, tmp_path):
     output_dir = tmp_path / "bids_centered"
     ref_dir = base_dir / "CenterNifti" / "ref" / "bids_centered"
 
-    with patch("time.strftime", wraps=strftime_mock) as time_mock:
+    with patch("time.strftime", wraps=_strftime_mock) as time_mock:
         center_nifti(
             str(base_dir / "CenterNifti" / "in" / "bids"),
             output_dir,

--- a/test/nonregression/testing_tools.py
+++ b/test/nonregression/testing_tools.py
@@ -563,21 +563,13 @@ def compare_niftis(out_path: Path, ref_path: Path):
         )
 
 
-def strftime_mock(format: str, struct_time: tuple) -> str:
-    """The mock returns the timestamp of the reference file in the CI data."""
-    return "20250225-151004"
-
-
-def _open_txt_file(file_path: Path) -> set:
-    with open(file_path, "r") as f:
-        return set(line.strip("\n") for line in f.readlines())
-
-
 def compare_txt_files(out_path: Path, ref_path: Path):
+    from filecmp import cmp
+
     errors = []
     for out_file_path in out_path.rglob("*.txt"):
         ref_file_path = ref_path / out_file_path.relative_to(out_path)
-        if not _open_txt_file(ref_file_path) == _open_txt_file(out_file_path):
+        if not cmp(ref_file_path, out_file_path, shallow=False):
             errors += [out_file_path.name]
     if errors:
         newline = "\n"

--- a/test/nonregression/testing_tools.py
+++ b/test/nonregression/testing_tools.py
@@ -569,13 +569,11 @@ def strftime_mock(format: str, struct_time: tuple) -> str:
 
 
 def _open_txt_file(file_path: Path) -> set:
-    # todo : change unit tests
     with open(file_path, "r") as f:
         return set(line.strip("\n") for line in f.readlines())
 
 
 def compare_txt_files(out_path: Path, ref_path: Path):
-    # todo : change unit tests
     errors = []
     for out_file_path in out_path.rglob("*.txt"):
         ref_file_path = ref_path / out_file_path.relative_to(out_path)

--- a/test/nonregression/testing_tools.py
+++ b/test/nonregression/testing_tools.py
@@ -561,3 +561,16 @@ def compare_niftis(out_path: Path, ref_path: Path):
         raise AssertionError(
             f"Following images do not meet the similarity criteria : \n\n {newline.join(errors)}"
         )
+
+
+def _open_txt_file(directory_path: Path) -> set:
+    directory_path = directory_path.resolve()
+    file_path = next(directory_path.rglob("*.txt"))
+    with open(file_path, "r") as f:
+        return set(Path(line.strip("\n")).name for line in f.readlines())
+
+
+def compare_txt_files(out_path: Path, ref_path: Path):
+    assert _open_txt_file(out_path) == _open_txt_file(
+        ref_path
+    ), f"The text files inside {out_path.name} and {ref_path.name} do not match"

--- a/test/nonregression/testing_tools.py
+++ b/test/nonregression/testing_tools.py
@@ -563,14 +563,26 @@ def compare_niftis(out_path: Path, ref_path: Path):
         )
 
 
-def _open_txt_file(directory_path: Path) -> set:
-    directory_path = directory_path.resolve()
-    file_path = next(directory_path.rglob("*.txt"))
+def strftime_mock(format: str, struct_time: tuple) -> str:
+    """The mock returns the timestamp of the reference file in the CI data."""
+    return "20250225-151004"
+
+
+def _open_txt_file(file_path: Path) -> set:
+    # todo : change unit tests
     with open(file_path, "r") as f:
-        return set(Path(line.strip("\n")).name for line in f.readlines())
+        return set(line.strip("\n") for line in f.readlines())
 
 
 def compare_txt_files(out_path: Path, ref_path: Path):
-    assert _open_txt_file(out_path) == _open_txt_file(
-        ref_path
-    ), f"The text files inside {out_path.name} and {ref_path.name} do not match"
+    # todo : change unit tests
+    errors = []
+    for out_file_path in out_path.rglob("*.txt"):
+        ref_file_path = ref_path / out_file_path.relative_to(out_path)
+        if not _open_txt_file(ref_file_path) == _open_txt_file(out_file_path):
+            errors += [out_file_path.name]
+    if errors:
+        newline = "\n"
+        raise AssertionError(
+            f"Following text files are different : \n\n {newline.join(errors)}"
+        )

--- a/test/unittests/iotools/utils/test_center_nifti.py
+++ b/test/unittests/iotools/utils/test_center_nifti.py
@@ -197,6 +197,4 @@ def test_center_nifti(tmp_path, centering_threshold, expected_files):
         )  # 3 files written by mock and 1 log file
         logs = [f for f in output_dir.glob("centered_nifti_list_*.txt")]
         assert len(logs) == 1
-        assert logs[0].read_text() == "\n".join(
-            [str(output_dir / f) for f in expected_files]
-        )
+        assert logs[0].read_text() == "\n".join([f for f in expected_files])

--- a/test/unittests/test_testing_tools.py
+++ b/test/unittests/test_testing_tools.py
@@ -376,12 +376,11 @@ def test_compare_niftis_error(tmp_path):
 
 
 def _write_txt_file_in_directory(
-    dir_path: Path, files_to_write: list[str] = ["foo/bar.nii.gz", "foo/foobar.nii.gz"]
+    dir_path: Path, files_to_write: tuple[str] = ("foo/bar.nii.gz", "foo/foobar.nii.gz")
 ) -> Path:
     dir_path.mkdir()
     with open(dir_path / "out.txt", "w") as fp:
         fp.write(f"\n".join([str(f) for f in files_to_write]))
-
     return dir_path
 
 
@@ -389,7 +388,9 @@ def test_open_txt_files(tmp_path):
     from test.nonregression.testing_tools import _open_txt_file
 
     out_path = _write_txt_file_in_directory(tmp_path / "out")
-    assert {"bar.nii.gz", "foobar.nii.gz"} == _open_txt_file(out_path)
+    assert {"foo/bar.nii.gz", "foo/foobar.nii.gz"} == _open_txt_file(
+        out_path / "out.txt"
+    )
 
 
 def test_compare_txt_files(tmp_path):
@@ -406,11 +407,8 @@ def test_compare_txt_files_error(tmp_path):
 
     out_path = _write_txt_file_in_directory(tmp_path / "out")
     ref_path = _write_txt_file_in_directory(
-        tmp_path / "ref", files_to_write=["foo/test.nii.gz"]
+        tmp_path / "ref", files_to_write=("foo/test.nii.gz",)
     )
 
-    with pytest.raises(
-        AssertionError,
-        match=f"The text files inside {out_path.name} and {ref_path.name} do not match",
-    ):
+    with pytest.raises(AssertionError, match="Following text files are different"):
         compare_txt_files(out_path, ref_path)

--- a/test/unittests/test_testing_tools.py
+++ b/test/unittests/test_testing_tools.py
@@ -384,15 +384,6 @@ def _write_txt_file_in_directory(
     return dir_path
 
 
-def test_open_txt_files(tmp_path):
-    from test.nonregression.testing_tools import _open_txt_file
-
-    out_path = _write_txt_file_in_directory(tmp_path / "out")
-    assert {"foo/bar.nii.gz", "foo/foobar.nii.gz"} == _open_txt_file(
-        out_path / "out.txt"
-    )
-
-
 def test_compare_txt_files(tmp_path):
     from test.nonregression.testing_tools import compare_txt_files
 
@@ -410,5 +401,7 @@ def test_compare_txt_files_error(tmp_path):
         tmp_path / "ref", files_to_write=("foo/test.nii.gz",)
     )
 
-    with pytest.raises(AssertionError, match="Following text files are different"):
+    with pytest.raises(
+        AssertionError, match="Following text files are different : \n\n out.txt"
+    ):
         compare_txt_files(out_path, ref_path)

--- a/test/unittests/test_testing_tools.py
+++ b/test/unittests/test_testing_tools.py
@@ -373,3 +373,44 @@ def test_compare_niftis_error(tmp_path):
             _create_nifti_in_dir(tmp_path / "ref", rds),
             _create_nifti_in_dir(tmp_path / "out", rds),
         )
+
+
+def _write_txt_file_in_directory(
+    dir_path: Path, files_to_write: list[str] = ["foo/bar.nii.gz", "foo/foobar.nii.gz"]
+) -> Path:
+    dir_path.mkdir()
+    with open(dir_path / "out.txt", "w") as fp:
+        fp.write(f"\n".join([str(f) for f in files_to_write]))
+
+    return dir_path
+
+
+def test_open_txt_files(tmp_path):
+    from test.nonregression.testing_tools import _open_txt_file
+
+    out_path = _write_txt_file_in_directory(tmp_path / "out")
+    assert {"bar.nii.gz", "foobar.nii.gz"} == _open_txt_file(out_path)
+
+
+def test_compare_txt_files(tmp_path):
+    from test.nonregression.testing_tools import compare_txt_files
+
+    out_path = _write_txt_file_in_directory(tmp_path / "out")
+    ref_path = _write_txt_file_in_directory(tmp_path / "ref")
+
+    compare_txt_files(out_path, ref_path)
+
+
+def test_compare_txt_files_error(tmp_path):
+    from test.nonregression.testing_tools import compare_txt_files
+
+    out_path = _write_txt_file_in_directory(tmp_path / "out")
+    ref_path = _write_txt_file_in_directory(
+        tmp_path / "ref", files_to_write=["foo/test.nii.gz"]
+    )
+
+    with pytest.raises(
+        AssertionError,
+        match=f"The text files inside {out_path.name} and {ref_path.name} do not match",
+    ):
+        compare_txt_files(out_path, ref_path)


### PR DESCRIPTION
#1438 follow-up

- Change from center_all_niftis to center_nifti
- Add non regression tests on the txt file

As of now breaks the CI because the txt file was not added to the CI ref folder. I would need to update the CI with it if this PR is validated. The test that is done on the file structure should stay as is though (i.e. not taking into account the txt file) since there is a timestamp in the txt file name. 