### PR TITLE
[REF] T1/FLAIR-Linear : set higher value for N4BiasFieldCorrection b-spline parameter 

### DIFF
--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -300,10 +300,7 @@ class AnatLinear(Pipeline):
         if self.use_antspy:
             n4biascorrection.inputs.output_dir = str(self.base_dir)
             n4biascorrection.inputs.verbose = True
-        if self.name == "t1-linear":
-            n4biascorrection.inputs.bspline_fitting_distance = 600
-        else:
-            n4biascorrection.inputs.bspline_fitting_distance = 100
+        n4biascorrection.inputs.bspline_fitting_distance = 600
 
         # 2. `RegistrationSynQuick` by *ANTS*. It uses nipype interface.
         ants_registration_node = npe.Node(

--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -300,7 +300,7 @@ class AnatLinear(Pipeline):
         if self.use_antspy:
             n4biascorrection.inputs.output_dir = str(self.base_dir)
             n4biascorrection.inputs.verbose = True
-        n4biascorrection.inputs.bspline_fitting_distance = 400
+        n4biascorrection.inputs.bspline_fitting_distance = 200
 
         # 2. `RegistrationSynQuick` by *ANTS*. It uses nipype interface.
         ants_registration_node = npe.Node(

--- a/clinica/pipelines/t1_linear/anat_linear_pipeline.py
+++ b/clinica/pipelines/t1_linear/anat_linear_pipeline.py
@@ -300,7 +300,7 @@ class AnatLinear(Pipeline):
         if self.use_antspy:
             n4biascorrection.inputs.output_dir = str(self.base_dir)
             n4biascorrection.inputs.verbose = True
-        n4biascorrection.inputs.bspline_fitting_distance = 600
+        n4biascorrection.inputs.bspline_fitting_distance = 400
 
         # 2. `RegistrationSynQuick` by *ANTS*. It uses nipype interface.
         ants_registration_node = npe.Node(


### PR DESCRIPTION
Closes #1691

As pointed out, b-spline parameters were different for FLAIR and T1 Linear. As is, the N4BiasFieldCorrection model from ANTs uses 4 fitting steps, dividing the b-spline parameter by 2 each time. If the input parameter is 600 mm, the last resolution of the b-spline grid would be 75 mm. If the b-spline parameter is lower, then structural differences can be mistaken for bias field (which was happening with 100mm for FLAIR). For balance between correction and safety, we put the parameter to 200 mm.