### PR TITLE
[FIX] Change querying pattern in `bids_pet_nii` when `tracer` exists but `reconstruction` is None

### DIFF
--- a/clinica/utils/input_files.py
+++ b/clinica/utils/input_files.py
@@ -611,15 +611,17 @@ def bids_pet_nii(
 
     description = f"PET data"
     trc = ""
+    rec = ""
+
     if tracer is not None:
         tracer = Tracer(tracer)
         trc = f"_trc-{tracer.value}"
         description += f" with {tracer.value} tracer"
-    rec = ""
+        rec = "*"
     if reconstruction is not None:
         reconstruction = ReconstructionMethod(reconstruction)
         rec = f"_rec-{reconstruction.value}"
-        description += f" and reconstruction method {reconstruction.value}"
+        description += f" with reconstruction method {reconstruction.value}"
 
     return {
         "pattern": Path("pet") / f"*{trc}{rec}_pet.nii*",

--- a/test/unittests/utils/test_input_files.py
+++ b/test/unittests/utils/test_input_files.py
@@ -40,30 +40,40 @@ def test_aggregator():
         toy_func_3((1, 2, 3), z=(4, 5))
 
 
-def test_bids_pet_nii_empty():
+@pytest.mark.parametrize(
+    "tracer, reconstruction, expected",
+    [
+        (None, None, {"pattern": Path("pet/*_pet.nii*"), "description": "PET data"}),
+        (
+            Tracer.FDG,
+            None,
+            {
+                "pattern": Path("pet/*_trc-18FFDG*_pet.nii*"),
+                "description": "PET data with 18FFDG tracer",
+            },
+        ),
+        (
+            None,
+            ReconstructionMethod.STATIC,
+            {
+                "pattern": Path("pet/*_rec-nacstat_pet.nii*"),
+                "description": "PET data with reconstruction method nacstat",
+            },
+        ),
+        (
+            "11CPIB",
+            "coregavg",
+            {
+                "pattern": Path("pet/*_trc-11CPIB_rec-coregavg_pet.nii*"),
+                "description": "PET data with 11CPIB tracer with reconstruction method coregavg",
+            },
+        ),
+    ],
+)
+def test_bids_pet_nii(tracer, reconstruction, expected):
     from clinica.utils.input_files import bids_pet_nii
 
-    assert bids_pet_nii() == {
-        "pattern": Path("pet") / "*_pet.nii*",
-        "description": "PET data",
-    }
-
-
-@pytest.fixture
-def expected_bids_pet_query(tracer, reconstruction):
-    return {
-        "pattern": Path("pet")
-        / f"*_trc-{tracer.value}_rec-{reconstruction.value}_pet.nii*",
-        "description": f"PET data with {tracer.value} tracer and reconstruction method {reconstruction.value}",
-    }
-
-
-@pytest.mark.parametrize("tracer", Tracer)
-@pytest.mark.parametrize("reconstruction", ReconstructionMethod)
-def test_bids_pet_nii(tracer, reconstruction, expected_bids_pet_query):
-    from clinica.utils.input_files import bids_pet_nii
-
-    assert bids_pet_nii(tracer, reconstruction) == expected_bids_pet_query
+    assert bids_pet_nii(tracer, reconstruction) == expected
 
 
 @pytest.mark.parametrize("dti_measure", DTIBasedMeasure)


### PR DESCRIPTION
Close #1469