### PR TITLE
[FIX] PET-Volume : Add `build_petpvc_name` as a task

### DIFF
--- a/clinica/pipelines/pet/volume/pipeline.py
+++ b/clinica/pipelines/pet/volume/pipeline.py
@@ -473,13 +473,13 @@ class PETVolume(GroupPipeline, PETPipeline):
 
         from .tasks import (
             apply_binary_mask_task,
+            build_pet_pvc_name_task,
             compute_atlas_statistics_task,
             create_binary_mask_task,
             create_pvc_mask_task,
             normalize_to_reference_task,
         )
         from .utils import (
-            build_pet_pvc_name,
             get_from_list,
             init_input_node,
         )
@@ -795,7 +795,7 @@ class PETVolume(GroupPipeline, PETPipeline):
                 name="atlas_stats_pvc",
                 iterfield=["image"],
             )
-            atlas_stats_pvc.inputs.in_atlas_names = self.parameters["atlases"]
+            atlas_stats_pvc.inputs.atlas_names = self.parameters["atlases"]
 
             # Connection
             # ==========
@@ -824,7 +824,7 @@ class PETVolume(GroupPipeline, PETPipeline):
                         [
                             ("coregistered_source", "in_file"),
                             (
-                                ("coregistered_source", build_pet_pvc_name, "RBV"),
+                                ("coregistered_source", build_pet_pvc_name_task, "RBV"),
                                 "out_file",
                             ),
                         ],

--- a/clinica/pipelines/pet/volume/tasks.py
+++ b/clinica/pipelines/pet/volume/tasks.py
@@ -39,3 +39,9 @@ def normalize_to_reference_task(pet_image: str, region_mask: str) -> str:
     from clinica.pipelines.pet.volume.utils import normalize_to_reference
 
     return str(normalize_to_reference(Path(pet_image), Path(region_mask)))
+
+
+def build_pet_pvc_name_task(pet_image: str, pvc_method: str) -> str:
+    from clinica.pipelines.pet.volume.utils import build_pet_pvc_name
+
+    return build_pet_pvc_name(pet_image, pvc_method)


### PR DESCRIPTION
## Description
When using option `--pvc_psf_tsv` with an actual file, code crashes because of improper  Nipype formatting (input name, type). This option is currently not tested in the CI.


## Key Changes Made
- Added the function `build_pet_pvc_name` from pet surface utils in the tasks with type checking compatible with Nipype
- Fixed input format for one node

## Checklist
- [x] Coding style respected (eg: '_' at the beginning of variable names, private or public functions, docstrings, ...)
- [ ] Unit tests added and passing
- [x] Functional testing completed (on Linux and macOS)
- [x] Instantiation tests passing

## How to Test
<!-- Steps to reproduce or validate -->
- Run the pet-volume pipeline with the option `--pvc_psf_tsv`
