### PR TITLE
[ENH ]OASIS3-to-BIDS: Adds TAU PET modality to converter

### DIFF
--- a/clinica/converters/oasis3_to_bids/_utils.py
+++ b/clinica/converters/oasis3_to_bids/_utils.py
@@ -34,6 +34,7 @@ _MODALITY_TO_BIDS = {
     "pet_FDG": {"datatype": "pet", "suffix": "pet", "trc_label": "18FFDG"},
     "pet_PIB": {"datatype": "pet", "suffix": "pet", "trc_label": "11CPIB"},
     "pet_AV45": {"datatype": "pet", "suffix": "pet", "trc_label": "18FAV45"},
+    "pet_AV1451": {"datatype": "pet", "suffix": "pet", "trc_label": "18FAV1451"},
 }
 
 # Clinical Score column names


### PR DESCRIPTION
Simple modification that results in the conversion of Tau PET data to BIDS