### PR TITLE
[FIX] Non-regression tests for `center-nifti` catch `time.strftime` only once

### DIFF
--- a/clinica/iotools/center_nifti.py
+++ b/clinica/iotools/center_nifti.py
@@ -40,12 +40,11 @@ def center_nifti(
     images detected as problematic are converted from INPUT_BIDS_DIRECTORY to OUTPUT_BIDS_DIRECTORY, whilst the others
     are copied verbatim.
     """
-    import time
     from pathlib import Path
 
     from clinica.utils.stream import cprint, log_and_raise
 
-    from .data_handling import center_all_nifti, write_list_of_files
+    from .data_handling import center_all_nifti, centered_timestamp, write_list_of_files
 
     cprint(
         f"Clinica is now centering the requested images with a threshold of {centering_threshold} mm.",
@@ -72,8 +71,10 @@ def center_nifti(
     )
 
     # Write list of created files
-    timestamp = time.strftime("%Y%m%d-%H%M%S", time.localtime(time.time()))
-    log_file = Path(output_bids_directory) / f"centered_nifti_list_{timestamp}.txt"
+    log_file = (
+        Path(output_bids_directory) / f"centered_nifti_list_{centered_timestamp()}.txt"
+    )
+
     if not write_list_of_files(
         sorted([f.relative_to(output_bids_directory) for f in centered_files]), log_file
     ):

--- a/clinica/iotools/data_handling/__init__.py
+++ b/clinica/iotools/data_handling/__init__.py
@@ -2,6 +2,7 @@ from ._centering import (
     are_images_centered_around_origin_of_world_coordinate_system,
     center_all_nifti,
     center_nifti_origin,
+    centered_timestamp,
     check_relative_volume_location_in_world_coordinate_system,
 )
 from ._files import create_subs_sess_list, write_list_of_files
@@ -18,4 +19,5 @@ __all__ = [
     "write_list_of_files",
     "are_images_centered_around_origin_of_world_coordinate_system",
     "check_relative_volume_location_in_world_coordinate_system",
+    "centered_timestamp",
 ]

--- a/clinica/iotools/data_handling/_centering.py
+++ b/clinica/iotools/data_handling/_centering.py
@@ -11,7 +11,14 @@ __all__ = [
     "are_images_centered_around_origin_of_world_coordinate_system",
     "check_relative_volume_location_in_world_coordinate_system",
     "center_all_nifti",
+    "centered_timestamp",
 ]
+
+
+def centered_timestamp():
+    import time
+
+    return time.strftime("%Y%m%d-%H%M%S", time.localtime(time.time()))
 
 
 def _handle_output_existing_files(

--- a/test/nonregression/test_run_iotools.py
+++ b/test/nonregression/test_run_iotools.py
@@ -84,7 +84,7 @@ def test_compute_missing_modalities(cmdopt, tmp_path):
         assert compare_missing_modality_tsv(out_name, ref_name)
 
 
-def _strftime_mock(format: str, struct_time: tuple) -> str:
+def _centered_timestamp_mock() -> str:
     """The mock returns the timestamp of the reference file in the CI data."""
     return "20250225-151004"
 
@@ -104,7 +104,10 @@ def test_center_nifti(cmdopt, tmp_path):
     output_dir = tmp_path / "bids_centered"
     ref_dir = base_dir / "CenterNifti" / "ref" / "bids_centered"
 
-    with patch("time.strftime", wraps=_strftime_mock) as time_mock:
+    with patch(
+        "clinica.iotools.data_handling.centered_timestamp",
+        wraps=_centered_timestamp_mock,
+    ) as time_mock:
         center_nifti(
             str(base_dir / "CenterNifti" / "in" / "bids"),
             output_dir,


### PR DESCRIPTION
Closes #1613

Exports timestamp computing in another function then patches it to avoid catching all underlying instances of `time.strftime`, for example through `cprint`. This was probably introduced when logging level was upgraded to DEBUG in tests 6 months ago.