### PR TITLE
[FIX] Fix imports in  `pet-volume` after creation of pipelines.pet

### DIFF
--- a/clinica/pydra/pet_volume/pipeline.py
+++ b/clinica/pydra/pet_volume/pipeline.py
@@ -72,9 +72,9 @@ def build_core_workflow(name: str = "core", parameters: dict = {}) -> Workflow:
     """
     from pydra.tasks import petpvc
 
+    from clinica.pipelines.pet.utils import get_suvr_mask
     from clinica.pydra.shared_workflows.smoothing import build_smoothing_workflow
     from clinica.pydra.utils import sanitize_fwhm
-    from clinica.pipelines.pet.utils import get_suvr_mask
     from clinica.utils.spm import use_spm_standalone_if_available
 
     use_spm_standalone_if_available()

--- a/clinica/pydra/pet_volume/pipeline.py
+++ b/clinica/pydra/pet_volume/pipeline.py
@@ -74,7 +74,7 @@ def build_core_workflow(name: str = "core", parameters: dict = {}) -> Workflow:
 
     from clinica.pydra.shared_workflows.smoothing import build_smoothing_workflow
     from clinica.pydra.utils import sanitize_fwhm
-    from clinica.utils.pet import get_suvr_mask
+    from clinica.pipelines.pet.utils import get_suvr_mask
     from clinica.utils.spm import use_spm_standalone_if_available
 
     use_spm_standalone_if_available()


### PR DESCRIPTION
Following PR #1497 there were some left-over imports that imported get_suvr_mask from `utils.pet`.

Adding the PR as these imports should be fixed while the pipeline is included in the new module (cf #1237).