### PR TITLE
[FIX] Set a random_seed in Flair Linear non regression tests to produce deterministic results

### DIFF
--- a/test/nonregression/pipelines/anat/test_t1_linear.py
+++ b/test/nonregression/pipelines/anat/test_t1_linear.py
@@ -59,10 +59,10 @@ def run_flair_linear(
         bids_directory=fspath(input_dir / "bids"),
         caps_directory=fspath(out_caps),
         base_dir=fspath(working_dir),
-        parameters={"uncropped_image": False},
+        parameters={"uncropped_image": False, "random_seed": 1},
         name="flair-linear",
     )
     pipeline.run(plugin="MultiProc", plugin_args={"n_procs": 4}, bypass_check=True)
 
     compare_folders(out_caps, ref_caps, output_dir)
-    compare_niftis(out_caps, ref_caps, threshold=0.8)
+    compare_niftis(out_caps, ref_caps)

--- a/test/nonregression/pipelines/anat/test_t1_linear.py
+++ b/test/nonregression/pipelines/anat/test_t1_linear.py
@@ -65,4 +65,4 @@ def run_flair_linear(
     pipeline.run(plugin="MultiProc", plugin_args={"n_procs": 4}, bypass_check=True)
 
     compare_folders(out_caps, ref_caps, output_dir)
-    compare_niftis(out_caps, ref_caps)
+    compare_niftis(out_caps, ref_caps, threshold=0.8)


### PR DESCRIPTION
Closes #1444

Sets the random_seed parameter to 1 in Flair Linear tests.