### PR TITLE
[REF] PET-Surface : Replace `fslmerge` with a python function

### DIFF
--- a/clinica/pipelines/pet_surface/pet_surface_utils.py
+++ b/clinica/pipelines/pet_surface/pet_surface_utils.py
@@ -1,3 +1,6 @@
+import os
+
+
 def get_new_subjects_dir(is_longitudinal, caps_dir, subject_id, session_id):
     """Extract SUBJECT_DIR.
 
@@ -862,6 +865,21 @@ def produce_tsv(pet, atlas_files):
     return os.path.abspath(filename_tsv[0]), os.path.abspath(filename_tsv[1])
 
 
+def merge_nifti_volumes(inputs: list[str]) -> str:
+    import os
+
+    import nibabel as nib
+    from nilearn.image import concat_imgs
+
+    sorted_inputs = sorted(
+        inputs, key=lambda p: int(p.split("/")[-1].split(".nii.gz")[0])
+    )
+    merged_image = concat_imgs([nib.load(p) for p in sorted_inputs])
+    output_path = os.getcwd() + "/merged_image.nii.gz"
+    nib.save(merged_image, output_path)
+    return output_path
+
+
 def get_wf(
     subject_id,
     session_id,
@@ -911,7 +929,6 @@ def get_wf(
     import nipype.interfaces.utility as niu
     import nipype.pipeline.engine as pe
     from nipype.interfaces.freesurfer import ApplyVolTransform, MRIConvert, Tkregister2
-    from nipype.interfaces.fsl import Merge
     from nipype.interfaces.petpvc import PETPVC
     from nipype.interfaces.spm import Coregister, Normalize12
 
@@ -997,7 +1014,12 @@ def get_wf(
         raise Exception("CSV file : " + labelconversion.inputs.csv + " does not exist.")
 
     merge_volume = pe.Node(
-        Merge(output_type="NIFTI_GZ", dimension="t"), name="merge_volume"
+        niu.Function(
+            input_names=["inputs"],
+            output_names=["merged_file"],
+            function=utils.merge_nifti_volumes,
+        ),
+        name="merge_volume",
     )
 
     vol2vol = pe.Node(
@@ -1375,7 +1397,7 @@ def get_wf(
             (vol2vol, pons_normalization, [("transformed_file", "pet_path")]),
             (vol2vol_mask, pons_normalization, [("transformed_file", "mask")]),
             (convert_gtmseg, labelconversion, [("out_file", "gtmsegfile")]),
-            (labelconversion, merge_volume, [("list_of_regions", "in_files")]),
+            (labelconversion, merge_volume, [("list_of_regions", "inputs")]),
             (merge_volume, pvc, [("merged_file", "mask_file")]),
             (pons_normalization, pvc, [("suvr", "in_file")]),
             (reformat_surface_name, mris_exp, [("out", "in_surface")]),

--- a/docs/Software/Third-party.md
+++ b/docs/Software/Third-party.md
@@ -63,19 +63,19 @@ Specific dependencies are described in the table below (1) :
 
 <div markdown="1" class="third_party_table">
 
-|                     | ANTs  | Convert3D | FreeSurfer | FSL | ITK | MRtrix3 | PETPVC | SPM |
-|:-------------------:|:-----:|:---------:|:----------:|:---:|:---:|:-------:|:------:|:---:|
-|    Anat > Linear    |  ✓∘   |           |            |     |     |         |        |     |
-|    Anat > Volume    |       |           |            |     |     |         |        |  ✓  |
-|  Anat > FreeSurfer  |       |           |     ✓      |     |     |         |        |     |
-| DWI > Preprocessing |   ✓   |     ✓     |            |  ✓  |     |    ✓    |        |     |
-|      DWI > DTI      |   ✓   |           |            |  ✓  |     |    ✓    |        |     |
-|  DWI > Connectome   |       |           |     ✓      |  ✓  |     |    ✓    |        |     |
-|    PET > Linear     |   ✓   |           |            |     |     |         |        |     |
-|    PET > Surface    |       |           |     ✓      |  ✓  | ✓⟡  |         |   ✓⟡   |  ✓  |
-|    PET > Volume     |       |           |            |     | ✓⟡  |         |   ✓⟡   |  ✓  |
-|   Stats > Surface   |       |           |     ✓      |     |     |         |        |     |
-|   Stats > Volume    |       |           |            |     |     |         |        |  ✓  |
+|                     | ANTs  | Convert3D | FreeSurfer | FSL | MRtrix3 | ITK + PETPVC | SPM |
+|:-------------------:|:-----:|:---------:|:----------:|:---:|:-------:|:------------:|:---:|
+|    Anat > Linear    |  ✓∘   |           |            |     |         |              |     |
+|    Anat > Volume    |       |           |            |     |         |              |  ✓  |
+|  Anat > FreeSurfer  |       |           |     ✓      |     |         |              |     |
+| DWI > Preprocessing |   ✓   |     ✓     |            |  ✓  |    ✓    |              |     |
+|      DWI > DTI      |   ✓   |           |            |  ✓  |    ✓    |              |     |
+|  DWI > Connectome   |       |           |     ✓      |  ✓  |    ✓    |              |     |
+|    PET > Linear     |   ✓   |           |            |     |         |              |     |
+|    PET > Surface    |       |           |     ✓      |     |         |      ✓⟡      |  ✓  |
+|    PET > Volume     |       |           |            |     |         |      ✓⟡      |  ✓  |
+|   Stats > Surface   |       |           |     ✓      |     |         |              |     |
+|   Stats > Volume    |       |           |            |     |         |              |  ✓  |
 </div>
 
 - *✓∘ : for anatomical linear pipelines there is also the possibility to use ANTsPy instead of ANTs since Clinica `v0.9.0`* 

--- a/docs/Software/Third-party.md
+++ b/docs/Software/Third-party.md
@@ -63,19 +63,19 @@ Specific dependencies are described in the table below (1) :
 
 <div markdown="1" class="third_party_table">
 
-|                     | ANTs  | Convert3D | FreeSurfer | FSL | MRtrix3 | ITK + PETPVC | SPM |
-|:-------------------:|:-----:|:---------:|:----------:|:---:|:-------:|:------------:|:---:|
-|    Anat > Linear    |  ✓∘   |           |            |     |         |              |     |
-|    Anat > Volume    |       |           |            |     |         |              |  ✓  |
-|  Anat > FreeSurfer  |       |           |     ✓      |     |         |              |     |
-| DWI > Preprocessing |   ✓   |     ✓     |            |  ✓  |    ✓    |              |     |
-|      DWI > DTI      |   ✓   |           |            |  ✓  |    ✓    |              |     |
-|  DWI > Connectome   |       |           |     ✓      |  ✓  |    ✓    |              |     |
-|    PET > Linear     |   ✓   |           |            |     |         |              |     |
-|    PET > Surface    |       |           |     ✓      |     |         |      ✓⟡      |  ✓  |
-|    PET > Volume     |       |           |            |     |         |      ✓⟡      |  ✓  |
-|   Stats > Surface   |       |           |     ✓      |     |         |              |     |
-|   Stats > Volume    |       |           |            |     |         |              |  ✓  |
+|                     | ANTs  | Convert3D | FreeSurfer |  FSL   |        MRtrix3        | ITK + PETPVC | SPM |
+|:-------------------:|:-----:|:---------:|:----------:|:------:|:---------------------:|:------------:|:---:|
+|    Anat > Linear    |  ✓∘   |           |            |        |                       |              |     |
+|    Anat > Volume    |       |           |            |        |                       |              |  ✓  |
+|  Anat > FreeSurfer  |       |           |     ✓      |        |                       |              |     |
+| DWI > Preprocessing |   ✓   |     ✓     |            |   ✓    |           ✓           |              |     |
+|      DWI > DTI      |   ✓   |           |            |   ✓    |           ✓           |              |     |
+|  DWI > Connectome   |       |           |     ✓      |   ✓    |           ✓           |              |     |
+|    PET > Linear     |   ✓   |           |            |        |                       |              |     |
+|    PET > Surface    |       |           |     ✓      |        |                       |      ✓⟡      |  ✓  |
+|    PET > Volume     |       |           |            |        |                       |      ✓⟡      |  ✓  |
+|   Stats > Surface   |       |           |     ✓      |        |                       |              |     |
+|   Stats > Volume    |       |           |            |        |                       |              |  ✓  |
 </div>
 
 - *✓∘ : for anatomical linear pipelines there is also the possibility to use ANTsPy instead of ANTs since Clinica `v0.9.0`* 

--- a/docs/css/clinica.css
+++ b/docs/css/clinica.css
@@ -92,7 +92,7 @@ h3, .h3, .md-typeset h3 {
 .third_party_table th:nth-child(6) {
     width: 15%;
     }
-    .third_party_table th:nth-child(7) {
+.third_party_table th:nth-child(7) {
     width: 15%;
     }
 .third_party_table th:nth-child(8) {

--- a/docs/css/clinica.css
+++ b/docs/css/clinica.css
@@ -78,7 +78,7 @@ h3, .h3, .md-typeset h3 {
     width: 19%;
     }
 .third_party_table th:nth-child(2) {
-    width: 10%;
+    width: 11%;
     }
 .third_party_table th:nth-child(3) {
     width: 15%;
@@ -87,17 +87,14 @@ h3, .h3, .md-typeset h3 {
     width: 15%;
     }
 .third_party_table th:nth-child(5) {
-    width: 7%;
+    width: 9%;
     }
 .third_party_table th:nth-child(6) {
-    width: 7%;
+    width: 15%;
     }
     .third_party_table th:nth-child(7) {
-    width: 12%;
+    width: 15%;
     }
 .third_party_table th:nth-child(8) {
-    width: 13%;
-    }
-.third_party_table th:nth-child(9) {
-    width: 8%;
+    width: 11%;
     }

--- a/test/unittests/pipelines/pet_surface/test_pet_surface_utils.py
+++ b/test/unittests/pipelines/pet_surface/test_pet_surface_utils.py
@@ -50,3 +50,21 @@ def test_mris_expand(tmp_path):
     assert {_padding_to_3(x) for x in range(7, 14)} == set(
         map(lambda x: x.name.split("-")[-1], outputs)
     )
+
+
+def test_merge_nifti_volumes(tmp_path):
+    import nibabel as nib
+    import numpy as np
+
+    from clinica.pipelines.pet_surface.pet_surface_utils import merge_nifti_volumes
+
+    image1 = nib.Nifti1Image(np.random.rand(3, 3, 3, 1), affine=np.eye(4))
+    image2 = nib.Nifti1Image(np.random.rand(3, 3, 3, 1), affine=np.eye(4))
+    nib.save(image1, tmp_path / "1.nii.gz")
+    nib.save(image2, tmp_path / "2.nii.gz")
+
+    merged_file_path = merge_nifti_volumes(
+        [str(tmp_path / "1.nii.gz"), str(tmp_path / "2.nii.gz")]
+    )
+    merged_image = nib.load(merged_file_path)
+    assert merged_image.shape == (3, 3, 3, 2)


### PR DESCRIPTION
## Description
For the PET Surface pipeline the external software FSL is required, but is only used to perform a "merge" of nifti images. The same can be achieved with a nibable function and avoids having to download a whole external library just for this basic application.

## Key Changes Made
- New merge function introduced for PET Surface
- Unit test added
- Documentation modified

## Checklist
- [x] Coding style respected (eg: '_' at the beginning of variable names, private or public functions, docstrings, ...)
- [x] Unit tests added and passing
- [x] Functional testing completed (on Linux and macOS)
- [x] Instantiation tests passing
- [x] Non-regression tests passing (on Linux and macOS)
- [x] CI database updated (if required) - not required
- [x] Documentation updated (if required)


## How to Test
Run the PET Surface pipeline without the FSL dependency.
