### PR TITLE
[FIX] Remove the `--yes` option from the `t1-volume` pipeline as it is not used anymore

### DIFF
--- a/clinica/pipelines/t1_volume/t1_volume_cli.py
+++ b/clinica/pipelines/t1_volume/t1_volume_cli.py
@@ -19,7 +19,6 @@ pipeline_name = "t1-volume"
 @cli_param.option_group.common_pipelines_options
 @cli_param.option.subjects_sessions_tsv
 @cli_param.option.working_directory
-@cli_param.option.yes
 @cli_param.option_group.advanced_pipeline_options
 @cli_param.option.tissue_classes
 @cli_param.option.tissue_probability_maps
@@ -50,7 +49,6 @@ def cli(
     subjects_sessions_tsv: Optional[str] = None,
     working_directory: Optional[str] = None,
     n_procs: Optional[int] = None,
-    yes: bool = False,
     caps_name: Optional[str] = None,
 ) -> None:
     """Volume-based processing of T1-weighted MR images.
@@ -104,7 +102,6 @@ def cli(
         subjects_sessions_tsv=subjects_sessions_tsv,
         working_directory=working_directory,
         n_procs=n_procs,
-        yes=yes,
         caps_name=caps_name,
     )
 


### PR DESCRIPTION
Following #1419, this option should not be in the client for the pipeline anymore.