### PR TITLE
[TEST] Only use `clinica.all` module in workflows

### DIFF
--- a/.github/workflows/test_instantiation.yml
+++ b/.github/workflows/test_instantiation.yml
@@ -50,7 +50,7 @@ jobs:
           source /builds/miniconda/etc/profile.d/conda.sh
           conda activate "${{ github.workspace }}"/env
           source /usr/local/Modules/init/profile.sh
-          module load clinica_standalone.all
+          module load clinica.all
           make install
           cd test
           poetry run pytest --verbose \

--- a/.github/workflows/test_non_regression_fast.yml
+++ b/.github/workflows/test_non_regression_fast.yml
@@ -49,7 +49,7 @@ jobs:
           source /builds/miniconda/etc/profile.d/conda.sh
           conda activate "${{ github.workspace }}"/env
           source /usr/local/Modules/init/profile.sh
-          module load clinica_standalone.all
+          module load clinica.all
           make install
           cd test
           poetry run pytest --verbose \

--- a/.github/workflows/test_pipelines_anat.yml
+++ b/.github/workflows/test_pipelines_anat.yml
@@ -97,7 +97,7 @@ jobs:
           source /builds/miniconda/etc/profile.d/conda.sh
           conda activate "${{ github.workspace }}"/env
           source /usr/local/Modules/init/profile.sh
-          module load clinica_standalone.all
+          module load clinica.all
           make install
           cd test
           poetry run pytest --verbose \

--- a/.github/workflows/test_pipelines_pet_no_surface.yml
+++ b/.github/workflows/test_pipelines_pet_no_surface.yml
@@ -71,7 +71,7 @@ jobs:
           source /builds/miniconda/etc/profile.d/conda.sh
           conda activate "${{ github.workspace }}"/env
           source /usr/local/Modules/init/profile.sh
-          module load clinica_standalone.all
+          module load clinica.all
           make install
           cd test
           poetry run pytest --verbose \

--- a/.github/workflows/test_pipelines_pet_surface.yml
+++ b/.github/workflows/test_pipelines_pet_surface.yml
@@ -46,7 +46,7 @@ jobs:
           source /builds/miniconda/etc/profile.d/conda.sh
           conda activate "${{ github.workspace }}"/env
           source /usr/local/Modules/init/profile.sh
-          module load clinica_standalone.all
+          module load clinica.all
           make install
           cd test
           poetry run pytest --verbose \


### PR DESCRIPTION
Now that the set-up with MATLAB + SPM has totally been removed from the code of clinica #1624 there is no reason to keep a module for `clinica` (previously with this outdated set-up) and one for `clinica_standalone`. There is now only one module `clinica` on CI machines which loads the standalone set-up. This PR includes the modifications to use it on every relevant workflow.