### PR TITLE
[TEST][FIX] IXI-to-BIDS : Add non-regression tests for metadata files

### DIFF
--- a/clinica/converters/ixi_to_bids/_utils.py
+++ b/clinica/converters/ixi_to_bids/_utils.py
@@ -365,9 +365,14 @@ def write_sessions(
     clinical_data : Dataframe containing the formatted clinical data of the IXI study.
     participant : Current converted subject study id (str).
     """
-    line = clinical_data[clinical_data["source_id"] == participant]
+    to_write = clinical_data[clinical_data["source_id"] == participant][
+        ["source_id", "session_id", "acq_time"]
+    ]
+    if to_write.empty:
+        to_write.loc[0, "source_id"] = participant
+        to_write.fillna("n/a", inplace=True)
     bids_id = bids_id_factory(StudyName.IXI).from_original_study_id(participant)
-    line[["source_id", "session_id", "acq_time"]].to_csv(
+    to_write.to_csv(
         bids_dir / bids_id / f"{bids_id}_sessions.tsv", sep="\t", index=False
     )
 

--- a/test/nonregression/test_run_converters.py
+++ b/test/nonregression/test_run_converters.py
@@ -15,7 +15,7 @@ import pytest
 from clinica.converters.study_models import StudyName
 
 
-@pytest.mark.parametrize("study", StudyName)
+@pytest.mark.parametrize("study", [StudyName.IXI])
 def test_converters(cmdopt, tmp_path, study: StudyName):
     from clinica.converters.factory import convert, get_converter_name
 
@@ -35,5 +35,5 @@ def test_converters(cmdopt, tmp_path, study: StudyName):
     )
 
     compare_folders(output_dir, ref_dir / "bids", output_dir)
-    if study == StudyName.AIBL:
+    if study in (StudyName.AIBL, StudyName.IXI):
         compare_bids_tsv(output_dir, ref_dir / "bids")

--- a/test/nonregression/test_run_converters.py
+++ b/test/nonregression/test_run_converters.py
@@ -15,7 +15,7 @@ import pytest
 from clinica.converters.study_models import StudyName
 
 
-@pytest.mark.parametrize("study", [StudyName.IXI])
+@pytest.mark.parametrize("study", StudyName)
 def test_converters(cmdopt, tmp_path, study: StudyName):
     from clinica.converters.factory import convert, get_converter_name
 


### PR DESCRIPTION
Extends non regression tests to metadata files as part of #1450. The function writing sessions needed a little fixing.