### PR TITLE
[DOC] Update information for mrtrix3 and convert3d

### DIFF
--- a/docs/Software/Installation.md
+++ b/docs/Software/Installation.md
@@ -18,9 +18,15 @@ To install Miniconda, open a new terminal and type the following commands:
     bash /tmp/miniconda-installer.sh
     ```
 
-=== "MacOS"
+=== "MacOS (Intell)"
     ```{.sourceCode .bash .copy}
     curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o /tmp/miniconda-installer.sh
+    bash /tmp/miniconda-installer.sh
+    ```
+
+=== "MacOS (ARM)"
+    ```{.sourceCode .bash .copy}
+    curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh -o /tmp/miniconda-installer.sh
     bash /tmp/miniconda-installer.sh
     ```
 
@@ -37,16 +43,10 @@ The latest release of Clinica can be installed by using the conventional
 [PyPI package manager](https://pypi.org/project/clinica/) as follows:
 
 ```{.shell .copy}
-conda create --name clinicaEnv python=3.10
+conda create --name clinicaEnv python=3.11
 conda activate clinicaEnv
 pip install clinica
 ```
-
-??? warning "Conda installation"
-    Since Clinica `v0.3.5`, Conda installation **is no longer available** (i.e.
-    `conda create --name clinicaEnv python=3.6 clinica -c Aramislab -c conda-forge`
-    will only install Clinica `v0.3.4`).
-    Pip is now the only way to install the latest version of Clinica.
 
 ## Installation of the third-party software packages
 
@@ -141,6 +141,9 @@ Clinica uses [Poetry](https://python-poetry.org) to manage its development envir
     ```{.shell .copy}
     conda env create -f environment.yml
     ```
+   
+    !!! warning
+        If you are on MacOS **ARM** you should use the `environment-macarm.yml` file instead.
 
 4. Install Clinica with the necessary development dependencies:
 

--- a/docs/Software/Third-party.md
+++ b/docs/Software/Third-party.md
@@ -111,11 +111,11 @@ ___
 You can find more details about `Convert3D` on their [website](http://www.itksnap.org/pmwiki/pmwiki.php?n=Convert3D.Convert3D). There are
 two options to install it :
 
-=== "Linux"
+=== "Linux / MacOS (Intell)"
     - [Use pre-built binaries](http://www.itksnap.org/pmwiki/pmwiki.php?n=Downloads.C3D).
     - [Use the official conda package](https://anaconda.org/conda-forge/convert3d).
 
-=== "MacOS"
+=== "MacOS (ARM)"
     [Use pre-built binaries](http://www.itksnap.org/pmwiki/pmwiki.php?n=Downloads.C3D).
 
 ___
@@ -186,7 +186,7 @@ ___
 You can find more details about `MRtrix3` on their [website](http://www.mrtrix.org), including
 official instructions for [downloading](https://www.mrtrix.org/download/).
 
-=== "Linux"
+=== "Linux / MacOS (Intell)"
     You have basically two options:
 
     - [Use the official conda package](https://www.mrtrix.org/download/linux-anaconda/).
@@ -195,7 +195,7 @@ official instructions for [downloading](https://www.mrtrix.org/download/).
     !!! tip
         Note that using the conda package should be easier in most cases.
 
-=== "MacOS"
+=== "MacOS (ARM)"
 
     - [Use the MacOS pre-compiled application package installer](https://www.mrtrix.org/download/macos-application/).
     - [Use the Homebrew formula](https://github.com/MRtrix3/homebrew-mrtrix3) (although large dependencies such as `XCode` and `Qt5` are required).

--- a/docs/Software/Third-party.md
+++ b/docs/Software/Third-party.md
@@ -111,8 +111,12 @@ ___
 You can find more details about `Convert3D` on their [website](http://www.itksnap.org/pmwiki/pmwiki.php?n=Convert3D.Convert3D). There are
 two options to install it :
 
-- [Use pre-built binaries](http://www.itksnap.org/pmwiki/pmwiki.php?n=Downloads.C3D).
-- [Use the official conda package](https://anaconda.org/conda-forge/convert3d).
+=== "Linux"
+    - [Use pre-built binaries](http://www.itksnap.org/pmwiki/pmwiki.php?n=Downloads.C3D).
+    - [Use the official conda package](https://anaconda.org/conda-forge/convert3d).
+
+=== "MacOS"
+    [Use pre-built binaries](http://www.itksnap.org/pmwiki/pmwiki.php?n=Downloads.C3D).
 
 ___
 
@@ -193,7 +197,6 @@ official instructions for [downloading](https://www.mrtrix.org/download/).
 
 === "MacOS"
 
-    - [Use the official conda package](https://www.mrtrix.org/download/macos-anaconda/).
     - [Use the MacOS pre-compiled application package installer](https://www.mrtrix.org/download/macos-application/).
     - [Use the Homebrew formula](https://github.com/MRtrix3/homebrew-mrtrix3) (although large dependencies such as `XCode` and `Qt5` are required).
 

--- a/environment-macarm.yml
+++ b/environment-macarm.yml
@@ -1,0 +1,8 @@
+name: clinica
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - dcm2niix
+  - petpvc
+


### PR DESCRIPTION
## Description
The conda channels used for these tools do not support Mac (ARM) installation. Documentation was modified to indicate how to install clinica considering this. An additional yml for conda environment was added to handle this specific case.

## To Check :
- Command line : `conda env create -n test -f environment(...).yml`
  - [x] Works for Linux / Mac Intel (should not change existing behavior)
  - [x] Now works for Mac ARM
- Documentation builds properly
