### PR TITLE
[REF] PET-Linear : Integrate Hugues Roy's work

### DIFF
--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -315,6 +315,7 @@ class PETLinear(PETPipeline):
 
         from .tasks import (
             clip_task,
+            get_item_from_list,
             get_skull_stripping_from_reference_task,
             perform_suvr_normalization_task,
         )
@@ -376,7 +377,6 @@ class PETLinear(PETPipeline):
         ants_registration_node = npe.Node(
             name="antsRegistration", interface=ants.Registration()
         )
-        ants_registration_node.inputs.write_composite_transform = True
         ## image dimension
         ants_registration_node.inputs.dimension = 3
         ## type of transform
@@ -524,9 +524,7 @@ class PETLinear(PETPipeline):
                 (
                     ants_registration_node,
                     concatenate_node,
-                    [
-                        ("inverse_composite_transform", "pet_to_t1w_transform")
-                    ],  # todo : why reverse forward transforms ? !!!
+                    [("reverse_forward_transforms", "pet_to_t1w_transform")],
                 ),
                 (
                     self.input_node,
@@ -573,7 +571,7 @@ class PETLinear(PETPipeline):
                 (
                     ants_registration_node,
                     self.output_node,
-                    [("composite_transform", "affine_mat")],
+                    [(("forward_transforms", get_item_from_list, 0), "affine_mat")],
                 ),
                 (
                     normalize_intensity_node,
@@ -631,7 +629,7 @@ class PETLinear(PETPipeline):
                     (
                         ants_registration_node,
                         ants_applytransform_optional_node,
-                        [("composite_transform", "transforms")],
+                        [("forward_transforms", "transforms")],
                     ),
                     (
                         ants_applytransform_optional_node,

--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -355,7 +355,6 @@ class PETLinear(PETPipeline):
         clipping_node.inputs.output_dir = self.base_dir
 
         # 1.2 `ApplyTransforms` by *ANTS*. It uses nipype interface. MNI brain mask to T1w space
-        # todo : check existence of several applytransforms node
         ants_applytransform_reversed_node = npe.Node(
             name="antsApplyTransformReverseMNItoT1w", interface=ants.ApplyTransforms()
         )
@@ -370,14 +369,14 @@ class PETLinear(PETPipeline):
                 output_names=["skull_stripped_t1"],
                 function=get_skull_stripping_from_reference_task,
             ),
-            name="T1BrainExtract",
+            name="t1_brain_extraction",
         )
 
-        # 2. `RegistrationSynQuick` by *ANTS*. It uses nipype interface.
-        # todo : what is the fixed image
+        # 2. Registration by *ANTS*. It uses nipype interface. From PET to T1
         ants_registration_node = npe.Node(
             name="antsRegistration", interface=ants.Registration()
         )
+        ants_registration_node.inputs.write_composite_transform = True
         ## image dimension
         ants_registration_node.inputs.dimension = 3
         ## type of transform
@@ -416,9 +415,7 @@ class PETLinear(PETPipeline):
         ants_registration_nonlinear_node = npe.Node(
             name="antsRegistrationT1W2MNI", interface=ants.Registration()
         )
-        ants_registration_nonlinear_node.inputs.fixed_image = (
-            self.ref_t1_template
-        )  # todo : must be a pathlike object
+        ants_registration_nonlinear_node.inputs.fixed_image = self.ref_t1_template
         ants_registration_nonlinear_node.inputs.metric = ["MI"]
         ants_registration_nonlinear_node.inputs.metric_weight = [1.0]
         ants_registration_nonlinear_node.inputs.transforms = ["SyN"]
@@ -527,7 +524,9 @@ class PETLinear(PETPipeline):
                 (
                     ants_registration_node,
                     concatenate_node,
-                    [("reverse_forward_transforms", "pet_to_t1w_transform")],
+                    [
+                        ("inverse_composite_transform", "pet_to_t1w_transform")
+                    ],  # todo : why reverse forward transforms ? !!!
                 ),
                 (
                     self.input_node,
@@ -574,7 +573,7 @@ class PETLinear(PETPipeline):
                 (
                     ants_registration_node,
                     self.output_node,
-                    [("forward_transforms", "affine_mat")],
+                    [("composite_transform", "affine_mat")],
                 ),
                 (
                     normalize_intensity_node,
@@ -632,7 +631,7 @@ class PETLinear(PETPipeline):
                     (
                         ants_registration_node,
                         ants_applytransform_optional_node,
-                        [("forward_transforms", "transforms")],
+                        [("composite_transform", "transforms")],
                     ),
                     (
                         ants_applytransform_optional_node,

--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -124,7 +124,7 @@ class PETLinear(PETPipeline):
         from clinica.utils.ux import print_images_to_process
 
         self.ref_brain_mask = get_mni_template("brain_mask")
-        self.ref_template = get_mni_template("t1")
+        self.ref_t1_template = get_mni_template("t1")
         self.ref_mask = get_suvr_mask(self.parameters["suvr_reference_region"])
 
         # Inputs from BIDS directory
@@ -350,7 +350,7 @@ class PETLinear(PETPipeline):
         clipping_node.inputs.output_dir = self.base_dir
 
         # 1.2 `ApplyTransforms` by *ANTS*. It uses nipype interface. MNI brain mask to T1w space
-
+        # todo : check existence of several applytransforms node
         ants_applytransform_reversed_node = npe.Node(
             name="antsApplyTransformReverseMNItoT1w", interface=ants.ApplyTransforms()
         )
@@ -360,7 +360,8 @@ class PETLinear(PETPipeline):
 
         # 1.3 "ImageMath" by *ANTS*. It uses nipype interface. skull stripping using "AND" operator
         ants_extractbrain_node = npe.Node(
-            name="antsMathImageBrainExtract", interface=ants.ImageMath()
+            name="antsMathImageBrainExtract",
+            interface=ants.ImageMath(),  # todo : replace with homemade function
         )
         ants_extractbrain_node.inputs.operation = "m"
 
@@ -400,13 +401,13 @@ class PETLinear(PETPipeline):
             name="antsApplyTransformPET2MNI", interface=ants.ApplyTransforms()
         )
         ants_applytransform_node.inputs.dimension = 3
-        ants_applytransform_node.inputs.reference_image = self.ref_template
+        ants_applytransform_node.inputs.reference_image = self.ref_t1_template
 
         # 4. Normalize the image (using nifti). It uses custom interface, from utils file
         ants_registration_nonlinear_node = npe.Node(
             name="antsRegistrationT1W2MNI", interface=ants.Registration()
         )
-        ants_registration_nonlinear_node.inputs.fixed_image = self.ref_template
+        ants_registration_nonlinear_node.inputs.fixed_image = self.ref_t1_template
         ants_registration_nonlinear_node.inputs.metric = ["MI"]
         ants_registration_nonlinear_node.inputs.metric_weight = [1.0]
         ants_registration_nonlinear_node.inputs.transforms = ["SyN"]
@@ -429,7 +430,7 @@ class PETLinear(PETPipeline):
             name="antsApplyTransformNonLinear", interface=ants.ApplyTransforms()
         )
         ants_applytransform_nonlinear_node.inputs.dimension = 3
-        ants_applytransform_nonlinear_node.inputs.reference_image = self.ref_template
+        ants_applytransform_nonlinear_node.inputs.reference_image = self.ref_t1_template
 
         if random_seed := self.parameters.get("random_seed", None):
             ants_registration_nonlinear_node.inputs.random_seed = random_seed
@@ -510,14 +511,12 @@ class PETLinear(PETPipeline):
                     ants_extractbrain_node,
                     ants_registration_node,
                     [("output_image", "fixed_image")],
-                ),  # todo : rename files ?
+                ),
                 # STEP 3
                 (
                     ants_registration_node,
                     concatenate_node,
-                    [
-                        ("reverse_forward_transforms", "pet_to_t1w_transform")
-                    ],  # todo : see ants reg node ?
+                    [("reverse_forward_transforms", "pet_to_t1w_transform")],
                 ),
                 (
                     self.input_node,

--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -315,11 +315,11 @@ class PETLinear(PETPipeline):
 
         from .tasks import (
             clip_task,
+            get_skull_stripping_from_reference_task,
             perform_suvr_normalization_task,
         )
         from .utils import (
             concatenate_transforms,
-            get_skull_stripping_from_reference,
             init_input_node,
             print_end_pipeline,
         )
@@ -368,7 +368,7 @@ class PETLinear(PETPipeline):
             interface=nutil.Function(
                 input_names=["image", "skull_stripped_reference_mask"],
                 output_names=["skull_stripped_t1"],
-                function=get_skull_stripping_from_reference,
+                function=get_skull_stripping_from_reference_task,
             ),
             name="T1BrainExtract",
         )
