### PR TITLE
[CI] Allow manual execution of anat test workflow

### DIFF
--- a/.github/workflows/test_pipelines_anat.yml
+++ b/.github/workflows/test_pipelines_anat.yml
@@ -3,6 +3,7 @@ name: Anat Pipelines Tests
 on:
   schedule:
     - cron: 0 13 * * 2 # every thursday at 8pm
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test_pipelines_anat.yml
+++ b/.github/workflows/test_pipelines_anat.yml
@@ -2,7 +2,7 @@ name: Anat Pipelines Tests
 
 on:
   schedule:
-    - cron: 0 13 * * 2 # every thursday at 8pm
+    - cron: 0 20 * * 4 # every thursday at 8pm
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Revert modification of cron for anat testing workflows made in #1486 and use manual dispatch instead.