### PR TITLE
[FIX] IXI-to-BIDS : Setting `session_id` as the first column of `*_sessions.tsv`

### DIFF
--- a/clinica/converters/ixi_to_bids/_utils.py
+++ b/clinica/converters/ixi_to_bids/_utils.py
@@ -364,7 +364,7 @@ def write_sessions(
     participant : Current converted subject study id (str).
     """
     to_write = clinical_data[clinical_data["source_id"] == participant][
-        ["source_id", "session_id", "acq_time"]
+        ["session_id", "source_id", "acq_time"]
     ]
     if to_write.empty:
         to_write.loc[0, "source_id"] = participant

--- a/test/unittests/converters/test_ixi_to_bids_utils.py
+++ b/test/unittests/converters/test_ixi_to_bids_utils.py
@@ -655,7 +655,7 @@ def test_write_sessions(tmp_path):
     assert (
         assert_frame_equal(
             pd.read_csv(file_path, sep="\t"),
-            clinical[["source_id", "session_id", "acq_time"]],
+            clinical[["session_id", "source_id", "acq_time"]],
         )
         is None
     )


### PR DESCRIPTION
Closes #1561 