@@ -571,7 +571,7 @@ class PETLinear(PETPipeline):
                 (
                     ants_registration_node,
                     self.output_node,
-                    [("out_matrix", "affine_mat")],
+                    [("forward_transforms", "affine_mat")],
                 ),
                 (
                     normalize_intensity_node,
@@ -629,7 +629,7 @@ class PETLinear(PETPipeline):
                     (
                         ants_registration_node,
                         ants_applytransform_optional_node,
-                        [("out_matrix", "transforms")],
+                        [("forward_transforms", "transforms")],
                     ),
                     (
                         ants_applytransform_optional_node,

--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -374,6 +374,7 @@ class PETLinear(PETPipeline):
         )
 
         # 2. `RegistrationSynQuick` by *ANTS*. It uses nipype interface.
+        # todo : what is the fixed image
         ants_registration_node = npe.Node(
             name="antsRegistration", interface=ants.Registration()
         )
@@ -415,7 +416,9 @@ class PETLinear(PETPipeline):
         ants_registration_nonlinear_node = npe.Node(
             name="antsRegistrationT1W2MNI", interface=ants.Registration()
         )
-        ants_registration_nonlinear_node.inputs.fixed_image = self.ref_t1_template
+        ants_registration_nonlinear_node.inputs.fixed_image = (
+            self.ref_t1_template
+        )  # todo : must be a pathlike object
         ants_registration_nonlinear_node.inputs.metric = ["MI"]
         ants_registration_nonlinear_node.inputs.metric_weight = [1.0]
         ants_registration_nonlinear_node.inputs.transforms = ["SyN"]

--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -317,7 +317,12 @@ class PETLinear(PETPipeline):
             clip_task,
             perform_suvr_normalization_task,
         )
