### PR TITLE
[ENH] Adaptation of user id retrieval for docker processes

### DIFF
--- a/clinica/dataset/caps/_dataset_description.py
+++ b/clinica/dataset/caps/_dataset_description.py
@@ -276,7 +276,11 @@ def _get_username() -> str:
     import os
     import pwd
 
-    return pwd.getpwuid(os.getuid()).pw_name
+    try:
+        return pwd.getpwuid(os.getuid()).pw_name
+    except KeyError:
+        cprint("Assuming a no-name docker user", lvl="debug")
+        return "docker_user"
 
 
 def _get_machine_name() -> str:


### PR DESCRIPTION
When writing the `dataset_description` file for CAPS, the user name of the person who does the processing is retrieved based on uid.  Inside a docker container, you have a uid/gid but that is not associated to a specific user. In other words, you run as a no-name user. As such, this part of the code was not adapted to running with docker and was adapted a little.