### PR TITLE
[BUG] Fix cross-subject clinical score merge in OASIS3 converter

### DIFF
--- a/clinica/converters/oasis3_to_bids/_utils.py
+++ b/clinica/converters/oasis3_to_bids/_utils.py
@@ -264,14 +264,13 @@ def _merge_clinical_scores(
 ) -> pd.DataFrame:
     """Bin clinical visits into session bins and merge scores onto imaging sessions."""
     df_clinical = _compute_session_bins(df_clinical)
-    df_clinical = (
-        df_clinical.merge(df_source["Subject"], how="inner", on="Subject")
-        .drop_duplicates()
-        .set_index(["Subject", "Date"])
-    )
+    df_clinical = df_clinical.merge(
+        df_source["Subject"], how="inner", on="Subject"
+    ).drop_duplicates()
     return df_source.merge(
         df_clinical[
             [
+                "Subject",
                 "session",
                 "mmse",
                 "cdr",
@@ -284,9 +283,9 @@ def _merge_clinical_scores(
                 "perscare",
                 "sumbox",
             ]
-        ],
+        ].drop_duplicates(),
         how="left",
-        on="session",
+        on=["Subject", "session"],
     )
 
 


### PR DESCRIPTION
Doing some exploration of the imaging data using methods from the new converter, I noticed that there is a bug with a "many-to-many" merge in _merge_clinical_scores that joined clinical scores on session bin only, ignoring subject.

This issue may have resulted in clinical scores (MMSE, CDR, etc.) in session TSVs containing values from a different subject sharing the same time bin.

*Some more details*
After .set_index(["Subject", "Date"]), Subject was moved to the index and excluded from the merge key. The subsequent merge(..., on="session") produced a cartesian product across all subjects within each session bin (~5M rows), which was masked downstream by drop_duplicates calls — but the surviving clinical values were arbitrary.

Fix: keep Subject as a column and merge on ["Subject", "session"].

Sorry about that :/