### PR TITLE
[REF] UKB : Modify tsv writing to fit BIDS specifications

### DIFF
--- a/clinica/converters/ukb_to_bids/_utils.py
+++ b/clinica/converters/ukb_to_bids/_utils.py
@@ -367,8 +367,27 @@ def _write_images(scans: pd.DataFrame, to: Path, source: Path, fs: LocalFileSyst
 
 def _write_scans(scans: pd.DataFrame, to: Path) -> None:
     scans = scans.reset_index().set_index(["bids_full_path"], verify_integrity=True)
+    # for participant_id, session in scans.groupby("participant_id"):
+    #     breakpoint()
     for bids_full_path, metadata in scans.iterrows():
         _write_row_in_scans_tsv_file(metadata, to)
+
+
+# def _add_sidecars_metadata_lines(metadata: pd.Series) -> pd.DataFrame:
+#     # todo :test
+#     # todo : use
+#     metadata.rename({"bids_filename": "filename"}, inplace=True)
+#     metadata["filename"] = f"{Path(metadata.name).parent.name}/{metadata["filename"]}.nii.gz"
+#     if sidecars := metadata.pop("sidecars"):
+#         metadata = metadata.to_frame().T.reset_index(
+#             drop=True)  # todo : do the series keep its name if I don't drop it ?
+#         for extension in list(map(lambda x: x.split(".")[-1], sidecars)):
+#             line_copy = metadata.loc[0].copy()
+#             line_copy["filename"] = line_copy["filename"].replace("nii.gz", extension)
+#             metadata = pd.concat([metadata, line_copy.to_frame().T], ignore_index=True)
+#             # todo : change what is used to serialize /write
+#     return metadata
+#
 
 
 def _write_row_in_scans_tsv_file(row: pd.Series, to: Path):

--- a/clinica/converters/ukb_to_bids/_utils.py
+++ b/clinica/converters/ukb_to_bids/_utils.py
@@ -376,7 +376,7 @@ def _get_extensions_from_sidecars(sidecars: list[str]) -> list[str]:
                 "An invalid extension for bids files was found and won't be registered in scans.tsv. Please check your files.",
                 lvl="warning",
             )
-    return extensions + [".nii.gz"]
+    return extensions + [Extension(".nii.gz")]
 
 
 def _write_scans(scans: pd.DataFrame, to: Path) -> None:
@@ -408,20 +408,6 @@ def _write_scans(scans: pd.DataFrame, to: Path) -> None:
             sep="\t",
             index=False,
         )
-
-
-def _serialize_row(row: pd.Series, write_column_names: bool) -> str:
-    row_dict = row.to_dict()
-    to_write = (
-        [row_dict.keys(), row_dict.values()]
-        if write_column_names
-        else [row_dict.values()]
-    )
-    return "\n".join([_serialize_list(list(_)) for _ in to_write])
-
-
-def _serialize_list(data: list, sep="\t") -> str:
-    return sep.join([str(value) for value in data])
 
 
 def _copy_file_to_bids(zipfile: Path, filenames: List[Path], bids_path: Path) -> None:

--- a/clinica/converters/ukb_to_bids/_utils.py
+++ b/clinica/converters/ukb_to_bids/_utils.py
@@ -338,13 +338,13 @@ def _write_description_and_participants(
 
 def _write_sessions(sessions: pd.DataFrame, to: Path, fs: LocalFileSystem):
     for participant_id, data_frame in sessions.groupby("participant_id"):
-        sessions = data_frame.droplevel(
+        sessions_to_write = data_frame.droplevel(
             ["participant_id", "modality", "bids_filename"]
         ).drop_duplicates()
-        sessions.index.name = "session_id"
+        sessions_to_write.index.name = "session_id"
         sessions_filepath = to / str(participant_id) / f"{participant_id}_sessions.tsv"
         with fs.open(str(sessions_filepath), "w") as sessions_file:
-            write_to_tsv(sessions, sessions_file)
+            write_to_tsv(sessions_to_write, sessions_file)
 
 
 def _write_images(scans: pd.DataFrame, to: Path, source: Path, fs: LocalFileSystem):
@@ -380,7 +380,6 @@ def _get_extensions_from_sidecars(sidecars: list[str]) -> list[str]:
 
 
 def _write_scans(scans: pd.DataFrame, to: Path) -> None:
-    # todo : test
     for subject_session, data in scans.groupby(["participant_id", "sessions"]):
         data["filename_no_extension"] = data["bids_full_path"].apply(
             lambda x: f"{Path(x).parent.name}/{Path(x).name}"

--- a/clinica/converters/ukb_to_bids/_utils.py
+++ b/clinica/converters/ukb_to_bids/_utils.py
@@ -381,11 +381,8 @@ def _get_extensions_from_sidecars(sidecars: list[str]) -> list[str]:
 
 
 def _write_scans(scans: pd.DataFrame, to: Path) -> None:
-    scans = scans.reset_index().set_index(["bids_full_path"], verify_integrity=True)
-
+    # todo : test
     for subject_session, data in scans.groupby(["participant_id", "sessions"]):
-        data.reset_index(drop=False, inplace=True)
-
         data["filename_no_extension"] = data["bids_full_path"].apply(
             lambda x: f"{Path(x).parent.name}/{Path(x).name}"
         )
@@ -405,7 +402,6 @@ def _write_scans(scans: pd.DataFrame, to: Path) -> None:
                         ),
                     ]
                 )
