### PR TITLE
[REF] GENFI -to-BIDS : Use source_path.parent instead of source_path in scans metadata

### DIFF
--- a/clinica/converters/genfi_to_bids/_utils.py
+++ b/clinica/converters/genfi_to_bids/_utils.py
@@ -67,7 +67,6 @@ def _filter_dicoms(df: DataFrame) -> DataFrame:
         "localiser",
         "localizer",
     ]
-
     df = df.drop_duplicates(subset=["source"])
     df = df.assign(
         series_desc=lambda x: x.source_path.apply(
@@ -859,7 +858,7 @@ def write_bids(
                 / str(metadata.session_id)
                 / f"{metadata.participant_id}_{metadata.session_id}_scan.tsv"
             )
-            metadata.source_path = metadata.source_path.relative_to(source)
+            metadata.source_path = metadata.source_path.relative_to(source).parent
             row_to_write = _serialize_row(
                 metadata.drop(["participant_id", "session_id"]),
                 write_column_names=not scans_filepath.exists(),


### PR DESCRIPTION
Closes #1509 

The issue caused failing non-regression tests when comparing scans.tsv files. Instead of trying to get the same dicom file every time upstream as described in 1509, I chose to modify the path written in the scans.tsv file. To modify that properly I would have had to unit test every intermediate function which is not my goal right now, though it has been added to the to-do list.


Current non-regression tests for GENFI can be expected to fail with this PR but should not when #1468 is rebased
