### PR TITLE
[FIX] Fix broken imports in CLI

### DIFF
--- a/clinica/iotools/cli.py
+++ b/clinica/iotools/cli.py
@@ -95,11 +95,8 @@ def check_missing_modalities(
     output_prefix: str = "missing_mods",
 ) -> None:
     """Check missing modalities in a BIDS dataset."""
-    from clinica.utils.inputs import check_bids_folder
-
     from .data_handling import compute_missing_mods
 
-    check_bids_folder(bids_directory)
     compute_missing_mods(bids_directory, output_directory, output_prefix)
 
 
@@ -113,11 +110,8 @@ def check_missing_processing(
     output_file: str,
 ) -> None:
     """Check missing processing in a CAPS dataset."""
-    from clinica.utils.inputs import check_caps_folder
-
     from .data_handling import compute_missing_processing
 
-    check_caps_folder(caps_directory)
     compute_missing_processing(bids_directory, caps_directory, output_file)
 
 

--- a/test/unittests/iotools/test_iotools_cli.py
+++ b/test/unittests/iotools/test_iotools_cli.py
@@ -1,5 +1,8 @@
+from pathlib import Path
+from typing import Optional
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from clinica.iotools.cli import check_missing_modalities, check_missing_processing
@@ -26,20 +29,55 @@ def test_check_missing_processing(mock_compute_missing_processing, tmp_path):
     )
 
 
-@patch("clinica.iotools.data_handling.compute_missing_mods")
-def test_check_missing_modalities(mock_compute_missing_mods, tmp_path):
-    (tmp_path / "bids").mkdir()
-    runner = CliRunner()
-    result = runner.invoke(
-        check_missing_modalities,
-        [
-            str(tmp_path / "bids"),
-            str(tmp_path / "output"),
-        ],
-    )
-    assert result.exit_code == 0
-    mock_compute_missing_mods.assert_called_once_with(
+@pytest.fixture
+def input_argument_list(
+    tmp_path: Path, option_name: Optional[str], option_value: Optional[str]
+) -> list:
+    input_argument_list = [
         str(tmp_path / "bids"),
         str(tmp_path / "output"),
-        "missing_mods",
+    ]
+    if option_name:
+        input_argument_list.extend([option_name, option_value])
+    return input_argument_list
+
+
+@pytest.fixture
+def expected_arguments_passed_to_mock(
+    tmp_path: Path, option_name: Optional[str], option_value: Optional[str]
+) -> list:
+    expected_arguments_passed_to_mock = [
+        str(tmp_path / "bids"),
+        str(tmp_path / "output"),
+    ]
+    if option_name:
+        expected_arguments_passed_to_mock.append(option_value)
+    else:
+        expected_arguments_passed_to_mock.append("missing_mods")
+    return expected_arguments_passed_to_mock
+
+
+@pytest.mark.parametrize(
+    "option_name,option_value",
+    [
+        (None, None),
+        ("--output_prefix", "foobar"),
+        ("--output_prefix", ""),
+    ],
+)
+@patch("clinica.iotools.data_handling.compute_missing_mods")
+def test_check_missing_modalities(
+    mock_compute_missing_mods,
+    tmp_path,
+    option_name,
+    option_value,
+    input_argument_list,
+    expected_arguments_passed_to_mock,
+):
+    (tmp_path / "bids").mkdir()
+    runner = CliRunner()
+    result = runner.invoke(check_missing_modalities, input_argument_list)
+    assert result.exit_code == 0
+    mock_compute_missing_mods.assert_called_once_with(
+        *expected_arguments_passed_to_mock
     )

--- a/test/unittests/iotools/test_iotools_cli.py
+++ b/test/unittests/iotools/test_iotools_cli.py
@@ -1,0 +1,45 @@
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from clinica.iotools.cli import check_missing_modalities, check_missing_processing
+
+
+@patch("clinica.iotools.data_handling.compute_missing_processing")
+def test_check_missing_processing(mock_compute_missing_processing, tmp_path):
+    (tmp_path / "bids").mkdir()
+    (tmp_path / "caps").mkdir()
+    runner = CliRunner()
+    result = runner.invoke(
+        check_missing_processing,
+        [
+            str(tmp_path / "bids"),
+            str(tmp_path / "caps"),
+            str(tmp_path / "outfile"),
+        ],
+    )
+    assert result.exit_code == 0
+    mock_compute_missing_processing.assert_called_once_with(
+        str(tmp_path / "bids"),
+        str(tmp_path / "caps"),
+        str(tmp_path / "outfile"),
+    )
+
+
+@patch("clinica.iotools.data_handling.compute_missing_mods")
+def test_check_missing_modalities(mock_compute_missing_mods, tmp_path):
+    (tmp_path / "bids").mkdir()
+    runner = CliRunner()
+    result = runner.invoke(
+        check_missing_modalities,
+        [
+            str(tmp_path / "bids"),
+            str(tmp_path / "output"),
+        ],
+    )
+    assert result.exit_code == 0
+    mock_compute_missing_mods.assert_called_once_with(
+        str(tmp_path / "bids"),
+        str(tmp_path / "output"),
+        "missing_mods",
+    )


### PR DESCRIPTION
Closes #1484 

This PR also proposes to add some unit tests related to the CLI client in order to avoid these kind of bugs (see issue #1485). The proposed solution consists of mocking the internal function and calling the CLI in the test with `CliRunner`. The tests then check the exit code as well as whether the mock was called and the arguments passed to it. Assuming the internal function is tested separately as well, this should be enough I believe. This testing strategy can be used for other CLI in order to close fully #1485.