### PR TITLE
[REF][TEST] Refactor and test `_select_sessions` in UKB-to-BIDS utils

### DIFF
--- a/clinica/converters/ukb_to_bids/_utils.py
+++ b/clinica/converters/ukb_to_bids/_utils.py
@@ -152,9 +152,6 @@ def _complete_clinical(df_clinical: pd.DataFrame) -> pd.DataFrame:
             lambda x: bids_id_factory(StudyName.UKB).from_original_study_id(x)
         )
     )
-    df_clinical = df_clinical.assign(
-        sessions=lambda df: "ses-" + df.source_sessions_number.astype("str")
-    )
     df_clinical = df_clinical.join(
         df_clinical.filename.map(
             {
@@ -226,6 +223,12 @@ def _complete_clinical(df_clinical: pd.DataFrame) -> pd.DataFrame:
         ).apply(pd.Series)
     )
     df_clinical = df_clinical.assign(year_of_birth=lambda df: df.year_of_birth_f34_0_0)
+
+    # Age handling :
+    #   - Session "0" : first session, only a questionnaire
+    #   - Session "2" : first imaging session (assumed to be ses-M000)
+    #   - Session "3" : second imaging session
+    # If there is no information about the age the image is deemed useless so not converted (see _select_sessions outputs)
 
     df_clinical = df_clinical.assign(age=lambda df: df.age_at_recruitment_f21022_0_0)
     df_clinical = df_clinical.assign(

--- a/clinica/converters/ukb_to_bids/_utils.py
+++ b/clinica/converters/ukb_to_bids/_utils.py
@@ -415,7 +415,7 @@ def _convert_dicom_to_nifti(zipfiles: Path, bids_path: Path) -> None:
         json.dump(json_file, f, indent=4)
 
 
-def _select_sessions(x: pd.Series) -> Optional[pd.Series]:
+def _select_sessions(x: pd.Series) -> Optional[float]:
     from clinica.utils.stream import cprint
 
     session = x["source_sessions_number"]

--- a/test/unittests/converters/test_ukb_to_bids_utils.py
+++ b/test/unittests/converters/test_ukb_to_bids_utils.py
@@ -1,3 +1,6 @@
+from cmath import nan
+
+import pandas as pd
 import pytest
 
 
@@ -14,3 +17,28 @@ def test_read_imaging_data(tmp_path):
         "or they are not handled by Clinica. Please check your data.",
     ):
         read_imaging_data(path_to_zip)
+
+
+@pytest.mark.parametrize(
+    "subject_id, source_session, age_2, age_3, expected",
+    [
+        ("sub1", "2", nan, nan, None),
+        ("sub2", "2", 23, nan, 23),
+        ("sub3", "3", nan, nan, None),
+        ("sub4", "3", nan, 35, 35),
+        ("sub5", "4", 0, 0, None),
+    ],
+)
+def test_select_sessions(subject_id, source_session, age_2, age_3, expected):
+    from clinica.converters.ukb_to_bids._utils import _select_sessions
+
+    clinical_data = pd.Series(
+        {
+            "eid": subject_id,
+            "source_sessions_number": source_session,
+            "age_when_attended_assessment_centre_f21003_2_0": age_2,
+            "age_when_attended_assessment_centre_f21003_3_0": age_3,
+        }
+    )
+
+    assert expected == _select_sessions(clinical_data)


### PR DESCRIPTION
While working on UKB-to-BIDS to extend #1450, I dug into the code for `sessions.tsv` writing and noticed a function that could be both improved and tested : 


https://github.com/aramis-lab/clinica/blob/c9ab28bec76c10ba8f8866555b39d713f640ce5a/clinica/converters/ukb_to_bids/_utils.py#L415-L453


The way of testing for nans was modified since it was doing nothing as it was.