### PR TITLE
[FIX] ADNI-to-BIDS : Quick fix - Invalid columns removed from `df_filtered` when empty

### DIFF
--- a/clinica/converters/adni_to_bids/_utils.py
+++ b/clinica/converters/adni_to_bids/_utils.py
@@ -455,10 +455,6 @@ def create_adni_sessions_dict(
                 ]["BIDS CLINICA"].tolist()
             )
 
-            df_filtered = df_filtered.loc[
-                :, (~df_filtered.columns.isin(df_subj_session.columns))
-            ]
-
             df_subj_session = pd.concat([df_subj_session, df_filtered], axis=1)
     if df_subj_session.empty:
         cprint(


### PR DESCRIPTION
Adds a quick fix to #1623, does not close it