### PR TITLE
[FIX] Fix imports in `pet-surface`

### DIFF
--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -933,12 +933,11 @@ def get_wf(
     from nipype.interfaces.spm import Coregister, Normalize12
 
     import clinica.pipelines.pet_surface.pet_surface_utils as utils
+    from clinica.pipelines.pet.utils import get_suvr_mask, read_psf_information
     from clinica.utils.filemanip import get_subject_id, load_volume, unzip_nii
     from clinica.utils.pet import (
         SUVRReferenceRegion,
         Tracer,
-        get_suvr_mask,
-        read_psf_information,
     )
     from clinica.utils.spm import get_tpm, use_spm_standalone_if_available
     from clinica.utils.ux import print_begin_image


### PR DESCRIPTION
After creation of `pipelines.pet` module some functions were moved to `pet.utils` from `utils.pet` but imports were not changed for `pet-surface`. This pipeline is also expected to be in this module (cf #1237) but in the meantime these imports should be fixed. 