-
         to_write.to_csv(
             to
             / subject_session[0]

--- a/clinica/converters/ukb_to_bids/_utils.py
+++ b/clinica/converters/ukb_to_bids/_utils.py
@@ -309,7 +309,8 @@ def write_bids(
     fs = LocalFileSystem(auto_mkdir=True)
     _write_description_and_participants(participants, to, fs)
     _write_sessions(sessions, to, fs)
-    _write_scans(scans, dataset_directory, to, fs)
+    _write_images(scans, to, dataset_directory, fs)
+    _write_scans(scans, to)
 
 
 def _write_description_and_participants(
@@ -345,9 +346,7 @@ def _write_sessions(sessions: pd.DataFrame, to: Path, fs: LocalFileSystem):
             write_to_tsv(sessions, sessions_file)
 
 
-def _write_scans(
-    scans: pd.DataFrame, source: Path, to: Path, fs: LocalFileSystem
-) -> None:
+def _write_images(scans: pd.DataFrame, to: Path, source: Path, fs: LocalFileSystem):
     scans = scans.reset_index().set_index(["bids_full_path"], verify_integrity=True)
     for bids_full_path, metadata in scans.iterrows():
         if metadata["modality_num"] != "20217" and metadata["modality_num"] != "20225":
@@ -364,6 +363,11 @@ def _write_scans(
             )
             if metadata["modality_num"] == "20217":
                 _import_event_tsv(bids_path=to, fs=fs)
+
+
+def _write_scans(scans: pd.DataFrame, to: Path) -> None:
+    scans = scans.reset_index().set_index(["bids_full_path"], verify_integrity=True)
+    for bids_full_path, metadata in scans.iterrows():
         _write_row_in_scans_tsv_file(metadata, to)
 
 

--- a/clinica/converters/ukb_to_bids/_utils.py
+++ b/clinica/converters/ukb_to_bids/_utils.py
@@ -321,9 +321,8 @@ def _write_description_and_participants(
     from clinica.converters.study_models import StudyName
     from clinica.dataset import BIDSDatasetDescription
 
-    participants = participants.droplevel(
-        ["sessions", "modality", "bids_filename"]
-    ).drop_duplicates()
+    participants = participants.droplevel(["sessions", "modality", "bids_filename"])
+    participants = participants.loc[~participants.index.duplicated(keep="first")]
 
     # Ensure BIDS hierarchy is written first.
     with fs.transaction:

--- a/test/nonregression/test_run_converters.py
+++ b/test/nonregression/test_run_converters.py
@@ -42,5 +42,6 @@ def test_converters(cmdopt, tmp_path, study: StudyName):
         StudyName.NIFD,
         StudyName.OASIS3,
         StudyName.GENFI,
+        StudyName.UKB,
     ):
         compare_bids_tsv(output_dir, ref_dir / "bids")

--- a/test/unittests/converters/test_ukb_to_bids_utils.py
+++ b/test/unittests/converters/test_ukb_to_bids_utils.py
@@ -122,20 +122,27 @@ def test_write_sessions(tmp_path):
     assert len(tsv) == 2
 
 
-# def test_write_scans(tmp_path):
-# todo
+def test_write_scans(tmp_path):
+    from clinica.converters.ukb_to_bids._utils import _write_scans
 
-# from clinica.converters.ukb_to_bids._utils import _write_scans
-# scans = pd.DataFrame(pd.DataFrame(
-#     {
-#         "participants": ["1", "2", "2"],
-#         "sessions": ["ses-M000", "ses-M000", "ses-M001"],
-#         "modality": ["dwi", "dwi", "dwi"],
-#         "bids_filename": ["1-0-dwi", "2-0-dwi", "2-1-dwi"],
-#         "sex": ["F", "F", "F"],
-#     }
-# ))
-#
-# to = tmp_path / "BIDS" / "sub-001" / "ses-M000"
-# to.mkdir(parents=True)
-# _write_scans(scans, to)
+    to = tmp_path / "BIDS"
+    (to / "sub-001" / "ses-M000").mkdir(parents=True, exist_ok=True)
+    scans = pd.DataFrame(
+        pd.DataFrame(
+            {
+                "participant_id": ["sub-001"],
+                "sessions": ["ses-M000"],
+                "modality": ["T1w"],
+                "bids_filename": ["sub-001_ses-M000_T1w"],
+                "bids_full_path": [
+                    to / "sub-001" / "ses-M000" / "sub-001_ses-M000_T1w"
+                ],
+                "sidecars": [["truc.json"]],
+            }
+        )
+    )
+    _write_scans(scans, to)
+    tsv_files = list(to.rglob("*tsv"))
+    assert len(tsv_files) == 1
+    tsv = pd.read_csv(tsv_files[0], sep="\t")
+    assert len(tsv) == 2

--- a/test/unittests/converters/test_ukb_to_bids_utils.py
+++ b/test/unittests/converters/test_ukb_to_bids_utils.py
@@ -20,8 +20,24 @@ def test_read_imaging_data(tmp_path):
         read_imaging_data(path_to_zip)
 
 
-def test_write_row_in_scans_tsv_file(tmp_path):
-    from clinica.converters.ukb_to_bids._utils import _write_row_in_scans_tsv_file
+@pytest.mark.parametrize(
+    "sidecars, expected", [([], {".nii.gz"}), (["truc.json"], {".nii.gz", ".json"})]
+)
+def test_get_extensions_from_sidecars_success(sidecars, expected):
+    from clinica.converters.ukb_to_bids._utils import _get_extensions_from_sidecars
+
+    assert expected == set(_get_extensions_from_sidecars(sidecars))
+
+
+@pytest.mark.parametrize("sidecars", [["foo"], [".bar"]])
+def test_get_extensions_from_sidecars_error(sidecars):
+    from clinica.converters.ukb_to_bids._utils import _get_extensions_from_sidecars
+
+    assert _get_extensions_from_sidecars(sidecars) == [".nii.gz"]
+
+
+def test_write_scans(tmp_path):
+    from clinica.converters.ukb_to_bids._utils import _write_scans
 
     row = pd.Series(
         {
@@ -35,7 +51,7 @@ def test_write_row_in_scans_tsv_file(tmp_path):
     target_dir = tmp_path / "BIDS" / "sub-0001" / "ses-M000"
     target_dir.mkdir(parents=True)
 
-    _write_row_in_scans_tsv_file(row, tmp_path / "BIDS")
+    _write_scans(row, tmp_path / "BIDS")
 
     scans_tsv = target_dir / "sub-0001_ses-M000_scans.tsv"
     assert scans_tsv.exists()

--- a/test/unittests/converters/test_ukb_to_bids_utils.py
+++ b/test/unittests/converters/test_ukb_to_bids_utils.py
@@ -36,35 +36,6 @@ def test_get_extensions_from_sidecars_error(sidecars):
     assert _get_extensions_from_sidecars(sidecars) == [".nii.gz"]
 
 
-def test_write_scans(tmp_path):
-    from clinica.converters.ukb_to_bids._utils import _write_scans
-
-    row = pd.Series(
-        {
-            "participant_id": "sub-0001",
-            "sessions": "ses-M000",
-            "filename": "sub-0001_ses-M000_T1w.nii.gz",
-            "modality": "T1w",
-        }
-    )
-
-    target_dir = tmp_path / "BIDS" / "sub-0001" / "ses-M000"
-    target_dir.mkdir(parents=True)
-
-    _write_scans(row, tmp_path / "BIDS")
-
-    scans_tsv = target_dir / "sub-0001_ses-M000_scans.tsv"
-    assert scans_tsv.exists()
-
-    content = scans_tsv.read_text().strip().splitlines()
-
-    columns_names = content[0].split("\t")
-    columns_items = content[1].split("\t")
-
-    assert columns_names == ["filename", "modality"]
-    assert columns_items == ["sub-0001_ses-M000_T1w.nii.gz", "T1w"]
-
-
 @pytest.mark.parametrize(
     "subject_id, source_session, age_2, age_3, expected",
     [


### PR DESCRIPTION
Following the work in #1450.

In order to facilitate new regression tests on metadata, this PR : 

- [x] Splits BIDS writing in participants/sessions/images/scans
- [x] Applies required modifications for scans to follow BIDS specifications
- [x] Tests scans writing (when logic is validated)
- [x] Should be accompanied by a PR data for CI (when logic is validated)