### PR TITLE
[FIX] GENFI : sort dicoms before dropping duplicates

### DIFF
--- a/clinica/converters/genfi_to_bids/_utils.py
+++ b/clinica/converters/genfi_to_bids/_utils.py
@@ -67,7 +67,7 @@ def _filter_dicoms(df: DataFrame) -> DataFrame:
         "localiser",
         "localizer",
     ]
-
+    df = df.sort_values(by="source_path").reset_index(drop=True)
     df = df.drop_duplicates(subset=["source"])
     df = df.assign(
         series_desc=lambda x: x.source_path.apply(


### PR DESCRIPTION
Closes #1509

Dicom dataframe was filtered, starting by dropping duplicates on one column. If the dataframe was not previously ordered on an adjacent column there was a possibility to not get the same output each time. This caused failing non-regression tests when comparing scans.tsv files. 

Current non-regression tests for GENFI can be expected to fail with this PR but should not when #1468 is rebased