-        from .utils import concatenate_transforms, init_input_node, print_end_pipeline
+        from .utils import (
+            concatenate_transforms,
+            get_skull_stripping_from_reference,
+            init_input_node,
+            print_end_pipeline,
+        )
 
         init_node = npe.Node(
             interface=nutil.Function(
@@ -358,12 +363,15 @@ class PETLinear(PETPipeline):
         ants_applytransform_reversed_node.inputs.invert_transform_flags = True
         ants_applytransform_reversed_node.inputs.input_image = self.ref_brain_mask
 
-        # 1.3 "ImageMath" by *ANTS*. It uses nipype interface. skull stripping using "AND" operator
+        # 1.3 Homemade skull-stripping function using a t1 (MNI) reference mask, multiplied with the desired image
         ants_extractbrain_node = npe.Node(
-            name="antsMathImageBrainExtract",
-            interface=ants.ImageMath(),  # todo : replace with homemade function
+            interface=nutil.Function(
+                input_names=["image", "skull_stripped_reference_mask"],
+                output_names=["skull_stripped_t1"],
+                function=get_skull_stripping_from_reference,
+            ),
+            name="T1BrainExtract",
         )
-        ants_extractbrain_node.inputs.operation = "m"
 
         # 2. `RegistrationSynQuick` by *ANTS*. It uses nipype interface.
         ants_registration_node = npe.Node(
@@ -494,12 +502,12 @@ class PETLinear(PETPipeline):
                 (
                     self.input_node,
                     ants_extractbrain_node,
-                    [("t1w", "op1")],
+                    [("t1w", "image")],
                 ),
                 (
                     ants_applytransform_reversed_node,
                     ants_extractbrain_node,
-                    [("output_image", "op2")],
+                    [("output_image", "skull_stripped_reference_mask")],
                 ),
                 # STEP 2
                 (
@@ -510,7 +518,7 @@ class PETLinear(PETPipeline):
                 (
                     ants_extractbrain_node,
                     ants_registration_node,
-                    [("output_image", "fixed_image")],
+                    [("skull_stripped_t1", "fixed_image")],
                 ),
                 # STEP 3
                 (

--- a/clinica/pipelines/pet/linear/pipeline.py
+++ b/clinica/pipelines/pet/linear/pipeline.py
@@ -123,6 +123,7 @@ class PETLinear(PETPipeline):
         from clinica.utils.stream import cprint
         from clinica.utils.ux import print_images_to_process
 
+        self.ref_brain_mask = get_mni_template("brain_mask")
         self.ref_template = get_mni_template("t1")
         self.ref_mask = get_suvr_mask(self.parameters["suvr_reference_region"])
 
@@ -348,12 +349,51 @@ class PETLinear(PETPipeline):
         )
         clipping_node.inputs.output_dir = self.base_dir
 
+        # 1.2 `ApplyTransforms` by *ANTS*. It uses nipype interface. MNI brain mask to T1w space
+
+        ants_applytransform_reversed_node = npe.Node(
+            name="antsApplyTransformReverseMNItoT1w", interface=ants.ApplyTransforms()
+        )
+        ants_applytransform_reversed_node.inputs.dimension = 3
+        ants_applytransform_reversed_node.inputs.invert_transform_flags = True
+        ants_applytransform_reversed_node.inputs.input_image = self.ref_brain_mask
+
+        # 1.3 "ImageMath" by *ANTS*. It uses nipype interface. skull stripping using "AND" operator
+        ants_extractbrain_node = npe.Node(
+            name="antsMathImageBrainExtract", interface=ants.ImageMath()
+        )
+        ants_extractbrain_node.inputs.operation = "m"
+
         # 2. `RegistrationSynQuick` by *ANTS*. It uses nipype interface.
         ants_registration_node = npe.Node(
-            name="antsRegistration", interface=ants.RegistrationSynQuick()
+            name="antsRegistration", interface=ants.Registration()
         )
+        ## image dimension
         ants_registration_node.inputs.dimension = 3
-        ants_registration_node.inputs.transform_type = "r"
+        ## type of transform
+        ants_registration_node.inputs.transforms = ["Rigid"]
+        ants_registration_node.inputs.transform_parameters = [(0.1,)]
+        ## metrics, weights, sampling strategy
+        ants_registration_node.inputs.metric = ["MI"]
+        ants_registration_node.inputs.metric_weight = [1.0]
+        ants_registration_node.inputs.radius_or_number_of_bins = [32]
+        ants_registration_node.inputs.sampling_strategy = ["Regular"]
+        ants_registration_node.inputs.sampling_percentage = [0.25]
+        ## levels parameters
+        ants_registration_node.inputs.shrink_factors = [[8, 4, 2, 1]]
+        ants_registration_node.inputs.smoothing_sigmas = [[3, 2, 1, 0]]
+        ants_registration_node.inputs.sigma_units = ["vox"]
+        ## convergence parameters
+        ants_registration_node.inputs.number_of_iterations = [[1000, 500, 250, 100]]
+        ants_registration_node.inputs.convergence_threshold = [1e-6]
+        ants_registration_node.inputs.convergence_window_size = [10]
+        ## preprocessing
+        ants_registration_node.inputs.winsorize_lower_quantile = 0.005
+        ants_registration_node.inputs.winsorize_upper_quantile = 0.995
+        ants_registration_node.inputs.use_histogram_matching = False
+        ## extra parameters
+        ants_registration_node.inputs.collapse_output_transforms = True
+        ants_registration_node.inputs.verbose = True
 
         # 3. `ApplyTransforms` by *ANTS*. It uses nipype interface. PET to MRI
         ants_applytransform_node = npe.Node(
@@ -438,18 +478,46 @@ class PETLinear(PETPipeline):
                 (self.input_node, init_node, [("pet", "pet")]),
                 # STEP 1:
                 (init_node, clipping_node, [("pet", "input_pet")]),
+                # STEP 1.2 Apply inverse transform
+                (
+                    self.input_node,
+                    ants_applytransform_reversed_node,
+                    [("t1w_to_mni", "transforms")],
+                ),
+                (
+                    self.input_node,
+                    ants_applytransform_reversed_node,
+                    [("t1w", "reference_image")],
+                ),
+                # STEP 1.3 Extract brain
+                (
+                    self.input_node,
+                    ants_extractbrain_node,
+                    [("t1w", "op1")],
+                ),
+                (
+                    ants_applytransform_reversed_node,
+                    ants_extractbrain_node,
+                    [("output_image", "op2")],
+                ),
                 # STEP 2
                 (
                     clipping_node,
                     ants_registration_node,
                     [("output_image", "moving_image")],
                 ),
-                (self.input_node, ants_registration_node, [("t1w", "fixed_image")]),
+                (
+                    ants_extractbrain_node,
+                    ants_registration_node,
+                    [("output_image", "fixed_image")],
+                ),  # todo : rename files ?
                 # STEP 3
                 (
                     ants_registration_node,
                     concatenate_node,
-                    [("out_matrix", "pet_to_t1w_transform")],
+                    [
+                        ("reverse_forward_transforms", "pet_to_t1w_transform")
+                    ],  # todo : see ants reg node ?
                 ),
                 (
                     self.input_node,

--- a/clinica/pipelines/pet/linear/tasks.py
+++ b/clinica/pipelines/pet/linear/tasks.py
@@ -67,3 +67,6 @@ def rename_into_caps_task(
         str(transformation_filename_caps),
         pet_filename_in_t1w_caps,
     )
+
+
+# todo : write the task for multiplication

--- a/clinica/pipelines/pet/linear/tasks.py
+++ b/clinica/pipelines/pet/linear/tasks.py
@@ -81,3 +81,8 @@ def get_skull_stripping_from_reference_task(
             Path(image), Path(skull_stripped_reference_mask)
         )
     )
+
+
+def get_item_from_list(input_list: list, index_in_list: int) -> str:
+    assert len(list) == index_in_list + 1
+    return input_list[index_in_list]

--- a/clinica/pipelines/pet/linear/tasks.py
+++ b/clinica/pipelines/pet/linear/tasks.py
@@ -84,5 +84,5 @@ def get_skull_stripping_from_reference_task(
 
 
 def get_item_from_list(input_list: list, index_in_list: int) -> str:
-    assert len(list) == index_in_list + 1
+    assert len(input_list) == index_in_list + 1
     return input_list[index_in_list]

--- a/clinica/pipelines/pet/linear/tasks.py
+++ b/clinica/pipelines/pet/linear/tasks.py
@@ -69,4 +69,11 @@ def rename_into_caps_task(
     )
 
 
-# todo : write the task for multiplication
+def get_skull_stripping_from_reference_task(
+    image: str, skull_stripped_reference_mask: str
+):
+    from pathlib import Path
+
+    from clinica.pipelines.pet.linear.utils import get_skull_stripping_from_reference
+
+    get_skull_stripping_from_reference(Path(image), Path(skull_stripped_reference_mask))

--- a/clinica/pipelines/pet/linear/tasks.py
+++ b/clinica/pipelines/pet/linear/tasks.py
@@ -71,9 +71,13 @@ def rename_into_caps_task(
 
 def get_skull_stripping_from_reference_task(
     image: str, skull_stripped_reference_mask: str
-):
+) -> str:
     from pathlib import Path
 
     from clinica.pipelines.pet.linear.utils import get_skull_stripping_from_reference
 
-    get_skull_stripping_from_reference(Path(image), Path(skull_stripped_reference_mask))
+    return str(
+        get_skull_stripping_from_reference(
+            Path(image), Path(skull_stripped_reference_mask)
+        )
+    )

--- a/clinica/pipelines/pet/linear/utils.py
+++ b/clinica/pipelines/pet/linear/utils.py
@@ -300,8 +300,6 @@ def get_skull_stripping_from_reference(
 
     import nibabel as nib
 
-    # todo : test this
-
     to_strip = nib.load(image)
     skull_stripped_image = nib.Nifti1Image(
         to_strip.get_fdata() * nib.load(skull_stripped_reference_mask).get_fdata(),

--- a/clinica/pipelines/pet/linear/utils.py
+++ b/clinica/pipelines/pet/linear/utils.py
@@ -26,7 +26,7 @@ def init_input_node(pet: str) -> str:
 
 
 def concatenate_transforms(
-    pet_to_t1w_transform: str, t1w_to_mni_transform: str
+    pet_to_t1w_transform: list, t1w_to_mni_transform: str
 ) -> list:
     """Concatenate two input transformation files into a list.
 
@@ -43,7 +43,7 @@ def concatenate_transforms(
     list :
         Both transform files path in a list.
     """
-    return [t1w_to_mni_transform, pet_to_t1w_transform]
+    return [t1w_to_mni_transform, *pet_to_t1w_transform]
 
 
 def perform_suvr_normalization(

--- a/clinica/pipelines/pet/linear/utils.py
+++ b/clinica/pipelines/pet/linear/utils.py
@@ -11,6 +11,7 @@ _all__ = [
     "rename_into_caps",
     "print_end_pipeline",
     "clip_img",
+    "get_skull_stripping_from_reference",
 ]
 
 
@@ -294,19 +295,17 @@ def print_end_pipeline(pet: str, final_file):
 
 
 def get_skull_stripping_from_reference(
-    image: Path, skull_stripped_reference: Path
+    image: Path, skull_stripped_reference_mask: Path
 ) -> Path:
     from pathlib import Path
 
     import nibabel as nib
-    import nilearn as nil
 
     # todo : test this
 
     to_strip = nib.load(image)
     skull_stripped_image = nib.Nifti1Image(
-        to_strip.get_fdata()
-        * nil.image.binarize_img(nib.load(skull_stripped_reference)).get_fdata(),
+        to_strip.get_fdata() * nib.load(skull_stripped_reference_mask).get_fdata(),
         to_strip.affine,
     )
     output_path = Path.cwd() / "skull_stripped_t1.nii.gz"

--- a/clinica/pipelines/pet/linear/utils.py
+++ b/clinica/pipelines/pet/linear/utils.py
@@ -26,7 +26,7 @@ def init_input_node(pet: str) -> str:
 
 
 def concatenate_transforms(
-    pet_to_t1w_transform: list, t1w_to_mni_transform: str
+    pet_to_t1w_transform: str, t1w_to_mni_transform: str
 ) -> list:
     """Concatenate two input transformation files into a list.
 
@@ -43,8 +43,7 @@ def concatenate_transforms(
     list :
         Both transform files path in a list.
     """
-    # todo : why list
-    return [t1w_to_mni_transform, *pet_to_t1w_transform]
+    return [t1w_to_mni_transform, pet_to_t1w_transform]
 
 
 def perform_suvr_normalization(

--- a/clinica/pipelines/pet/linear/utils.py
+++ b/clinica/pipelines/pet/linear/utils.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Optional, Tuple, Union
 
@@ -41,6 +42,7 @@ def concatenate_transforms(
     list :
         Both transform files path in a list.
     """
+    # todo : why list
     return [t1w_to_mni_transform, *pet_to_t1w_transform]
 
 
@@ -289,3 +291,26 @@ def print_end_pipeline(pet: str, final_file):
     from clinica.utils.ux import print_end_image
 
     print_end_image(get_subject_id(pet))
+
+
+def get_skull_stripping_from_reference(
+    image: Path, skull_stripped_reference: Path
+) -> Path:
+    from pathlib import Path
+
+    import nibabel as nib
+    import nilearn as nil
+
+    # todo : test this
+
+    to_strip = nib.load(image)
+    skull_stripped_image = nib.Nifti1Image(
+        to_strip.get_fdata()
+        * nil.image.binarize_img(nib.load(skull_stripped_reference)).get_fdata(),
+        to_strip.affine,
+    )
+    output_path = Path.cwd() / "skull_stripped_t1.nii.gz"
+
+    skull_stripped_image.to_filename(output_path)
+
+    return output_path

--- a/clinica/pipelines/pet/linear/utils.py
+++ b/clinica/pipelines/pet/linear/utils.py
@@ -24,7 +24,7 @@ def init_input_node(pet: str) -> str:
 
 
 def concatenate_transforms(
-    pet_to_t1w_transform: str, t1w_to_mni_transform: str
+    pet_to_t1w_transform: list, t1w_to_mni_transform: str
 ) -> list:
     """Concatenate two input transformation files into a list.
 
@@ -41,7 +41,7 @@ def concatenate_transforms(
     list :
         Both transform files path in a list.
     """
-    return [t1w_to_mni_transform, pet_to_t1w_transform]
+    return [t1w_to_mni_transform, *pet_to_t1w_transform]
 
 
 def perform_suvr_normalization(

--- a/clinica/utils/image.py
+++ b/clinica/utils/image.py
@@ -376,10 +376,10 @@ def get_mni_template(modality: str) -> Path:
 
 def _get_mni_brain_mask() -> Path:
     return _get_file_locally_or_download(
-        filename="mni_icbm152_t1_tal_nlin_sym_09c_brain_mask.nii",
-        url=None,
-        expected_checksum=None,
-    )  # todo : add it on the inria file system ???
+        filename="qc_pet_mask_brain.nii.gz",
+        url="https://aramislab.paris.inria.fr/files/data/masks/",
+        expected_checksum="e78a542da49755f5c9ba751b4acca725650396999a671831f0acd8fbf4b898e8",
+    )
 
 
 def _get_mni_template_t1() -> Path:

--- a/clinica/utils/image.py
+++ b/clinica/utils/image.py
@@ -365,11 +365,21 @@ def get_mni_template(modality: str) -> Path:
     FileNotFoundError:
         If the template could not be retrieved locally or remotely.
     """
+    if modality.lower() == "brain_mask":
+        return _get_mni_brain_mask()
     if modality.lower() == "t1":
         return _get_mni_template_t1()
     if modality.lower() == "flair":
         return _get_mni_template_flair()
     raise ValueError(f"No MNI template available for modality {modality}.")
+
+
+def _get_mni_brain_mask() -> Path:
+    return _get_file_locally_or_download(
+        filename="mni_icbm152_t1_tal_nlin_sym_09c_brain_mask.nii",
+        url=None,
+        expected_checksum=None,
+    )  # todo : add it on the inria file system ???
 
 
 def _get_mni_template_t1() -> Path:

--- a/test/unittests/pipelines/pet/test_pet_linear_utils.py
+++ b/test/unittests/pipelines/pet/test_pet_linear_utils.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from clinica.utils.pet import SUVRReferenceRegion
@@ -96,3 +98,39 @@ def test_compute_clipping_threshold(
     assert _compute_clipping_threshold(tmp_path / "test.nii.gz") == pytest.approx(
         expected_threshold
     )
+
+
+def test_get_skull_stripping_from_reference(tmp_path):
+    from pathlib import Path
+
+    import nibabel as nib
+
+    from clinica.pipelines.pet.linear.utils import get_skull_stripping_from_reference
+    from clinica.utils.testing_utils import build_test_image_cubic_object
+
+    build_test_image_cubic_object(
+        shape=(3, 3, 3),
+        background_value=0,
+        object_value=12,
+        object_size=3,
+    ).to_filename(tmp_path / "image.nii.gz")
+
+    build_test_image_cubic_object(
+        shape=(3, 3, 3),
+        background_value=0,
+        object_value=1,
+        object_size=1,
+    ).to_filename(tmp_path / "mask.nii.gz")
+
+    get_skull_stripping_from_reference(
+        tmp_path / "image.nii.gz", tmp_path / "mask.nii.gz"
+    )
+    assert (
+        nib.load(Path.cwd() / "skull_stripped_t1.nii.gz").get_fdata()
+        == build_test_image_cubic_object(
+            shape=(3, 3, 3),
+            background_value=0,
+            object_value=12,
+            object_size=1,
+        ).get_fdata()
+    ).all()


### PR DESCRIPTION
## Description
Based on Hugues Roy's work. Removes usage of Synquick script for rigid registration. To prevent the skull intensities from messing with the registration, a new "skull-stripping" (multiplication between registered-to-T1 MNI and T1) node is added. 


## Key Changes Made
- Introduce a node for skull-stripping using Ants Math method
- Removes Synquick Registration script in favor of the regular Ants Registration method


## Checklist
- [x] Coding style respected (eg: '_' at the beginning of variable names, private or public functions, docstrings, ...)
- [x] Unit tests added and passing
- [x] Functional testing completed (on Linux and macOS)
- [x] Instantiation tests passing
- [x] Non-regression tests passing (on Linux and macOS)
- [x] CI database updated (if required)
- [ ] Documentation updated (if required)

## Further work
When T1-Linear integrates skull-stripping, its output could be used instead of using a MNI reference here.